### PR TITLE
style: Ruff-Cleanup (Altlasten abbauen)

### DIFF
--- a/arcade_scanner/config.py
+++ b/arcade_scanner/config.py
@@ -2,7 +2,7 @@ import json
 import os
 import socket
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from pydantic import ConfigDict, Field
 from pydantic_settings import BaseSettings

--- a/arcade_scanner/core/__init__.py
+++ b/arcade_scanner/core/__init__.py
@@ -3,3 +3,5 @@
 # from .cache_manager import load_cache, save_cache
 from .maintenance import purge_broken_media, purge_media
 from .video_processor import process_video
+
+__all__ = ["process_video", "purge_broken_media", "purge_media"]

--- a/arcade_scanner/core/bitrate_analyzer.py
+++ b/arcade_scanner/core/bitrate_analyzer.py
@@ -207,7 +207,7 @@ class EncodingParams:
 def analyze_bitrate(filepath: str) -> BitrateProfile:
     """
     Use ffprobe to deeply analyse a video file's bitrate characteristics.
-    
+
     We use per-packet analysis (show_packets) to get accurate min/max/variance
     rather than relying solely on the container-level average.
     """

--- a/arcade_scanner/core/bitrate_analyzer.py
+++ b/arcade_scanner/core/bitrate_analyzer.py
@@ -12,7 +12,7 @@ import math
 import os
 import subprocess
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
 # Codec efficiency ratios – when transcoding *from* one codec *to* another,

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -151,13 +151,13 @@ class _BandedHashIndex:
 class DuplicateDetector:
     """
     Detects duplicate media files using various strategies.
-    
+
     Videos: Exact match on size + duration + resolution
     Images: Perceptual hash (if imagehash available) or exact size + resolution
-    
+
     Performance:
     - Perceptual hashes are cached to disk across scans
-    - Hash bucketing eliminates O(n²) comparisons 
+    - Hash bucketing eliminates O(n²) comparisons
     """
 
     def __init__(self):
@@ -222,13 +222,13 @@ class DuplicateDetector:
     def find_all_duplicates(self, entries: List, progress_callback=None, batch_size: int = 5000, batch_offset: int = 0) -> Tuple[List[DuplicateGroup], bool]:
         """
         Find duplicates in the media library with batching support.
-        
+
         Args:
             entries: List of VideoEntry objects from the database
             progress_callback: Optional callable(str, float) to report status and progress (0-100)
             batch_size: Max number of images to process per batch (default 5000)
             batch_offset: Starting offset for image processing (for pagination)
-            
+
         Returns:
             Tuple of (List of DuplicateGroup objects, has_more: bool indicating if more batches available)
         """
@@ -579,7 +579,7 @@ class DuplicateDetector:
         """
         Find duplicate images using perceptual hash.
         Images with hash difference <= threshold are considered duplicates.
-        
+
         Performance optimizations:
         - Hash caching: reuses previously computed hashes from disk
         - Hash bucketing: groups by exact hash first (O(n)), then near-miss via prefix buckets

--- a/arcade_scanner/core/maintenance.py
+++ b/arcade_scanner/core/maintenance.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 from arcade_scanner.config import config
 

--- a/arcade_scanner/core/video_processor.py
+++ b/arcade_scanner/core/video_processor.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 from typing import Any, Dict, Optional
+
 from arcade_scanner.config import config
 
 logger = logging.getLogger(__name__)
@@ -126,7 +127,6 @@ def create_thumbnail(video_path: str, duration: Optional[float] = None) -> str:
 
 
 # --- HARDWARE ENCODER DETECTION ---
-from arcade_scanner.core.hw_encode_detect import get_best_h264_encoder as get_best_encoder, get_optimal_workers
 
 def process_video(filepath: str, cache: Dict[str, Any], rebuild_mode: str = None) -> Optional[Dict[str, Any]]:
     """

--- a/arcade_scanner/database/__init__.py
+++ b/arcade_scanner/database/__init__.py
@@ -1,2 +1,4 @@
 from .sqlite_store import SQLiteStore, db
 from .user_store import UserStore, user_db
+
+__all__ = ["SQLiteStore", "UserStore", "db", "user_db"]

--- a/arcade_scanner/database/sqlite_store.py
+++ b/arcade_scanner/database/sqlite_store.py
@@ -18,10 +18,10 @@ import threading
 import time
 from typing import List, Optional
 
-logger = logging.getLogger(__name__)
-
 from ..config import config
 from ..models.video_entry import VideoEntry
+
+logger = logging.getLogger(__name__)
 
 # All VideoEntry fields → SQLite columns
 # Primary key is file_path (TEXT). All other fields map 1:1.
@@ -331,7 +331,7 @@ class SQLiteStore:
 
     def get_all_dicts(self) -> List[dict]:
         """Return all entries as plain dictionaries with UI aliases.
-        
+
         This is much more memory efficient than get_all() for large libraries,
         as it avoids Pydantic model overhead.
         """

--- a/arcade_scanner/database/sqlite_store.py
+++ b/arcade_scanner/database/sqlite_store.py
@@ -10,20 +10,18 @@ Benefits over the JSON format:
     - ACID guarantees for concurrent access
     - Scales to 100K+ entries without memory pressure
 """
+import json
 import logging
 import os
 import sqlite3
-import json
-import hashlib
 import threading
 import time
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
 from ..config import config
 from ..models.video_entry import VideoEntry
-
 
 # All VideoEntry fields → SQLite columns
 # Primary key is file_path (TEXT). All other fields map 1:1.

--- a/arcade_scanner/database/user_store.py
+++ b/arcade_scanner/database/user_store.py
@@ -247,10 +247,12 @@ class UserStore:
     def migrate_tags(self):
         """Migrates global available_tags to admin user."""
         admin = self.get_user("admin")
-        if not admin: return
+        if not admin:
+            return
 
         settings_path = os.path.join(config.hidden_data_dir, "settings.json")
-        if not os.path.exists(settings_path): return
+        if not os.path.exists(settings_path):
+            return
 
         try:
             with open(settings_path, "r", encoding="utf-8") as f:
@@ -275,10 +277,12 @@ class UserStore:
     def migrate_scan_settings(self):
         """Migrates global scan targets/excludes to admin user."""
         admin = self.get_user("admin")
-        if not admin: return
+        if not admin:
+            return
 
         settings_path = os.path.join(config.hidden_data_dir, "settings.json")
-        if not os.path.exists(settings_path): return
+        if not os.path.exists(settings_path):
+            return
 
         try:
             with open(settings_path, "r", encoding="utf-8") as f:
@@ -308,10 +312,12 @@ class UserStore:
     def migrate_collections(self):
         """Migrates smart collections from global settings to admin user."""
         admin = self.get_user("admin")
-        if not admin: return
+        if not admin:
+            return
 
         settings_path = os.path.join(config.hidden_data_dir, "settings.json")
-        if not os.path.exists(settings_path): return
+        if not os.path.exists(settings_path):
+            return
 
         try:
             with open(settings_path, "r", encoding="utf-8") as f:
@@ -336,10 +342,12 @@ class UserStore:
     def migrate_sensitive_settings(self):
         """Migrates global sensitive settings (Safe Mode) to admin user."""
         admin = self.get_user("admin")
-        if not admin: return
+        if not admin:
+            return
 
         settings_path = os.path.join(config.hidden_data_dir, "settings.json")
-        if not os.path.exists(settings_path): return
+        if not os.path.exists(settings_path):
+            return
 
         try:
             with open(settings_path, "r", encoding="utf-8") as f:
@@ -378,7 +386,8 @@ class UserStore:
     def cleanup_legacy_settings(self):
         """Removes migrated keys from settings.json."""
         settings_path = os.path.join(config.hidden_data_dir, "settings.json")
-        if not os.path.exists(settings_path): return
+        if not os.path.exists(settings_path):
+            return
 
         try:
             with open(settings_path, "r", encoding="utf-8") as f:

--- a/arcade_scanner/database/user_store.py
+++ b/arcade_scanner/database/user_store.py
@@ -4,7 +4,7 @@ import json
 import os
 import shutil
 import sqlite3
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from arcade_scanner.config import config
 from arcade_scanner.models.user import User, UserVideoData

--- a/arcade_scanner/logging_config.py
+++ b/arcade_scanner/logging_config.py
@@ -8,7 +8,6 @@ logger that writes to both the console and to a rotating log file.
 
 import logging
 import logging.handlers
-import os
 from pathlib import Path
 
 

--- a/arcade_scanner/main.py
+++ b/arcade_scanner/main.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import os
 import time
 import webbrowser
 

--- a/arcade_scanner/models/__init__.py
+++ b/arcade_scanner/models/__init__.py
@@ -1,1 +1,3 @@
 from .video_entry import VideoEntry
+
+__all__ = ["VideoEntry"]

--- a/arcade_scanner/models/user.py
+++ b/arcade_scanner/models/user.py
@@ -1,3 +1,4 @@
+import copy
 import time
 from typing import Any, Dict, List
 
@@ -66,8 +67,6 @@ DEFAULT_SMART_COLLECTIONS = [
         "criteria": {**_default_criteria(), "date": {"type": "relative", "relative": "7d", "from": None, "to": None}}
     }
 ]
-
-import copy
 
 
 def _get_default_smart_collections():

--- a/arcade_scanner/models/user.py
+++ b/arcade_scanner/models/user.py
@@ -1,9 +1,8 @@
-from pydantic import BaseModel, Field
-from typing import List, Dict, Optional, Any
-from datetime import datetime
 import time
+from typing import Any, Dict, List
 
-import uuid
+from pydantic import BaseModel, Field
+
 
 def _default_criteria():
     return {
@@ -69,6 +68,7 @@ DEFAULT_SMART_COLLECTIONS = [
 ]
 
 import copy
+
 
 def _get_default_smart_collections():
     return copy.deepcopy(DEFAULT_SMART_COLLECTIONS)

--- a/arcade_scanner/models/video_entry.py
+++ b/arcade_scanner/models/video_entry.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/arcade_scanner/onboarding.py
+++ b/arcade_scanner/onboarding.py
@@ -4,9 +4,8 @@ Provides an interactive ASCII terminal experience for initial configuration.
 """
 import os
 import shutil
-import subprocess
 import sys
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 
 # ANSI color codes

--- a/arcade_scanner/scanner/__init__.py
+++ b/arcade_scanner/scanner/__init__.py
@@ -2,3 +2,11 @@ from .file_system import AsyncFileSystem, fs_scanner
 from .manager import ScannerManager, get_scanner_manager
 from .media_probe import MediaProbe
 
+__all__ = [
+    "AsyncFileSystem",
+    "MediaProbe",
+    "ScannerManager",
+    "fs_scanner",
+    "get_scanner_manager",
+]
+

--- a/arcade_scanner/scanner/image_inspector.py
+++ b/arcade_scanner/scanner/image_inspector.py
@@ -1,8 +1,7 @@
 import asyncio
 import os
 import shutil
-import subprocess
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional
 
 from ..models.media_asset import ImageMetadata, MediaAsset, MediaType
 from .inspector import MediaInspector

