### PR TITLE
ci: Ruff auf blockierend setzen (lint-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ jobs:
     uses: ralksta/ci-workflows/.github/workflows/python-ci.yml@main
     with:
       install: python -m pip install --upgrade pip && pip install -r requirements.txt && pip install -e ".[dev]"
-      # ruff/mypy stay advisory (lint-blocking/typecheck-blocking default to false)
-      # until the pre-existing debt is cleaned up, then flip them to true.
+      # ruff is now clean (PR #30 took it 316 -> 0) -> blocking to prevent regression.
+      # mypy stays advisory until its ~131 pre-existing errors are annotated.
       lint: ruff check .
+      lint-blocking: true
       typecheck: mypy arcade_scanner
       test: pytest


### PR DESCRIPTION
Folge-PR zu #30. Da `ruff check .` jetzt **0 Findings** hat, wird der Lint-Step blockierend (`lint-blocking: true` im python-ci-Caller) — verhindert künftige Style-Regressionen.

Mypy bleibt advisory, bis dessen ~131 vorbestehende Typing-Fehler annotiert sind.

Der grüne Run auf diesem PR belegt, dass ruff mit blockierendem Gate durchläuft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)