### PR TITLE
ci: GitHub Actions für Ruff, Mypy & Pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ci:
+    name: Lint, Type-check & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e ".[dev]"
+      - name: Ruff
+        # Advisory only: the package currently has many pre-existing style
+        # findings. Kept non-blocking so it does not gate the pipeline; clean
+        # these up incrementally, then flip to blocking.
+        continue-on-error: true
+        run: ruff check .
+      - name: Mypy
+        # Advisory only: ~131 pre-existing typing errors. Non-blocking until
+        # the codebase is annotated; flip to blocking once clean.
+        continue-on-error: true
+        run: mypy arcade_scanner
+      - name: Pytest
+        run: pytest


### PR DESCRIPTION
## Warum
Die Test-Suite (545 Tests) lief bisher **nie automatisch** – Regressionen in PRs nach `dev`/`main` fielen erst manuell auf. Das Dev-Tooling (`pytest`, `pytest-mock`, `ruff`, `mypy`) war bereits in `pyproject.toml` als `[dev]`-Extra deklariert; es fehlte nur die CI, die es ausführt.

## Was
`.github/workflows/ci.yml` – läuft bei `push` und `pull_request` auf `dev` und `main`:
- **Pytest**: blockierend (Kern-Gate).
- **Ruff** und **Mypy**: vorerst `continue-on-error: true` (advisory), da der Bestandscode Altlasten hat. So gated die Pipeline sofort sinnvoll über die grüne Test-Suite, ohne an vorbestehenden Style-/Typing-Findings dauerhaft rot zu stehen. Beide können nach einer Aufräumaktion auf blockierend gestellt werden.
- Concurrency mit `cancel-in-progress`, 15 min Timeout, pip-Cache, Python 3.11.
- Install: `requirements.txt` (Pillow/imagehash sind nur dort deklariert) + `pip install -e ".[dev]"`.

## Lokale Verifikation (Python 3.14, venv)

| Check | Ergebnis | CI-Verhalten |
|-------|----------|--------------|
| `pytest` | ✅ 545 passed | blockierend |
| `mypy arcade_scanner` | ⚠️ 131 Fehler (vorbestehend) | non-blocking |
| `ruff check .` | ⚠️ 258 Findings im Paket (vorbestehend) | non-blocking |

Die Ruff-/Mypy-Findings sind vorbestehend und nicht Teil dieses PRs; ein Mass-Autofix (185 Fixes bräuchten `--unsafe-fixes`, inkl. verhaltensändernder E701/E722/F841) wäre in einem separaten, geprüften PR sinnvoller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)