--- a/arcade_scanner/scanner/image_inspector.py
+++ b/arcade_scanner/scanner/image_inspector.py
@@ -12,7 +12,7 @@ class ImageInspector(MediaInspector):
     Inspector for Image Files.
     Uses native macOS 'sips' for high performance metadata extraction without heavy dependencies.
     Falls back to Pillow if sips is missing (cross-platform safety).
-    
+
     Performance: Batches up to BATCH_SIZE files per sips subprocess call,
     reducing process overhead from ~50K spawns to ~500 for large libraries.
     """
@@ -181,7 +181,7 @@ class ImageInspector(MediaInspector):
     def _parse_batch_sips_output(self, output: str) -> Dict[str, Dict[str, str]]:
         """
         Parse multi-file sips output. Each file section starts with the filepath:
-        
+
         /path/to/file1.png
           pixelWidth: 1920
           pixelHeight: 1080

--- a/arcade_scanner/scanner/inspector.py
+++ b/arcade_scanner/scanner/inspector.py
@@ -1,6 +1,6 @@
 from typing import Optional, Protocol
 
-from ..models.media_asset import MediaAsset, MediaType
+from ..models.media_asset import MediaAsset
 
 
 class MediaInspector(Protocol):

--- a/arcade_scanner/scanner/manager.py
+++ b/arcade_scanner/scanner/manager.py
@@ -3,12 +3,11 @@ import hashlib
 import os
 import threading
 import time
-from typing import Callable, List, Optional, Set
+from typing import Callable, Optional, Set
 
 from ..config import config
 from ..database import db
 from ..models.media_asset import MediaAsset
-from ..models.video_entry import VideoEntry
 from .file_system import fs_scanner
 from .image_inspector import ImageInspector
 from .media_probe import MediaProbe

--- a/arcade_scanner/scanner/manager.py
+++ b/arcade_scanner/scanner/manager.py
@@ -98,7 +98,8 @@ class ScannerManager:
         workers = []
         # Number of workers should match concurrency settings to avoid process pile-up
         num_workers = config.settings.max_concurrent_video_scans
-        if num_workers < 1: num_workers = 1
+        if num_workers < 1:
+            num_workers = 1
 
         async def _check_system_load():
             """Simple Watchdog using load average."""

--- a/arcade_scanner/scanner/video_inspector.py
+++ b/arcade_scanner/scanner/video_inspector.py
@@ -1,5 +1,3 @@
-import asyncio
-import os
 from typing import Optional
 
 from ..models.media_asset import MediaAsset, MediaType, VideoMetadata

--- a/arcade_scanner/security/validators.py
+++ b/arcade_scanner/security/validators.py
@@ -23,7 +23,7 @@ class PathValidator:
     def __init__(self, allowed_dirs: List[str]):
         """
         Initialize validator with allowed directories.
-        
+
         Args:
             allowed_dirs: List of directory paths to whitelist
         """
@@ -32,10 +32,10 @@ class PathValidator:
     def is_allowed(self, path: str) -> bool:
         """
         Check if path is within allowed directories.
-        
+
         Args:
             path: File path to validate
-            
+
         Returns:
             True if path is allowed, False otherwise
         """
@@ -50,13 +50,13 @@ class PathValidator:
     def validate(self, path: str) -> str:
         """
         Validate and return absolute path if allowed.
-        
+
         Args:
             path: File path to validate
-            
+
         Returns:
             Absolute path if valid
-            
+
         Raises:
             SecurityError: If path is not in whitelist
             ValueError: If path is invalid or doesn't exist
@@ -81,14 +81,14 @@ class PathValidator:
 def sanitize_path(path: str, allowed_dirs: Optional[List[str]] = None) -> str:
     """
     Sanitize and validate a file path.
-    
+
     Args:
         path: Path to sanitize
         allowed_dirs: Optional list of allowed directories. If None, uses config.
-        
+
     Returns:
         Absolute, validated path
-        
+
     Raises:
         SecurityError: If path validation fails
         ValueError: If path is invalid
@@ -106,11 +106,11 @@ def sanitize_path(path: str, allowed_dirs: Optional[List[str]] = None) -> str:
 def is_path_allowed(path: str, allowed_dirs: Optional[List[str]] = None) -> bool:
     """
     Check if a path is allowed based on scan targets and security rules.
-    
+
     Args:
         path: Path to check (file or directory)
         allowed_dirs: Optional list of allowed directories. Defaults to config scan targets.
-        
+
     Returns:
         True if path is allowed, False otherwise
     """
@@ -130,7 +130,8 @@ def is_path_allowed(path: str, allowed_dirs: Optional[List[str]] = None) -> bool
         allowed_abs = [os.path.realpath(os.path.abspath(d)) for d in allowed_dirs if d]
 
         # 2. Case-insensitive check on Windows/macOS
-        platform_norm = lambda p: p.lower() if (IS_WIN or sys.platform == "darwin") else p
+        def platform_norm(p):
+            return p.lower() if (IS_WIN or sys.platform == "darwin") else p
 
         path_norm = platform_norm(abs_path)
         is_whitelisted = any(path_norm.startswith(platform_norm(allowed)) for allowed in allowed_abs)
@@ -173,12 +174,12 @@ def is_path_allowed(path: str, allowed_dirs: Optional[List[str]] = None) -> bool
 def validate_filename(filename: str, prefix: str = "", suffix: str = "") -> bool:
     """
     Validate a filename matches expected pattern.
-    
+
     Args:
         filename: Filename to validate
         prefix: Required prefix (e.g., "thumb_")
         suffix: Required suffix (e.g., ".jpg")
-        
+
     Returns:
         True if filename is valid, False otherwise
     """
@@ -203,11 +204,11 @@ def validate_filename(filename: str, prefix: str = "", suffix: str = "") -> bool
 def is_safe_directory_traversal(base_dir: str, target_path: str) -> bool:
     """
     Check if target_path stays within base_dir (prevents directory traversal).
-    
+
     Args:
         base_dir: Base directory that should contain the target
         target_path: Path to check
-        
+
     Returns:
         True if target is within base, False otherwise
     """

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -2,12 +2,8 @@ import http.server
 import json
 import mimetypes
 import os
-import shlex
 import socket
 import ssl
-import subprocess
-import sys
-import tempfile
 import threading
 import time
 from http.cookies import SimpleCookie
@@ -17,18 +13,12 @@ from urllib.parse import parse_qs, unquote, urlparse
 from arcade_scanner.config import (
     ALLOWED_THUMBNAIL_PREFIX,
     DUPLICATES_CACHE_FILE,
-    IS_WIN,
-    MAX_REQUEST_SIZE,
-    SETTINGS_FILE,
     config,
 )
 from arcade_scanner.database import db, user_db
-from arcade_scanner.scanner import get_scanner_manager
 from arcade_scanner.security import (
     SecurityError,
     is_path_allowed,
-    is_safe_directory_traversal,
-    sanitize_path,
     session_manager,
     validate_filename,
 )
@@ -371,7 +361,6 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
         2. On miss: do a full cache warm from DB (first call) or a targeted scan for new entries
         3. On persistent miss: scan full DB once more (catches entries added after server start)
         """
-        import hashlib
         from collections import OrderedDict
 
         cache = FinderHandler._thumb_source_cache
@@ -586,7 +575,7 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
                     else:
                         self.send_error(404)
                         return
-                except Exception as e:
+                except Exception:
                     self.send_error(500)
                     return
 

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -33,7 +33,7 @@ from arcade_scanner.templates.dashboard_template import generate_html_report
 
 class _MediaCache:
     """Thread-safe in-memory cache für db.get_all() mit 30s TTL.
-    
+
     Verhindert wiederholte Full-Table-Scans für API-Requests, die in kurzer
     Zeit mehrfach alle Einträge lesen. Wird explizit invalidiert wenn Daten
     verändert werden (upsert, remove etc.).
@@ -355,7 +355,7 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
 
     def _resolve_thumb_source(self, thumb_filename: str):
         """Reverse-lookup: given 'thumb_<hash>.jpg', find the source media file path.
-        
+
         Strategy:
         1. Check in-memory LRU cache (fast path)
         2. On miss: do a full cache warm from DB (first call) or a targeted scan for new entries
@@ -395,11 +395,16 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
         self._response_started = False
         try:
             from .routes import duplicates, files, queue, settings, tags
-            if queue.handle_get(self): return
-            if settings.handle_get(self): return
-            if duplicates.handle_get(self): return
-            if tags.handle_get(self): return
-            if files.handle_get(self): return
+            if queue.handle_get(self):
+                return
+            if settings.handle_get(self):
+                return
+            if duplicates.handle_get(self):
+                return
+            if tags.handle_get(self):
+                return
+            if files.handle_get(self):
+                return
         except Exception as e:
             print(f"Module route error GET: {e}")
             if getattr(self, "_response_started", False):
@@ -701,7 +706,8 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
                         # Always show items in Review mode, regardless of scan targets
                         if entry["Status"] == "REVIEW" or is_match:
                              filtered_videos.append(entry)
-                             if is_match: match_count += 1
+                             if is_match:
+                                 match_count += 1
 
                     if not filtered_videos and all_entries:
                          sample = os.path.abspath(all_entries[0]["FilePath"])
@@ -892,10 +898,14 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
         self._response_started = False
         try:
             from .routes import duplicates, queue, settings, tags
-            if queue.handle_post(self): return
-            if settings.handle_post(self): return
-            if duplicates.handle_post(self): return
-            if tags.handle_post(self): return
+            if queue.handle_post(self):
+                return
+            if settings.handle_post(self):
+                return
+            if duplicates.handle_post(self):
+                return
+            if tags.handle_post(self):
+                return
         except Exception as e:
             print(f"Module route error POST: {e}")
             if getattr(self, "_response_started", False):

--- a/arcade_scanner/server/response_helpers.py
+++ b/arcade_scanner/server/response_helpers.py
@@ -9,8 +9,6 @@ import gzip
 import json
 from http.server import BaseHTTPRequestHandler
 
-from arcade_scanner.config import MAX_REQUEST_SIZE
-
 # Bodies smaller than this aren't worth the gzip CPU/header overhead.
 GZIP_MIN_SIZE = 512
 

--- a/arcade_scanner/server/routes/files.py
+++ b/arcade_scanner/server/routes/files.py
@@ -433,14 +433,16 @@ def _handle_discard_optimized(handler) -> None:
                     db.upsert(VideoEntry(**orig_dict))
 
                     # Cleanup
-                    if os.path.exists(abs_path): os.remove(abs_path)
+                    if os.path.exists(abs_path):
+                        os.remove(abs_path)
                     db.remove(abs_path)
                     db.remove(orig_file.file_path)
 
                     try:
                         if os.path.exists(job_dir) and not os.listdir(job_dir):
                             os.rmdir(job_dir)
-                    except Exception: pass
+                    except Exception:
+                        pass
                 else:
                     # Just discard this file
                     if os.path.exists(abs_path):

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -5,7 +5,7 @@ OPTIMIZE_PANEL_COMPONENT = """
 <!-- Optimize Panel (Tailwind) -->
 <div id="optimizePanel" class="fixed bottom-4 left-0 right-0 mx-auto w-[96%] max-w-5xl bg-[#101018]/85 backdrop-blur-2xl border border-white/20 p-4 rounded-2xl translate-y-[150%] transition-transform duration-500 z-[10050] animate-glow-pulse glow-cyan flex flex-col gap-3">
     <!-- Active state class 'translate-y-0' handled by JS and inline CSS in HEAD -->
-    
+
     <!-- Header -->
     <div class="flex items-center justify-between border-b border-white/10 pb-2">
         <h3 class="text-white font-bold text-base flex items-center gap-2">
@@ -19,7 +19,7 @@ OPTIMIZE_PANEL_COMPONENT = """
 
     <!-- Grid Layout for Settings (Compact 4-col) -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-        
+
         <!-- Codec Card -->
         <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
@@ -81,12 +81,12 @@ OPTIMIZE_PANEL_COMPONENT = """
         <!-- Trim block -->
         <div class="bg-white/[0.02] border border-white/5 rounded-xl p-3 flex-1 flex flex-col gap-2 relative group w-full">
             <div class="absolute inset-0 bg-gradient-to-r from-transparent via-arcade-cyan/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-1000 pointer-events-none rounded-xl"></div>
-            
+
             <div class="flex items-center justify-between relative z-10 hidden md:flex">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest flex items-center gap-1.5">
                     <span class="material-icons text-[14px]">content_cut</span> Trim
                 </div>
-                
+
                 <div class="flex items-center gap-1.5">
                     <input type="text" class="bg-black/40 border border-white/10 text-white px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-arcade-cyan focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all" id="optTrimStart" placeholder="00:00:00">
                     <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-arcade-cyan transition-colors" onclick="setTrimFromHead('start')" title="Set Start from playhead">
@@ -102,11 +102,11 @@ OPTIMIZE_PANEL_COMPONENT = """
                     </button>
                 </div>
             </div>
-            
+
             <!-- Timeline Scrubber -->
             <div class="relative w-full mt-0.5 z-10 min-h-[50px] md:min-h-[60px]" id="optimizeTimeline"></div>
         </div>
-        
+
         <!-- Actions -->
         <div class="flex items-center justify-end gap-2 shrink-0">
             <button class="px-4 py-2 rounded-xl text-sm font-bold text-gray-400 bg-transparent hover:bg-white/5 hover:text-white transition-colors" onclick="closeOptimize()">
@@ -124,7 +124,7 @@ GIF_EXPORT_PANEL_COMPONENT = """
 <!-- GIF Export Panel (Tailwind) -->
 <div id="gifExportPanel" class="fixed bottom-4 left-0 right-0 mx-auto w-[96%] max-w-5xl bg-[#101018]/85 backdrop-blur-2xl border border-white/20 p-4 rounded-2xl translate-y-[150%] transition-transform duration-500 z-[10100] animate-glow-pulse glow-purple flex flex-col gap-3">
     <!-- Active state class 'translate-y-0' handled by JS -->
-    
+
     <!-- Header -->
     <div class="flex items-center justify-between border-b border-white/10 pb-2">
         <h3 class="text-white font-bold text-base flex items-center gap-2">
@@ -138,7 +138,7 @@ GIF_EXPORT_PANEL_COMPONENT = """
 
     <!-- Grid Layout (5 cols: Preset / FPS / Loop / Speed / Quality) -->
     <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
-        
+
         <!-- Preset Card -->
         <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
@@ -216,15 +216,15 @@ GIF_EXPORT_PANEL_COMPONENT = """
         <!-- Trim block -->
         <div class="bg-white/[0.02] border border-white/5 rounded-xl p-3 flex-1 flex flex-col gap-2 relative group w-full">
             <div class="absolute inset-0 bg-gradient-to-r from-transparent via-purple-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-1000 pointer-events-none rounded-xl"></div>
-            
+
             <div class="flex items-center justify-between relative z-10 hidden md:flex">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest flex items-center gap-1.5">
                     <span class="material-icons text-[14px]">content_cut</span> Trim
                 </div>
-                
+
                 <div class="flex items-center gap-1.5">
                     <span class="text-xs text-gray-500 mr-2">Dur: <span id="gifDuration" class="text-purple-400 font-mono">0.0s</span></span>
-                    
+
                     <input type="text" class="bg-black/40 border border-white/10 text-white px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400/30 transition-all" id="gifTrimStart" placeholder="00:00:00" oninput="updateGifEstimate()">
                     <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-purple-400 transition-colors" onclick="setGifTrimFromHead('start')" title="Set Start from playhead">
                         <span class="material-icons text-[12px]">arrow_downward</span>
@@ -239,11 +239,11 @@ GIF_EXPORT_PANEL_COMPONENT = """
                     </button>
                 </div>
             </div>
-            
+
             <!-- Timeline Scrubber -->
             <div class="relative w-full mt-0.5 z-10 min-h-[50px] md:min-h-[60px]" id="gifTimeline"></div>
         </div>
-        
+
         <!-- Actions -->
         <div class="flex items-center justify-end gap-2 shrink-0">
             <button class="px-4 py-2 rounded-xl text-sm font-bold text-gray-400 bg-transparent hover:bg-white/5 hover:text-white transition-colors" onclick="closeGifExport()">
@@ -261,17 +261,17 @@ CINEMA_MODAL_COMPONENT = """
 <!-- Cinema Modal (Tailwind) -->
 <div id="cinemaModal" class="fixed inset-0 z-50 bg-black opacity-0 pointer-events-none transition-opacity duration-500 flex flex-col justify-center items-center">
     <!-- Active class 'opacity-100 pointer-events-auto' toggled by JS -->
-    
+
     <button class="absolute top-4 right-4 text-white/50 hover:text-white z-50 p-2" onclick="closeCinema()">
         <span class="material-icons text-4xl">close</span>
     </button>
-    
+
     <h2 id="cinemaTitle" class="absolute top-6 left-0 right-0 text-center text-white/80 font-light tracking-[4px] text-lg uppercase pointer-events-none z-40 drop-shadow-lg transition-transform duration-500">Movie Player</h2>
-    
+
     <video id="cinemaVideo" controls preload="metadata" class="max-w-full max-h-[80vh] w-auto h-auto shadow-[0_0_50px_rgba(0,0,0,0.8)] rounded-lg outline-none transition-all duration-500 origin-bottom"></video>
-    
+
     <img id="cinemaImage" class="hidden max-w-full max-h-[80vh] w-auto h-auto shadow-[0_0_50px_rgba(0,0,0,0.8)] rounded-lg object-contain transition-all duration-500 origin-bottom" src="">
-    
+
     <div id="cinemaSourceMessage" class="hidden flex-col items-center justify-center bg-black/60 backdrop-blur-md rounded-2xl p-8 border border-purple-500/30 shadow-[0_0_50px_rgba(168,85,247,0.15)] text-center animate-glow-pulse glow-purple max-w-md w-full mx-4 z-40">
         <span class="material-icons text-purple-400 text-6xl mb-4">movie_filter</span>
         <h3 class="text-white text-xl font-bold tracking-widest mb-2">SOURCE MEDIA</h3>
@@ -285,7 +285,7 @@ CINEMA_MODAL_COMPONENT = """
             </a>
         </div>
     </div>
-    
+
     <div id="cinemaInfoPanel" class="absolute top-20 right-4 w-80 bg-black/80 backdrop-blur-md border border-white/10 rounded-lg p-4 transform translate-x-[120%] transition-transform duration-300 z-40 text-sm text-gray-300 animate-glow-pulse glow-cyan">
         <div class="flex items-center gap-2 mb-3 text-white font-bold border-b border-white/10 pb-2">
             <span class="material-icons text-sm">info</span>
@@ -293,12 +293,12 @@ CINEMA_MODAL_COMPONENT = """
         </div>
         <div id="cinemaInfoContent" class="space-y-2 text-xs font-mono"></div>
     </div>
-    
+
     <!-- Assigned Tags Display (Visible List with Remove X) -->
     <div id="cinemaAssignedTags" class="absolute top-20 left-4 max-w-sm flex flex-wrap gap-2 z-40 pointer-events-auto">
         <!-- Populated by JS -->
     </div>
-    
+
     <!-- Tag Picker Dropdown (appears above the Tags button) -->
     <div id="cinemaTagPanel" class="hidden absolute bottom-24 left-1/2 -translate-x-1/2 bg-black/90 backdrop-blur-md border border-white/10 rounded-xl p-3 z-50 min-w-[200px] max-w-[320px] animate-glow-pulse glow-cyan">
         <div class="flex items-center gap-2 mb-2 text-white/80 text-xs border-b border-white/10 pb-2">
@@ -309,7 +309,7 @@ CINEMA_MODAL_COMPONENT = """
             <!-- Populated by JS -->
         </div>
     </div>
-    
+
     <div id="cinemaActions" class="cinema-actions absolute bottom-8 flex gap-3 z-40">
 
         <!-- Info Button -->
@@ -399,12 +399,12 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
 <!-- Duplicate Checker Fullscreen Modal -->
 <div id="duplicateCheckerModal" class="fixed inset-0 z-50 bg-black opacity-0 pointer-events-none transition-opacity duration-300 flex flex-col">
     <!-- Active class 'opacity-100 pointer-events-auto' toggled by JS -->
-    
+
     <!-- Close Button -->
     <button class="absolute top-6 right-6 text-white/50 hover:text-white z-50 p-2 transition-colors" onclick="closeDuplicateChecker()">
         <span class="material-icons text-4xl">close</span>
     </button>
-    
+
     <!-- Header: Group Counter -->
     <div class="absolute top-6 left-0 right-0 text-center z-40">
         <div class="text-white/60 text-sm font-mono mb-1">DUPLICATE GROUP</div>
@@ -415,11 +415,11 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
             2 duplicate candidates • Qualify diff: 0.0 pts
         </div>
     </div>
-    
+
     <!-- Main Comparison Area -->
     <div class="flex-1 flex items-center justify-center px-8 py-24">
         <div class="grid grid-cols-2 gap-8 w-full max-w-7xl">
-            
+
             <!-- File A (Left) -->
             <div id="dupFileA" class="duplicate-file-panel flex flex-col gap-4 p-6 rounded-2xl border-2 border-white/10 bg-white/[0.02] transition-all hover:border-purple-400/50 hover:scale-[1.02]">
                 <!-- Label -->
@@ -434,7 +434,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                         ✓ Higher Quality
                     </div>
                 </div>
-                
+
                 <!-- Thumbnail -->
                 <div class="relative aspect-video bg-black rounded-lg overflow-hidden cursor-pointer group" onclick="previewDuplicateFile('A')">
                     <img id="dupFileAThumb" src="" class="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity">
@@ -442,10 +442,10 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                         <span class="material-icons text-white text-4xl drop-shadow-lg">play_circle</span>
                     </div>
                 </div>
-                
+
                 <!-- Filename -->
                 <div class="text-white font-medium text-sm truncate" id="dupFileAName" title="">filename_a.mp4</div>
-                
+
                 <!-- Metadata Grid -->
                 <div class="grid grid-cols-2 gap-2 text-xs">
                     <div class="bg-white/5 rounded-lg p-2">
@@ -465,7 +465,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                         <div id="dupFileABitrate" class="text-white font-mono">--</div>
                     </div>
                 </div>
-                
+
                 <!-- Action Button -->
                 <button onclick="keepDuplicateFile('A')" class="w-full py-3 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border-2 border-purple-500/50 hover:border-purple-500 text-purple-400 hover:text-white font-bold text-sm uppercase tracking-wider transition-all flex items-center justify-center gap-2 group">
                     <span class="material-icons">check_circle</span>
@@ -473,7 +473,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                     <span class="text-xs opacity-60 group-hover:opacity-100">(Press 1 or ←)</span>
                 </button>
             </div>
-            
+
             <!-- File B (Right) -->
             <div id="dupFileB" class="duplicate-file-panel flex flex-col gap-4 p-6 rounded-2xl border-2 border-white/10 bg-white/[0.02] transition-all hover:border-purple-400/50 hover:scale-[1.02]">
                 <!-- Label -->
@@ -488,7 +488,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                         ✓ Higher Quality
                     </div>
                 </div>
-                
+
                 <!-- Thumbnail -->
                 <div class="relative aspect-video bg-black rounded-lg overflow-hidden cursor-pointer group" onclick="previewDuplicateFile('B')">
                     <img id="dupFileBThumb" src="" class="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity">
@@ -496,10 +496,10 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                         <span class="material-icons text-white text-4xl drop-shadow-lg">play_circle</span>
                     </div>
                 </div>
-                
+
                 <!-- Filename -->
                 <div class="text-white font-medium text-sm truncate" id="dupFileBName" title="">filename_b.mp4</div>
-                
+
                 <!-- Metadata Grid -->
                 <div class="grid grid-cols-2 gap-2 text-xs">
                     <div class="bg-white/5 rounded-lg p-2">
@@ -519,7 +519,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                         <div id="dupFileBBitrate" class="text-white font-mono">--</div>
                     </div>
                 </div>
-                
+
                 <!-- Action Button -->
                 <button onclick="keepDuplicateFile('B')" class="w-full py-3 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border-2 border-purple-500/50 hover:border-purple-500 text-purple-400 hover:text-white font-bold text-sm uppercase tracking-wider transition-all flex items-center justify-center gap-2 group">
                     <span class="material-icons">check_circle</span>
@@ -527,10 +527,10 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
                     <span class="text-xs opacity-60 group-hover:opacity-100">(Press 2 or →)</span>
                 </button>
             </div>
-            
+
         </div>
     </div>
-    
+
     <!-- Bottom Action Bar -->
     <div class="absolute bottom-8 left-0 right-0 flex items-center justify-center gap-4 z-40">
         <!-- Skip Button -->
@@ -539,7 +539,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
             <span>Skip</span>
             <span class="text-xs opacity-60">(S or Space)</span>
         </button>
-        
+
         <!-- Any is Fine Button -->
         <button onclick="markAnyIsFine()" class="px-6 py-3 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/50 hover:border-green-500 text-green-400 hover:text-white font-semibold text-sm transition-all flex items-center gap-2">
             <span class="material-icons text-lg">done_all</span>
@@ -547,7 +547,7 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
             <span class="text-xs opacity-60">(A)</span>
         </button>
     </div>
-    
+
     <!-- Keyboard Shortcuts Legend -->
     <div class="absolute bottom-24 left-1/2 -translate-x-1/2 bg-black/80 backdrop-blur-md border border-white/10 rounded-xl px-6 py-3 z-30">
         <div class="flex items-center gap-6 text-xs text-white/60">
@@ -637,51 +637,51 @@ BATCH_BAR_COMPONENT = """
 <!-- Batch Action Bar -->
 <div id="batchBar" class="fixed bottom-20 md:bottom-8 left-1/2 md:left-[calc(50%+128px)] z-50 bg-[#0d0d14] border-2 border-arcade-cyan/30 rounded-2xl animate-glow-pulse glow-cyan px-4 py-2.5 flex items-center gap-2 transition-transform duration-300" style="transform: translateX(-50%) translateY(8rem);">
     <!-- Active class 'translate-y-0' handled by JS -->
-    
+
     <!-- Select All Button -->
     <button class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-xs font-semibold text-gray-300 hover:bg-white/10 hover:text-white transition-all" onclick="selectAllVisible()">
         <span class="material-icons text-sm">select_all</span>
         All
     </button>
-    
+
     <div class="h-8 w-px bg-white/10"></div>
-    
+
     <span class="text-base font-bold text-white whitespace-nowrap"><span id="batchCount" class="text-arcade-cyan text-lg">0</span> Selected</span>
-    
+
     <div class="h-8 w-px bg-white/10"></div>
-    
+
     <!-- TAG Button -->
     <button class="batch-action-btn" style="--btn-color: #a855f7" onclick="openBatchTagModal()">
         <span class="material-icons text-base">label</span>
         <span>TAG</span>
     </button>
-    
+
     <!-- OPTIMIZE Button -->
     <button class="batch-action-btn" style="--btn-color: #00ffd0" onclick="triggerBatchCompress()">
         <span class="material-icons text-base">bolt</span>
         <span>OPTIMIZE</span>
     </button>
-    
+
     <!-- FAV Button -->
     <button class="batch-action-btn" style="--btn-color: #F4B342" onclick="triggerBatchFavorite(true)">
         <span class="material-icons text-base">star</span>
         <span>FAV</span>
     </button>
-    
+
     <!-- VAULT Button -->
     <button class="batch-action-btn" style="--btn-color: #DE1A58" onclick="triggerBatchHide(true)">
         <span class="material-icons text-base">archive</span>
         <span>VAULT</span>
     </button>
-    
+
     <!-- DELETE Button -->
     <button class="batch-action-btn" style="--btn-color: #EF4444" onclick="triggerBatchDelete()">
         <span class="material-icons text-base">delete_forever</span>
         <span>DELETE</span>
     </button>
-    
+
     <div class="h-8 w-px bg-white/10"></div>
-    
+
     <button class="text-gray-400 hover:text-white transition-colors p-1" onclick="clearSelection()" title="Clear Selection">
         <span class="material-icons text-xl">close</span>
     </button>
@@ -715,14 +715,14 @@ FOLDER_SIDEBAR_COMPONENT = """
 <!-- Folder Sidebar (Off-Canvas) -->
 <div id="folderSidebar" class="fixed inset-y-0 left-0 w-80 bg-[#101018]/95 backdrop-blur-xl border-r border-white/10 transform -translate-x-full transition-transform duration-300 z-30 flex flex-col pt-safe-top">
     <!-- Active class 'translate-x-0' handled by JS -->
-    
+
     <div class="p-4 border-b border-white/10 flex items-center justify-between">
         <h3 class="font-bold text-white tracking-wider">FOLDERS</h3>
         <button class="text-gray-400 hover:text-white" onclick="toggleFolderSidebar()">
             <span class="material-icons">close</span>
         </button>
     </div>
-    
+
     <div id="folderList" class="flex-1 overflow-y-auto p-2 space-y-1">
         <!-- Injected by JS -->
     </div>
@@ -741,11 +741,11 @@ FILTER_PANEL_COMPONENT = """
 <div id="filterPanel" class="fixed inset-0 z-40 hidden">
     <!-- Backdrop -->
     <div id="filterPanelBackdrop" class="absolute inset-0 bg-black/60 opacity-0 transition-opacity duration-300" onclick="closeFilterPanel()"></div>
-    
+
     <!-- Panel Content -->
     <div id="filterPanelContent" class="absolute bg-arcade-bg/98 dark:bg-[#12121a]/95 backdrop-blur-xl border-black/10 dark:border-white/10 shadow-2xl transition-transform duration-300 flex flex-col overflow-hidden
         right-0 top-0 bottom-0 w-80 translate-x-full rounded-l-2xl border-l">
-        
+
         <!-- Header -->
         <div class="p-4 border-b border-white/5 flex items-center justify-between shrink-0">
             <div class="flex items-center gap-3">
@@ -757,10 +757,10 @@ FILTER_PANEL_COMPONENT = """
                 <span class="material-icons">close</span>
             </button>
         </div>
-        
+
         <!-- Scrollable Body -->
         <div class="flex-1 overflow-y-auto p-4 space-y-6">
-            
+
             <!-- SIZE Section -->
             <section>
                 <h3 class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-3">Filesize (MB)</h3>
@@ -818,7 +818,7 @@ FILTER_PANEL_COMPONENT = """
                     </button>
                 </div>
             </section>
-            
+
             <!-- CODEC Section -->
             <section>
                 <h3 class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-3">Codec</h3>
@@ -837,7 +837,7 @@ FILTER_PANEL_COMPONENT = """
                     </button>
                 </div>
             </section>
-            
+
             <!-- TAGS Section -->
             <section>
                 <div class="flex items-center justify-between mb-3">
@@ -850,7 +850,7 @@ FILTER_PANEL_COMPONENT = """
                     <!-- Tag chips injected by JS -->
                     <span class="text-xs text-gray-600 italic">No tags created yet</span>
                 </div>
-                
+
                 <!-- Untagged Toggle -->
                 <label class="flex items-center gap-2 mt-4 cursor-pointer group">
                     <input type="checkbox" id="filterUntaggedOnly" onchange="toggleUntaggedFilter()" class="sr-only peer">
@@ -860,9 +860,9 @@ FILTER_PANEL_COMPONENT = """
                     <span class="text-sm text-gray-400 group-hover:text-white transition-colors">Show untagged only</span>
                 </label>
             </section>
-            
+
         </div>
-        
+
         <!-- Footer -->
         <div class="p-4 border-t border-black/5 dark:border-white/5 flex items-center justify-between shrink-0 bg-black/5 dark:bg-[#0a0a12]">
             <button onclick="resetFilters()" class="text-sm text-gray-500 hover:text-white transition-colors">
@@ -880,7 +880,7 @@ FILTER_PANEL_COMPONENT = """
     #filterPanel.active { display: block !important; }
     #filterPanel.active #filterPanelBackdrop { opacity: 1; }
     #filterPanel.active #filterPanelContent { transform: translateX(0); }
-    
+
     /* Filter Chip Styles */
     .filter-chip {
         padding: 0.375rem 0.875rem;
@@ -901,7 +901,7 @@ FILTER_PANEL_COMPONENT = """
         border-color: rgba(0, 255, 208, 0.5);
         color: #00ffd0;
     }
-    
+
     /* Tag Filter Chips */
     .tag-filter-chip {
         padding: 0.375rem 0.75rem;
@@ -942,7 +942,7 @@ TAG_MANAGER_MODAL_COMPONENT = """
 <!-- Tag Manager Modal -->
 <div id="tagManagerModal" class="fixed inset-0 z-40 bg-black/80 backdrop-blur-sm hidden opacity-0 transition-opacity duration-300 flex items-center justify-center p-4">
     <div class="w-full max-w-md bg-[#1a1a24] rounded-2xl shadow-2xl border border-white/10 transform scale-95 transition-transform duration-300 overflow-hidden">
-        
+
         <!-- Header -->
         <div class="p-4 border-b border-white/5 flex items-center justify-between">
             <div class="flex items-center gap-3">
@@ -953,7 +953,7 @@ TAG_MANAGER_MODAL_COMPONENT = """
                 <span class="material-icons">close</span>
             </button>
         </div>
-        
+
         <!-- Create New Tag -->
         <div class="p-4 border-b border-white/5 bg-[#12121a]">
             <h3 class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-3">Create New Tag</h3>
@@ -974,20 +974,20 @@ TAG_MANAGER_MODAL_COMPONENT = """
                                     <button type="button" class="w-6 h-6 rounded" style="background: #f97316" onclick="selectTagColor('#f97316')"></button>
                                 </div>
                             </div>
-                            
+
                             <!-- Shortcut Key -->
-                            <input type="text" id="newTagShortcut" 
-                                   placeholder="Key" 
+                            <input type="text" id="newTagShortcut"
+                                   placeholder="Key"
                                    maxlength="1"
                                    class="w-12 px-2 py-2 bg-black/40 border border-white/10 rounded-lg text-white text-center uppercase focus:outline-none focus:border-arcade-cyan/50"
                                    title="Cinema mode keyboard shortcut (A-Z, except F and V)">
-                            
+
                             <button type="button" onclick="createNewTag()" class="px-4 py-2 bg-arcade-cyan/20 text-arcade-cyan rounded-lg hover:bg-arcade-cyan/30 transition-colors text-sm font-medium">
                                 Add
                             </button>
             </div>
         </div>
-        
+
         <!-- Existing Tags List -->
         <div class="p-4 max-h-64 overflow-y-auto">
             <h3 id="manageTagsHeader" class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-3">Manage Existing Tags</h3>
@@ -996,7 +996,7 @@ TAG_MANAGER_MODAL_COMPONENT = """
                 <p class="text-sm text-gray-600 italic">No tags created yet</p>
             </div>
         </div>
-        
+
         <!-- Footer -->
         <div class="p-4 border-t border-white/5 bg-[#0a0a12]">
             <button onclick="closeTagManager()" class="w-full py-2 bg-white/5 text-gray-400 font-medium rounded-lg hover:bg-white/10 hover:text-white transition-colors">
@@ -1498,7 +1498,7 @@ SETUP_WIZARD_COMPONENT = """
 <!-- First-Run Setup Wizard -->
 <div id="setupWizard" class="hidden fixed inset-0 z-50 bg-gradient-to-br from-[#0a0a12] via-[#1a1a24] to-[#0a0a12] flex items-center justify-center p-4">
     <div class="w-full max-w-3xl">
-        
+
         <!-- Welcome Header -->
         <div class="text-center mb-8">
             <div class="inline-block p-4 bg-arcade-cyan/10 rounded-full mb-4">
@@ -1510,7 +1510,7 @@ SETUP_WIZARD_COMPONENT = """
 
         <!-- Setup Card -->
         <div class="bg-[#1a1a24] rounded-2xl shadow-2xl border border-white/10 p-8">
-            
+
             <!-- Step 1: Select Directories -->
             <div class="mb-8">
                 <div class="flex items-center gap-3 mb-4">
@@ -1518,7 +1518,7 @@ SETUP_WIZARD_COMPONENT = """
                     <h2 class="text-xl font-semibold text-white">Select Media Directories</h2>
                 </div>
                 <p class="text-sm text-gray-400 mb-4">Choose which directories to scan for videos and images. Your media is mounted at <code class="px-2 py-0.5 bg-black/40 rounded text-arcade-cyan">/media</code></p>
-                
+
                 <!-- Directory List -->
                 <div id="setupDirectoryList" class="space-y-2 max-h-64 overflow-y-auto">
                     <!-- Populated dynamically -->
@@ -1567,7 +1567,7 @@ SETUP_WIZARD_COMPONENT = """
 
 <style>
     #setupWizard.active { display: flex !important; }
-    
+
     /* Custom scrollbar for directory list */
     #setupDirectoryList::-webkit-scrollbar {
         width: 8px;
@@ -1583,7 +1583,7 @@ SETUP_WIZARD_COMPONENT = """
     #setupDirectoryList::-webkit-scrollbar-thumb:hover {
         background: rgba(100, 255, 218, 0.3);
     }
-    
+
     .setup-dir-card {
         padding: 1rem;
         background: rgba(0, 0, 0, 0.3);
@@ -1606,14 +1606,14 @@ SETUP_WIZARD_COMPONENT = """
 SETTINGS_MODAL_COMPONENT = """
 <div id="settingsModal" class="hidden fixed inset-0 z-40 bg-black/80 backdrop-blur-sm opacity-0 transition-opacity duration-300 flex items-center justify-center p-4 md:p-8">
     <div class="settings-container w-full h-full md:w-2/3 md:h-auto md:max-w-5xl md:max-h-[85vh] bg-arcade-bg dark:bg-[#1a1a24] rounded-2xl animate-glow-pulse glow-cyan flex flex-col md:flex-row overflow-hidden border border-black/10 dark:border-white/10 transform scale-95 transition-transform duration-300">
-        
+
         <!-- Sidebar Navigation -->
         <aside class="w-full md:w-56 bg-[#f1f3f5] dark:bg-[#12121a] border-b md:border-b-0 md:border-r border-black/10 dark:border-white/5 flex md:flex-col shrink-0">
             <div class="p-4 md:p-5 flex items-center gap-3 border-b border-black/8 dark:border-white/5 md:border-none">
                 <span class="material-icons text-arcade-gold text-xl">settings</span>
                 <h2 class="font-semibold tracking-wide text-lg text-text-main dark:text-white">Settings</h2>
             </div>
-            
+
             <nav class="flex md:flex-col overflow-x-auto md:overflow-visible p-2 md:px-3 md:py-2 gap-1">
                 <button class="settings-nav-item active flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="scanning">
                     <span class="material-icons text-lg">folder_open</span>
@@ -1630,9 +1630,9 @@ SETTINGS_MODAL_COMPONENT = """
                     <span class="hidden md:inline">Interface</span>
                     <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-                
+
                 <div class="w-px h-6 md:w-full md:h-px bg-white/10 md:my-2 mx-2 md:mx-0"></div>
-                
+
                 <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="storage">
                     <span class="material-icons text-lg">storage</span>
                     <span class="hidden md:inline">Storage</span>
@@ -1658,10 +1658,10 @@ SETTINGS_MODAL_COMPONENT = """
                 </button>
             </nav>
         </aside>
-        
+
         <!-- Main Content -->
         <main class="flex-1 flex flex-col min-w-0 bg-arcade-bg dark:bg-[#1a1a24]">
-            
+
             <!-- Header -->
             <header class="p-5 md:p-6 border-b border-white/5 flex justify-between items-center">
                 <div>
@@ -1672,10 +1672,10 @@ SETTINGS_MODAL_COMPONENT = """
                     <span class="material-icons">close</span>
                 </button>
             </header>
-            
+
             <!-- Scrollable Body -->
             <div class="settings-body flex-1 overflow-y-auto p-5 md:p-6 space-y-6">
-                
+
                 <!-- SCANNING SECTION -->
                 <div class="content-section active space-y-6" id="content-scanning">
                     <section class="space-y-3">
@@ -1687,7 +1687,7 @@ SETTINGS_MODAL_COMPONENT = """
                             <p class="text-sm text-gray-500 mt-1">Paths to scan for video files. One per line.</p>
                         </div>
                         <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsTargets" placeholder="/Users/username/Videos" rows="4" oninput="markSettingsUnsaved()"></textarea>
-                        
+
                         <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 flex gap-3 text-sm text-blue-300">
                              <span class="material-icons text-blue-400 text-lg">info</span>
                              <div>
@@ -1696,7 +1696,7 @@ SETTINGS_MODAL_COMPONENT = """
                              </div>
                         </div>
                     </section>
-                    
+
                     <section class="space-y-3">
                         <div>
                             <h3 class="text-base font-medium text-white flex items-center gap-2">
@@ -1709,7 +1709,7 @@ SETTINGS_MODAL_COMPONENT = """
                             <!-- Populated by JS -->
                         </div>
                     </section>
-                    
+
                     <section class="space-y-3">
                         <div>
                             <h3 class="text-base font-medium text-white flex items-center gap-2">
@@ -1741,7 +1741,7 @@ SETTINGS_MODAL_COMPONENT = """
                         </label>
                     </section>
                 </div>
-                
+
                 <!-- PERFORMANCE SECTION -->
                 <div class="content-section hidden space-y-6" id="content-performance">
                     <section class="space-y-4">
@@ -1752,7 +1752,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Ignore videos smaller than this size.</p>
                         </div>
-                        
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Minimum Size</div>
@@ -1772,7 +1772,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </div>
                         </div>
                     </section>
-                    
+
                     <section class="space-y-4">
                         <div>
                             <h3 class="text-base font-medium text-white flex items-center gap-2">
@@ -1781,7 +1781,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Ignore images smaller than this. Filters out tiny icons/thumbnails.</p>
                         </div>
-                        
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Minimum Size</div>
@@ -1801,7 +1801,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </div>
                         </div>
                     </section>
-                    
+
                     <section class="space-y-4">
                         <div>
                             <h3 class="text-base font-medium text-white flex items-center gap-2">
@@ -1810,7 +1810,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Videos above this are marked as HIGH bitrate.</p>
                         </div>
-                        
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Bitrate Threshold</div>
@@ -1839,7 +1839,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Generate thumbnails during scan to prevent lag while scrolling.</p>
                         </div>
-                        
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Pre-compute Thumbnails</div>
@@ -1887,7 +1887,7 @@ SETTINGS_MODAL_COMPONENT = """
                         <input type="hidden" id="settingsEncodingPreset" value="balanced">
                     </section>
                 </div>
-                
+
                 <!-- INTERFACE SECTION -->
                 <div class="content-section hidden space-y-6" id="content-interface">
                     <section class="space-y-4">
@@ -1898,7 +1898,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Customize the visual style.</p>
                         </div>
-                        
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 space-y-4">
                             <label class="block text-xs text-gray-400 mb-1">Color Paradigm</label>
                             <select id="settingsTheme" onchange="markSettingsUnsaved()" class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none">
@@ -1918,9 +1918,9 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Customize the dashboard experience.</p>
                         </div>
-                        
 
-                        
+
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Video Optimizer</div>
@@ -1969,7 +1969,7 @@ SETTINGS_MODAL_COMPONENT = """
 
                     </section>
                 </div>
-                
+
                 <!-- STORAGE SECTION -->
                 <div class="content-section hidden space-y-6" id="content-storage">
                     <section class="space-y-4">
@@ -1980,7 +1980,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Disk space used by generated assets.</p>
                         </div>
-                        
+
                         <div class="grid grid-cols-2 gap-3">
                             <div class="bg-black/40 p-4 rounded-xl border border-white/5 flex flex-col items-center gap-2">
                                 <span class="material-icons text-gray-500 text-2xl">image</span>
@@ -1993,7 +1993,7 @@ SETTINGS_MODAL_COMPONENT = """
                                 <span class="text-lg font-mono text-arcade-cyan" id="statTotal">—</span>
                             </div>
                         </div>
-                        
+
                         <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 flex gap-3 text-sm text-amber-200">
                             <span class="material-icons text-amber-400 text-lg">info</span>
                             <div>Cache changes require an app restart. Clearing cache deletes all thumbnails.</div>
@@ -2030,13 +2030,13 @@ SETTINGS_MODAL_COMPONENT = """
                                 <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsSensitiveDirs" placeholder="/path/to/private" rows="3" oninput="markSettingsUnsaved()"></textarea>
                                 <p class="text-xs text-gray-500 mt-1">One absolute path per line. Files in these folders will be hidden.</p>
                             </div>
-                            
+
                             <div>
                                 <label class="block text-xs font-medium text-white mb-2">Sensitive Tags</label>
                                 <input type="text" id="settingsSensitiveTags" placeholder="nsfw, adult" class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none" oninput="markSettingsUnsaved()">
                                 <p class="text-xs text-gray-500 mt-1">Comma separated list of tags to hide.</p>
                             </div>
-                            
+
                             <div>
                                 <label class="block text-xs font-medium text-white mb-2">Sensitive Collections</label>
                                 <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsSensitiveCollections" placeholder="My Private Collection" rows="3" oninput="markSettingsUnsaved()"></textarea>
@@ -2056,7 +2056,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Download your current configuration, including collections and tags.</p>
                         </div>
-                        
+
                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Backup Configuration</div>
@@ -2077,7 +2077,7 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-sm text-gray-500 mt-1">Restore configuration from a backup file. Existing settings will be overwritten.</p>
                         </div>
-                        
+
                          <div class="bg-black/30 rounded-xl p-4 border border-white/5 space-y-4">
                             <div class="flex items-center gap-4">
                                 <div class="flex-1">
@@ -2132,7 +2132,7 @@ SETTINGS_MODAL_COMPONENT = """
                     </section>
                 </div>
             </div>
-            
+
             <!-- Footer -->
             <footer class="p-4 border-t border-black/8 dark:border-white/5 bg-[#f1f3f5] dark:bg-[#12121a] flex justify-between items-center">
                 <div class="flex items-center gap-2">
@@ -2153,7 +2153,7 @@ SETTINGS_MODAL_COMPONENT = """
                     </button>
                 </div>
             </footer>
-            
+
         </main>
     </div>
 </div>
@@ -2176,7 +2176,7 @@ FILTER_BAR_COMPONENT = """
         <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 text-[18px]">search</span>
         <input type="text" id="mobileSearchInput" oninput="onSearchInput()" placeholder="Search..." class="w-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-full pl-10 pr-4 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:border-arcade-cyan/50 focus:bg-black/10 dark:focus:bg-white/10 transition-all placeholder-gray-500 dark:placeholder-gray-600">
     </div>
-    
+
     <!-- Filter Controls (Simplified) -->
     <div class="flex items-center gap-2 overflow-x-auto pb-1 md:pb-0 scrollbar-hide flex-shrink-0">
         <!-- Unified Filters Button -->
@@ -2185,7 +2185,7 @@ FILTER_BAR_COMPONENT = """
             <span>Filters</span>
             <span id="filterBadge" class="hidden bg-arcade-cyan text-black text-[10px] font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">0</span>
         </button>
-        
+
         <!-- Sort Dropdown (kept for quick access) -->
         <div class="relative group">
             <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-[16px] pointer-events-none group-hover:text-arcade-cyan transition-colors">sort</span>
@@ -2196,7 +2196,7 @@ FILTER_BAR_COMPONENT = """
                 <option value="date">Date ↓</option>
             </select>
         </div>
-        
+
         <!-- View Toggles & Grid Scale -->
         <div class="hidden md:flex items-center bg-black/5 dark:bg-white/5 rounded-lg p-0.5 ml-2 border border-black/5 dark:border-white/5">
             <!-- Grid Scale Slider -->
@@ -2205,7 +2205,7 @@ FILTER_BAR_COMPONENT = """
                 <input type="range" id="gridScaleSlider" min="150" max="500" value="240" step="10" oninput="updateGridScale(this.value)" class="w-16 h-1 bg-black/10 dark:bg-white/10 rounded-full appearance-none cursor-pointer">
                 <span class="material-icons text-[16px] text-gray-500/70 group-hover:text-arcade-cyan transition-colors">photo_size_select_large</span>
             </div>
-            
+
             <button id="viewToggleGrid" onclick="setLayout('grid')" class="p-1.5 rounded hover:bg-black/10 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition-colors" title="Grid View">
                 <span class="material-icons text-[18px]">grid_view</span>
             </button>
@@ -2219,7 +2219,7 @@ FILTER_BAR_COMPONENT = """
                 <span class="material-icons text-[18px]">folder</span>
             </button>
         </div>
-        
+
         <button id="refreshBtn" onclick="rescanLibrary()" class="bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white p-2 rounded-full transition-colors flex items-center justify-center flex-shrink-0" title="Rescan Library">
             <span class="material-icons text-[18px]">refresh</span>
         </button>

--- a/arcade_scanner/templates/dashboard_template.py
+++ b/arcade_scanner/templates/dashboard_template.py
@@ -23,7 +23,7 @@ from arcade_scanner.templates.components import (
     TAG_MANAGER_MODAL_COMPONENT,
     TREEMAP_LEGEND_COMPONENT,
 )
-from arcade_scanner.templates.theme import CURRENT_THEME, THEMES
+from arcade_scanner.templates.theme import THEMES
 from arcade_scanner.templates.ui_components import (
     render_base_layout,
     render_header,

--- a/arcade_scanner/templates/dashboard_template.py
+++ b/arcade_scanner/templates/dashboard_template.py
@@ -102,15 +102,15 @@ def generate_html_report(results, report_file, server_port=8000):
     {nav_html}
 
     {FOLDER_SIDEBAR_COMPONENT}
-    
+
     <!-- Desktop: Main Content Area (offset by sidebar width) -->
     <div class="flex-1 flex flex-col md:ml-64 min-h-screen bg-arcade-bg relative overflow-x-hidden max-w-full">
         {header_html}
-        
+
         {FILTER_BAR_COMPONENT}
 
         {SAVED_VIEWS_COMPONENT}
-        
+
         {TREEMAP_LEGEND_COMPONENT}
 
         {FOLDER_BROWSER_LEGEND_COMPONENT}
@@ -127,7 +127,7 @@ def generate_html_report(results, report_file, server_port=8000):
 
         <!-- Main Content Container with safe area padding -->
         <main class="flex-1 p-2 md:p-6 pb-[80px] md:pb-6 relative w-full overflow-x-hidden" id="mainContentArea">
-            
+
             <!-- Video Grid -->
             <div id="videoGrid" class="responsive-grid transition-opacity duration-300 overflow-hidden">
                 <!-- Skeleton cards shown while data loads -->
@@ -141,23 +141,23 @@ def generate_html_report(results, report_file, server_port=8000):
                     </div>
                 </div>''' for _ in range(8)])}
             </div>
-            
+
             <!-- List View -->
             {LIST_VIEW_COMPONENT}
-            
+
             <!-- Treemap Container -->
             <div id="treemapContainer" class="hidden h-[70vh] w-full rounded-xl overflow-hidden border border-white/10 shadow-2xl"></div>
-            
+
             <!-- Loading Spinner -->
             <div id="loadingSentinel" class="h-24 flex items-center justify-center opacity-0 transition-opacity">
                 <span class="material-icons animate-spin text-arcade-cyan text-3xl">refresh</span>
             </div>
-            
+
         </main>
 
-        
+
     </div>
-    
+
     <!-- Modals & Overlays -->
     {cinema_modal_html}
     {DUPLICATE_CHECKER_MODAL_COMPONENT}
@@ -170,7 +170,7 @@ def generate_html_report(results, report_file, server_port=8000):
     {SETUP_WIZARD_COMPONENT}
     {HIDDEN_PATH_MODAL_COMPONENT}
     {BATCH_BAR_COMPONENT}
-    
+
     <!-- Hidden frame for form submissions if needed -->
     <iframe name='h_frame' style='display:none;'></iframe>
     """

--- a/arcade_scanner/templates/gif_panel_component.py
+++ b/arcade_scanner/templates/gif_panel_component.py
@@ -2,7 +2,7 @@ GIF_EXPORT_PANEL_COMPONENT = """
 <!-- GIF Export Panel (Tailwind) -->
 <div id="gifExportPanel" class="fixed bottom-0 left-0 right-0 bg-[#101018]/95 backdrop-blur-xl border-t border-white/10 p-6 translate-y-[110%] transition-transform duration-300 z-[10100] shadow-[0_-10px_40px_rgba(0,0,0,0.5)] flex flex-col gap-4">
     <!-- Active state class 'translate-y-0' handled by JS -->
-    
+
     <!-- Preset Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">Preset</div>
@@ -30,44 +30,44 @@ GIF_EXPORT_PANEL_COMPONENT = """
         <div class="flex-1"></div>
         <span class="text-xs text-gray-500">Frame rate (higher = smoother)</span>
     </div>
-    
+
     <!-- Trim Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">Trim</div>
         <input type="text" class="bg-black/30 border border-white/10 text-white px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifTrimStart" placeholder="00:00:00" oninput="updateGifEstimate()">
-        
+
         <button class="w-[30px] h-[30px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors" onclick="setGifTrimFromHead('start')" title="Set Start">
             <span class="material-icons text-[16px]">arrow_downward</span>
         </button>
-        
+
         <div class="w-[10px] text-center text-gray-600">-</div>
-        
+
         <input type="text" class="bg-black/30 border border-white/10 text-white px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifTrimEnd" placeholder="END" oninput="updateGifEstimate()">
-        
+
         <button class="w-[30px] h-[30px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors" onclick="setGifTrimFromHead('end')" title="Set End">
             <span class="material-icons text-[16px]">arrow_downward</span>
         </button>
-        
+
         <button class="w-[30px] h-[30px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors ml-2" onclick="clearGifTrim()" title="Clear">
             <span class="material-icons text-[16px]">close</span>
         </button>
-        
+
         <div class="flex-1"></div>
         <span class="text-xs text-gray-500">Duration: <span id="gifDuration" class="text-arcade-cyan">0.0s</span></span>
     </div>
-    
+
     <!-- Quality Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">Quality</div>
         <input type="number" class="bg-black/30 border border-white/10 text-white px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifQuality" placeholder="80" value="80" min="50" max="100" step="10" oninput="updateGifEstimate()">
-        
+
         <span class="text-xs text-gray-500 font-mono">Estimated: <span id="gifEstimatedSize" class="text-arcade-cyan">~0 MB</span></span>
     </div>
-    
+
     <!-- Actions -->
     <div class="flex items-center gap-4 mt-2">
         <button class="flex-1 py-2.5 rounded-lg font-bold cursor-pointer text-gray-400 bg-white/5 hover:bg-white/10 hover:text-white transition-all max-w-[120px]" onclick="closeGifExport()">Cancel</button>
-        
+
         <button class="flex-1 py-2.5 rounded-lg font-bold cursor-pointer text-white bg-purple-500/20 text-purple-400 border border-purple-500/50 shadow-[0_0_15px_rgba(168,85,247,0.2)] hover:bg-purple-500 hover:text-white transition-all flex items-center justify-center gap-2" onclick="triggerGifExport()">
             <span class="material-icons">gif</span> EXPORT GIF
         </button>

--- a/arcade_scanner/templates/ui_components.py
+++ b/arcade_scanner/templates/ui_components.py
@@ -12,28 +12,28 @@ def render_base_layout(theme: BaseTheme, content: str, scripts: str, active_them
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Arcade Video Dashboard</title>
-    
+
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=SF+Mono:wght@400;600&display=swap" rel="stylesheet">
-    
+
     <!-- Theme CSS Variables -->
     {render_theme_css()}
 
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     {theme.render_tailwind_config()}
-    
-    <style>        
+
+    <style>
         .scrollbar-hide::-webkit-scrollbar {{ display: none; }}
         .scrollbar-hide {{ -ms-overflow-style: none; scrollbar-width: none; }}
-        
+
         .glass-panel {{
             background: var(--surface-glass);
             backdrop-filter: blur(20px);
             border: 1px solid var(--surface-border);
         }}
-        
+
         /* JS Active State Helpers */
         #folderSidebar.active {{ transform: translateX(0); }}
         #batchBar.active {{ transform: translateY(0); }}
@@ -41,7 +41,7 @@ def render_base_layout(theme: BaseTheme, content: str, scripts: str, active_them
         #settingsModal.active {{ display: flex !important; opacity: 1; pointer-events: auto; }}
         #cinemaModal.active {{ opacity: 1; pointer-events: auto; }}
         #cinemaInfoPanel.active {{ transform: translateX(0); }}
-        
+
         /* Treemap Tooltip */
         #treemapTooltip {{
             position: fixed;
@@ -58,7 +58,7 @@ def render_base_layout(theme: BaseTheme, content: str, scripts: str, active_them
             box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
             transition: opacity 0.1s;
         }}
-        
+
         .responsive-grid {{
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(var(--grid-min-width, 240px), 1fr));
@@ -129,7 +129,7 @@ def render_header(theme: BaseTheme, hostname: str, count: int, size_gb: str) -> 
             <span class="material-icons text-[18px]">logout</span>
         </button>
     </div>
-    
+
     <!-- Mobile Actions -->
     <button onclick="openSettings()" class="md:hidden p-1 {theme.text_secondary} hover:text-black dark:hover:text-white">
         <span class="material-icons text-[18px]">settings</span>
@@ -165,13 +165,13 @@ def render_navigation(theme: BaseTheme) -> str:
     return f"""
 <nav class="{theme.sidebar_container}">
     <div class="text-[11px] font-bold {theme.text_secondary} uppercase tracking-widest mb-2 px-3">Workspace</div>
-    
+
     {nav_btn("m-lobby", "setWorkspaceMode('lobby')", "dashboard", "Lobby", "arcade-cyan", active=True)}
     {nav_btn("m-favorites", "setWorkspaceMode('favorites')", "star", "Favoriten", "arcade-gold")}
     {nav_btn("m-optimized", "setWorkspaceMode('optimized')", "offline_bolt", "Review", "arcade-cyan")}
     {nav_btn("m-vault", "setWorkspaceMode('vault')", "archive", "Vault", "arcade-magenta")}
     {nav_btn("m-duplicates", "setWorkspaceMode('duplicates')", "content_copy", "Duplicates", "purple")}
-    
+
     <!-- Smart Collections Section -->
     <div class="mt-4 border-t border-black/5 dark:border-white/5 pt-3">
         <div class="flex items-center justify-between px-3 mb-2">
@@ -182,7 +182,7 @@ def render_navigation(theme: BaseTheme) -> str:
         </div>
         <div id="collectionsNav" class="space-y-0.5"></div>
     </div>
-    
+
     <div class="mt-auto border-t border-black/5 dark:border-white/5 pt-3">
         <button onclick="openSettings()" class="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-600 dark:text-gray-400 hover:bg-black/5 dark:hover:bg-white/5 hover:text-black dark:hover:text-white transition-colors">
             <span class="material-icons text-[20px]">settings</span>

--- a/scripts/batch_controller.py
+++ b/scripts/batch_controller.py
@@ -4,16 +4,15 @@ Batch Controller V2.1 - Clean Summary Table Display with Logging
 Shows a live-updating status table for all parallel encodes.
 Writes detailed results to a persistent log file.
 """
-import os
-import sys
 import argparse
-import time
-import threading
-import subprocess
 import re
-from pathlib import Path
-from datetime import datetime
+import subprocess
+import sys
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
 
 # Logs directory
 LOG_DIR = Path.home() / ".arcade-scanner" / "logs"
@@ -22,7 +21,7 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 # Add parent path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from arcade_scanner.core.video_processor import get_optimal_workers, get_best_encoder
+from arcade_scanner.core.video_processor import get_best_encoder, get_optimal_workers
 
 # --- COLORS ---
 G = '\033[0;32m'

--- a/scripts/batch_controller.py
+++ b/scripts/batch_controller.py
@@ -21,7 +21,10 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 # Add parent path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from arcade_scanner.core.video_processor import get_best_encoder, get_optimal_workers
+from arcade_scanner.core.video_processor import (  # noqa: E402
+    get_best_encoder,
+    get_optimal_workers,
+)
 
 # --- COLORS ---
 G = '\033[0;32m'

--- a/scripts/finalize_review.py
+++ b/scripts/finalize_review.py
@@ -7,9 +7,8 @@ and allows the user to keep the optimized version or revert to the original.
 """
 
 import os
-import sys
 import shutil
-from pathlib import Path
+import sys
 
 # Add project root to sys.path
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -18,6 +17,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from arcade_scanner.config import config
 from arcade_scanner.database import db
 from arcade_scanner.models.video_entry import VideoEntry
+
 
 def print_banner():
     print("╔════════════════════════════════════════╗")

--- a/scripts/finalize_review.py
+++ b/scripts/finalize_review.py
@@ -14,9 +14,9 @@ import sys
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PROJECT_ROOT)
 
-from arcade_scanner.config import config
-from arcade_scanner.database import db
-from arcade_scanner.models.video_entry import VideoEntry
+from arcade_scanner.config import config  # noqa: E402
+from arcade_scanner.database import db  # noqa: E402
+from arcade_scanner.models.video_entry import VideoEntry  # noqa: E402
 
 
 def print_banner():
@@ -104,7 +104,8 @@ def finalize_pair(pair, decision):
             # Remove remaining files in job dir (like thumbnails if generated)
             for f in os.listdir(job_dir):
                 f_path = os.path.join(job_dir, f)
-                if os.path.isfile(f_path): os.remove(f_path)
+                if os.path.isfile(f_path):
+                    os.remove(f_path)
             os.rmdir(job_dir)
     except Exception as e:
         print(f"⚠️ Cleanup warning: {e}")

--- a/scripts/reset_admin_password.py
+++ b/scripts/reset_admin_password.py
@@ -1,12 +1,11 @@
 import binascii
-import hashlib
 import os
 import sys
 
 # Add project root to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from arcade_scanner.database.user_store import UserStore, user_db
+from arcade_scanner.database.user_store import user_db
 from arcade_scanner.models.user import User
 
 

--- a/scripts/restore_collections.py
+++ b/scripts/restore_collections.py
@@ -1,5 +1,4 @@
 
-import json
 import os
 import sys
 

--- a/scripts/video_optimizer.py
+++ b/scripts/video_optimizer.py
@@ -25,7 +25,7 @@ try:
     _core_path = Path(__file__).parent.parent / "arcade_scanner" / "core"
     if _core_path.exists():
         _sys.path.insert(0, str(_core_path))
-        from bitrate_analyzer import BitrateProfile, analyze_bitrate
+        from bitrate_analyzer import analyze_bitrate
         from hw_encode_detect import detect_hevc_optimizer_encoder
         _sys.path.pop(0)
         BITRATE_ANALYZER_AVAILABLE = True
@@ -519,7 +519,6 @@ def get_multi_ssim(
             text=True
         )
 
-        stderr_chunks = []
         out_time_us = 0
         total_us = total_sample_duration * 1_000_000
 
@@ -715,8 +714,10 @@ def build_ffmpeg_command(input_path, output_path, profile, quality_value, copy_a
     cmd = ['ffmpeg', '-y']
 
     # Trim input if needed (fast seek)
-    if ss: cmd.extend(['-ss', str(ss)])
-    if to: cmd.extend(['-to', str(to)])
+    if ss:
+        cmd.extend(['-ss', str(ss)])
+    if to:
+        cmd.extend(['-to', str(to)])
 
     if video_mode == 'copy':
         # Passthrough video
@@ -1189,7 +1190,6 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
         # Note: ffmpeg output parsing logic below relies partially on encoding stats.
         # Copy mode outputs less stats, but we can try reuse the existing loop.
 
-        cur_stats = {"bitrate": "copy", "speed": "N/A"}
         encode_start = time.time()
         captured_errors = []
 
@@ -1232,7 +1232,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
 
         except KeyboardInterrupt:
             process.terminate()
-            if output_path.exists(): output_path.unlink()
+            if output_path.exists():
+                output_path.unlink()
             return (False, 0)
 
         process.wait()
@@ -1253,7 +1254,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
              last_encode_result['duration'] = file_time
              last_encode_result['saved_bytes'] = saved_bytes # Might be negative if container overhead
 
-             if port: notify_server(port, input_path)
+             if port:
+                 notify_server(port, input_path)
              return (True, 0)
         else:
 
@@ -1380,7 +1382,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
             print()
 
             if early_abort:
-                if effective_out.exists(): effective_out.unlink()
+                if effective_out.exists():
+                    effective_out.unlink()
                 # Estimate how far over the target we projected to be.
                 # mid-encode: we wrote _abort_size bytes after _last_out_time_ms µs of video.
                 # total_duration_us = encode duration in µs.
@@ -1405,14 +1408,16 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
                 print(f"{R}FFmpeg error during encoding.{NC}")
                 for err in captured_errors[-10:]:
                     print(f"  {R}{err}{NC}")
-                if effective_out.exists(): effective_out.unlink()
+                if effective_out.exists():
+                    effective_out.unlink()
                 return (False, 0, 0, 'ffmpeg_error')
 
             size_after = effective_out.stat().st_size
 
             if size_after >= size_to_compare:
                 print(f" {R}-> File larger ({format_size(size_after)} > {format_size(size_to_compare)}).{NC}")
-                if effective_out != output_path and effective_out.exists(): effective_out.unlink()
+                if effective_out != output_path and effective_out.exists():
+                    effective_out.unlink()
                 return (False, size_after, 0, 'too_large')
 
             # Early savings check: skip SSIM if compression is not worth it
@@ -1421,7 +1426,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
             MIN_SAVINGS_FOR_SSIM = 10.0  # Only run SSIM if we saved at least 10%
             if saved_pct_pre < MIN_SAVINGS_FOR_SSIM:
                 print(f" {Y}-> Saved only {saved_pct_pre:.2f}% – skipping SSIM (below {MIN_SAVINGS_FOR_SSIM:.0f}% threshold). Not optimal.{NC}")
-                if effective_out != output_path and effective_out.exists(): effective_out.unlink()
+                if effective_out != output_path and effective_out.exists():
+                    effective_out.unlink()
                 return (False, size_after, 0.0, 'poor_savings')
 
             # Quality verification: single ffmpeg pass over the pre-computed
@@ -1444,7 +1450,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
         except KeyboardInterrupt:
             print(f"\n{R}>>> Abort. Cleaning up...{NC}")
             process.terminate()
-            if effective_out.exists(): effective_out.unlink()
+            if effective_out.exists():
+                effective_out.unlink()
             _cleanup_staging()
             sys.exit(1)
 
@@ -1541,7 +1548,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
                     low = mid + 1   # VideoToolbox: lower Q = more compression
                 else:
                     high = mid - 1  # NVENC: higher CQ = more compression
-                if staging.exists(): staging.unlink()
+                if staging.exists():
+                    staging.unlink()
                 continue
 
             if not success:
@@ -1557,7 +1565,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
                 print(f" {R}   -> Quality too low for this level.{NC}")
                 # Need better quality (less compression) → move towards index 0 (best quality).
                 high = mid - 1
-                if staging.exists(): staging.unlink()
+                if staging.exists():
+                    staging.unlink()
                 continue
 
             saved_bytes = size_to_compare - size_after
@@ -1658,8 +1667,6 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
     # Fallback: Linear search (used when q_override is set or only 1 quality value)
     # Uses same staging strategy: encode to a temp file, promote if good, discard otherwise.
     quality = q_override if q_override is not None else quality_values[0]
-    linear_best_path: 'Path | None' = None
-    linear_best_result = None
     # Track best acceptable result: (quality, size_after, ssim, saved_pct, staging_path)
     linear_best_acceptable: 'tuple | None' = None
     linear_best_acceptable_path: 'Path | None' = None
@@ -1766,7 +1773,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
                     if port:
                         notify_server(port, input_path)
                     return (True, saved_bytes_preview)
-            if staging.exists(): staging.unlink()
+            if staging.exists():
+                staging.unlink()
             _cleanup_staging()
             batch_stats['failed'] += 1
             file_time = time.time() - file_start_time
@@ -1820,7 +1828,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
             print(f" {Y}   -> Not optimal (SSIM {ssim:.4f}, saved {saved_pct:.1f}%). Trying more compression...{NC}")
         else:
             print(f" {R}   -> Not optimal. Next pass...{NC}")
-            if staging.exists(): staging.unlink()
+            if staging.exists():
+                staging.unlink()
         quality += step
 
     # Loop exhausted – try the best acceptable fallback if we have one
@@ -2015,7 +2024,7 @@ def main():
 
         # Write to encode log (for both batch controller and single-file calls)
         if last_encode_result['filename']:
-            log_file = write_encode_log(
+            write_encode_log(
                 filename=last_encode_result['filename'],
                 status=last_encode_result['status'],
                 encoder_name=profile['name'],

--- a/test_dump.py
+++ b/test_dump.py
@@ -1,5 +1,4 @@
 from arcade_scanner.database.sqlite_store import SQLiteStore
-from arcade_scanner.models.video_entry import VideoEntry
 
 db = SQLiteStore()
 print("DB Loaded.")

--- a/test_probe.py
+++ b/test_probe.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 
 
 async def test():

--- a/test_probe3.py
+++ b/test_probe3.py
@@ -65,7 +65,7 @@ async def test():
         probe = NoSwallowMediaProbe()
         res = await probe.get_metadata("/Users/ralfo/Downloads/-5444695758810163208.mp4")
         print("SUCCESS:", res)
-    except Exception as e:
+    except Exception:
         import traceback
         traceback.print_exc()
 

--- a/test_probe3.py
+++ b/test_probe3.py
@@ -18,13 +18,6 @@ class NoSwallowMediaProbe(MediaProbe):
         width = int(video_stream.get("width", 0))
         height = int(video_stream.get("height", 0))
         video_codec = video_stream.get("codec_name", "unknown")
-        profile = video_stream.get("profile", "")
-        pixel_format = video_stream.get("pix_fmt", "")
-        level_raw = video_stream.get("level", 0)
-        try:
-            level = float(level_raw)
-        except:
-            level = 0.0
         fps_str = video_stream.get("avg_frame_rate", "0/0")
         fps = 0.0
         if "/" in fps_str:
@@ -32,15 +25,14 @@ class NoSwallowMediaProbe(MediaProbe):
                 num, den = fps_str.split("/")
                 if float(den) > 0:
                     fps = float(num) / float(den)
-            except:
+            except Exception:
                 pass
         else:
             try:
                 fps = float(fps_str)
-            except:
+            except Exception:
                 pass
         audio_codec = audio_stream.get("codec_name", "unknown")
-        audio_channels = int(audio_stream.get("channels", 0))
         container = fmt.get("format_name", "unknown")
         status = "OK"
         from arcade_scanner.models.video_entry import VideoEntry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,6 @@
 """
 Shared pytest fixtures for arcade-video-scanner tests.
 """
-import json
-import os
-import tempfile
-import threading
 from pathlib import Path
 
 import pytest

--- a/tests/test_dom_contract.py
+++ b/tests/test_dom_contract.py
@@ -278,6 +278,7 @@ class TestApiResponseSchema:
             from arcade_scanner.server import response_helpers
         except ImportError as e:
             pytest.fail(f"response_helpers nicht importierbar: {e}")
+        assert response_helpers is not None
 
     def test_video_dict_has_required_keys(self):
         """
@@ -291,6 +292,7 @@ class TestApiResponseSchema:
             from arcade_scanner.core.video_processor import get_video_metadata
         except ImportError:
             pytest.skip("video_processor nicht verfügbar")
+        assert callable(get_video_metadata)
 
         # Felder die engine.js/cards.js auf dem Video-Object erwartet
         # Hinweis: In video_processor.py kann der interne Key-Name abweichen

--- a/tests/test_http_performance.py
+++ b/tests/test_http_performance.py
@@ -15,8 +15,6 @@ import email.utils
 import gzip
 import io
 
-import pytest
-
 from arcade_scanner.server.response_helpers import (
     GZIP_MIN_SIZE,
     client_accepts_gzip,

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -3,7 +3,6 @@ Tests for arcade_scanner.logging_config
 """
 import logging
 import logging.handlers
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_route_interface.py
+++ b/tests/test_route_interface.py
@@ -14,7 +14,6 @@ Why this exists:
 """
 import importlib
 import inspect
-import pkgutil
 
 import pytest
 

--- a/tests/test_security_validators.py
+++ b/tests/test_security_validators.py
@@ -17,7 +17,6 @@ Coverage:
 """
 
 import os
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_unicode_surrogates.py
+++ b/tests/test_unicode_surrogates.py
@@ -62,7 +62,8 @@ def test_sqlite_store_handles_surrogates(store):
 def test_manager_hash_generation_handles_surrogates():
     from arcade_scanner.scanner.manager import ScannerManager
 
-    manager = ScannerManager()
+    # Constructing the manager must not raise for surrogate-containing paths.
+    ScannerManager()
     surrogate_path = "/media_nas/Sites/h\udcf6gl.mp4"
 
     # Should not raise UnicodeEncodeError

--- a/tests/test_unicode_surrogates.py
+++ b/tests/test_unicode_surrogates.py
@@ -1,6 +1,4 @@
 import hashlib
-import os
-import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -93,7 +91,6 @@ def test_encoding_queue_handles_surrogates(store):
         pytest.fail(f"get_next_pending failed with UnicodeEncodeError: {e}")
 
 def test_thumbnail_hashing_handles_surrogates():
-    from arcade_scanner.config import config
     from arcade_scanner.core.video_processor import create_thumbnail
 
     surrogate_path = "/media_nas/Sites/h\udcf6gl.mp4"

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -6,8 +6,6 @@ Focus: IMAGE_EXTENSIONS constant, detect_h264_encoder dependency injection,
 import subprocess
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from arcade_scanner.core.hw_encode_detect import detect_h264_encoder as detect_hw_encoder
 from arcade_scanner.core.video_processor import (
     IMAGE_EXTENSIONS,


### PR DESCRIPTION
## Ziel
Vorbestehende Ruff-Findings sauber und reviewbar abbauen, damit Ruff spaeter als blockierendes Gate laufen kann. **Nur Code-Cleanup** — keine Workflow-Dateien angefasst.

## Ergebnis
- `ruff check .` ist jetzt **vollstaendig gruen** (vorher 316 Findings). Ein Folge-PR kann `lint-blocking: true` setzen.
- `pytest`: weiterhin **545 passed** (Baseline unveraendert).

## Findings vorher -> nachher (pro Regel)
| Regel | Beschreibung | vorher | nachher |
|-------|--------------|-------:|--------:|
| W293  | blank-line-with-whitespace | 170 | 0 |
| F401  | unused-import | 72 | 0 |
| E701  | multiple-statements-on-one-line | 36 | 0 |
| F841  | unused-variable | 12 | 0 |
| I001  | unsorted-imports | 10 | 0 |
| E402  | import-not-at-top | 8 | 0 |
| W291  | trailing-whitespace | 4 | 0 |
| E722  | bare-except | 3 | 0 |
| E731  | lambda-assignment | 1 | 0 |
| **Summe** | | **316** | **0** |

## Commits
1. `style: ruff safe fixes` — F401 (unused imports) + I001 (Import-Sortierung), reine `ruff --fix` safe fixes.
2. `style: ruff safe-formatting fixes` — W293/W291 (Whitespace), E701 (`if cond: stmt` aufgeteilt), E731 (lambda -> def).
3. `style: ruff urteilsbasierte fixes` — die Findings mit Verhaltens-Relevanz (siehe unten).

## Urteilsbasierte Fixes (Commit 3)
- **E722** (3x in `test_probe3.py`): `except:` -> `except Exception:`. Diese `except` umschliessen ausschliesslich `float()`-Konvertierungen mit Fallback-Wert. Sie sollen `ValueError`/`TypeError` abfangen, nie `KeyboardInterrupt`/`SystemExit` — die Umstellung verbessert genau das (kein Verschlucken von Interrupts) und ist ansonsten verhaltensgleich. Es gab keine Stelle, an der bewusst `BaseException`/`KeyboardInterrupt` gefangen werden sollte.
- **F841**: ungenutzte Zuweisungen entfernt. Bei `write_encode_log(...)` in `video_optimizer.py` wurde **nur die Zuweisung** entfernt, der Aufruf (Seiteneffekt: Log schreiben) bleibt. `cur_stats` bei Zeile ~1194 war ein toter Shadow (wird vor jedem Read neu zugewiesen).
- **F401 Re-Exports**: In `core/`, `database/`, `models/`, `scanner/` `__init__.py` wurde `__all__` ergaenzt statt die Imports zu loeschen — die oeffentliche API (Re-Exports) bleibt erhalten. In `test_dom_contract.py` werden die Import-Checks jetzt per `assert` genutzt.
- **E402**: In `sqlite_store.py`/`models/user.py` Imports vor die erste Anweisung gezogen. In `scripts/finalize_review.py` und `scripts/batch_controller.py` liegen die Imports bewusst nach `sys.path.insert(...)` — hier `# noqa: E402` gesetzt statt umzustrukturieren.

## Bewusst NICHT umstrukturiert
- Die `sys.path.insert()`-Imports in den Scripts (per `# noqa: E402` markiert statt zu verschieben, da das die Imports brechen wuerde).

Keine Regel musste komplett ausgelassen werden — alle 316 Findings sind behoben, pytest bleibt gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)