### PR TITLE
chore(types): mypy sauber (131 -> 0) + typecheck blockierend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,9 @@ jobs:
     with:
       install: python -m pip install --upgrade pip && pip install -r requirements.txt && pip install -e ".[dev]"
       # ruff is now clean (PR #30 took it 316 -> 0) -> blocking to prevent regression.
-      # mypy stays advisory until its ~131 pre-existing errors are annotated.
+      # mypy is now clean (131 -> 0) -> blocking to prevent regression.
       lint: ruff check .
       lint-blocking: true
       typecheck: mypy arcade_scanner
+      typecheck-blocking: true
       test: pytest

--- a/arcade_scanner/config.py
+++ b/arcade_scanner/config.py
@@ -4,8 +4,8 @@ import socket
 import sys
 from typing import Any, Dict, List
 
-from pydantic import ConfigDict, Field
-from pydantic_settings import BaseSettings
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # ==============================================================================
 # CONSTANTS & PATHS
@@ -166,7 +166,7 @@ class AppSettings(BaseSettings):
     max_concurrent_image_scans: int = Field(5)
     enable_resource_watchdog: bool = Field(True)
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_prefix="ARCADE_",
         extra="ignore",
     )
@@ -187,7 +187,7 @@ class ConfigManager:
 
     def _load_settings(self) -> AppSettings:
         # Load from JSON if exists
-        file_data = {}
+        file_data: Dict[str, Any] = {}
         if os.path.exists(SETTINGS_FILE):
             try:
                 with open(SETTINGS_FILE, "r", encoding="utf-8") as f:

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Optional imagehash for perceptual image hashing
 try:
@@ -75,11 +75,11 @@ class DuplicateGroup:
         }
 
 
-if hasattr(int, "bit_count"):  # Python 3.10+
-    _popcount = int.bit_count
-else:  # pyproject declares requires-python >=3.8
-    def _popcount(value: int) -> int:
-        return bin(value).count("1")
+def _popcount(value: int) -> int:
+    """Count set bits. Uses int.bit_count on 3.10+, else a portable fallback."""
+    if hasattr(value, "bit_count"):  # Python 3.10+
+        return value.bit_count()
+    return bin(value).count("1")
 
 
 def _hamming(a: int, b: int) -> int:
@@ -426,7 +426,7 @@ class DuplicateDetector:
         Threshold: max hash difference to consider as duplicate (0=exact, higher=more lenient)
         """
         # Get visual hashes for all files
-        hash_data: List[Tuple[any, any]] = []  # (file, phash_obj)
+        hash_data: List[Tuple[Any, Any]] = []  # (file, phash_obj)
 
         for f in files:
             path = f.file_path
@@ -590,7 +590,7 @@ class DuplicateDetector:
         self._ensure_hash_cache()
 
         # Phase 1: Compute/retrieve hashes with progress tracking
-        hash_data: List[Tuple[str, 'imagehash.ImageHash', any]] = []
+        hash_data: List[Tuple[str, 'imagehash.ImageHash', Any]] = []
         total_images = len(images)
         cache_hits = 0
         cache_misses = 0
@@ -618,9 +618,8 @@ class DuplicateDetector:
             # Cache miss — compute hash
             try:
                 with Image.open(path) as pil_img:
-                    if pil_img.mode not in ('RGB', 'L'):
-                        pil_img = pil_img.convert('RGB')
-                    phash = imagehash.phash(pil_img)
+                    hash_img = pil_img.convert('RGB') if pil_img.mode not in ('RGB', 'L') else pil_img
+                    phash = imagehash.phash(hash_img)
                     hash_str = str(phash)
                     hash_data.append((hash_str, phash, img))
                     self._set_cached_hash(path, hash_str)

--- a/arcade_scanner/core/hw_encode_detect.py
+++ b/arcade_scanner/core/hw_encode_detect.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import sys
+from typing import Callable, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ def get_available_ffmpeg_encoders() -> str:
         logger.debug("Failed to get ffmpeg encoders: %s", e)
         return ""
 
-def test_ffmpeg_encoder(codec: str, extra_args: list = None) -> bool:
+def test_ffmpeg_encoder(codec: str, extra_args: Optional[List[str]] = None) -> bool:
     """Test if an encoder actually works by performing a tiny lavfi encode."""
     if extra_args is None:
         extra_args = []
@@ -32,7 +33,7 @@ def test_ffmpeg_encoder(codec: str, extra_args: list = None) -> bool:
     except Exception:
         return False
 
-def get_vaapi_device(log_fn=None) -> str:
+def get_vaapi_device(log_fn: Optional[Callable[[str], None]] = None) -> Optional[str]:
     """Detect the best VAAPI device, testing common paths."""
     if log_fn is None:
         log_fn = logger.info

--- a/arcade_scanner/core/video_processor.py
+++ b/arcade_scanner/core/video_processor.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import subprocess
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from arcade_scanner.config import config
 
@@ -14,7 +14,7 @@ IMAGE_EXTENSIONS = frozenset({'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', 
 
 
 def get_video_metadata(filepath: str) -> Dict[str, Any]:
-    cmd = [
+    cmd: List[Union[str, bytes]] = [
         "ffprobe",
         "-v",
         "error",
@@ -68,7 +68,7 @@ def create_thumbnail(video_path: str, duration: Optional[float] = None) -> str:
         # Get duration for smart seeking if not provided
         if duration is None:
             try:
-                cmd_dur = ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", os.fsencode(video_path)]
+                cmd_dur: List[Union[str, bytes]] = ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", os.fsencode(video_path)]
                 duration = float(subprocess.check_output(cmd_dur, stderr=subprocess.DEVNULL, timeout=60).decode().strip())
             except Exception as e:
                 logger.debug("Duration probe failed for %s: %s", video_path, e)
@@ -128,7 +128,7 @@ def create_thumbnail(video_path: str, duration: Optional[float] = None) -> str:
 
 # --- HARDWARE ENCODER DETECTION ---
 
-def process_video(filepath: str, cache: Dict[str, Any], rebuild_mode: str = None) -> Optional[Dict[str, Any]]:
+def process_video(filepath: str, cache: Dict[str, Any], rebuild_mode: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """
     Legacy method kept for compatibility if needed, but updated to use new config.
     """

--- a/arcade_scanner/database/sqlite_store.py
+++ b/arcade_scanner/database/sqlite_store.py
@@ -16,7 +16,7 @@ import os
 import sqlite3
 import threading
 import time
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from ..config import config
 from ..models.video_entry import VideoEntry
@@ -90,58 +90,66 @@ class SQLiteStore:
             except Exception:
                 pass
 
-    def _ensure_connection(self):
-        """Lazy-init the connection and create schema if needed."""
+    def _ensure_connection(self) -> sqlite3.Connection:
+        """Lazy-init the connection and create schema if needed.
+
+        Returns the live connection so callers get a non-``Optional`` handle.
+        """
         if self._conn is not None:
-            return
+            return self._conn
 
         with self._write_lock:
             # Re-check inside the lock: two threads can both find _conn empty,
             # and the loser would otherwise open a second connection and leak it.
             if self._conn is not None:
-                return
+                return self._conn
             self._open_connection()
+        assert self._conn is not None  # _open_connection always sets it
+        return self._conn
 
-    def _open_connection(self):
+    def _open_connection(self) -> None:
         os.makedirs(os.path.dirname(self.db_file), exist_ok=True)
-        self._conn = sqlite3.connect(
+        conn = sqlite3.connect(
             self.db_file,
             check_same_thread=False,
             isolation_level=None,  # autocommit
         )
-        self._conn.row_factory = sqlite3.Row
+        self._conn = conn
+        conn.row_factory = sqlite3.Row
         # Performance pragmas
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA synchronous=NORMAL")
-        self._conn.execute("PRAGMA cache_size=-64000")  # 64MB cache (Performance boost)
-        self._conn.execute("PRAGMA temp_store=MEMORY")
-        self._conn.execute("PRAGMA mmap_size=268435456") # 256MB mmap
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA cache_size=-64000")  # 64MB cache (Performance boost)
+        conn.execute("PRAGMA temp_store=MEMORY")
+        conn.execute("PRAGMA mmap_size=268435456") # 256MB mmap
 
         self._create_table()
 
-    def _create_table(self):
+    def _create_table(self) -> None:
         """Create the media table, indexes, and encoding_queue table if they don't exist."""
+        conn = self._conn
+        assert conn is not None  # only called from _open_connection
         cols = ", ".join(f"{name} {typedef}" for name, typedef in _COLUMNS)
-        self._conn.execute(f"CREATE TABLE IF NOT EXISTS media ({cols})")
+        conn.execute(f"CREATE TABLE IF NOT EXISTS media ({cols})")
 
         # Performance indexes for common filter/sort queries
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_status ON media(status)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_codec ON media(codec)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_size_mb ON media(size_mb)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mtime ON media(mtime)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_favorite ON media(favorite)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_vaulted ON media(vaulted)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_media_type ON media(media_type)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_thumb ON media(thumb)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_status ON media(status)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_codec ON media(codec)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_size_mb ON media(size_mb)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_mtime ON media(mtime)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_favorite ON media(favorite)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_vaulted ON media(vaulted)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_media_type ON media(media_type)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_thumb ON media(thumb)")
 
         # Migration: Add original_path to media table if it doesn't exist
         try:
-            self._conn.execute("ALTER TABLE media ADD COLUMN original_path TEXT DEFAULT ''")
+            conn.execute("ALTER TABLE media ADD COLUMN original_path TEXT DEFAULT ''")
         except Exception:
             pass # Already exists
 
         # Encoding queue for remote optimization
-        self._conn.execute("""
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS encoding_queue (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 file_path TEXT NOT NULL,
@@ -158,7 +166,7 @@ class SQLiteStore:
         """)
         # Add target_codec column to existing installations (migration)
         try:
-            self._conn.execute("ALTER TABLE encoding_queue ADD COLUMN target_codec TEXT DEFAULT 'hevc'")
+            conn.execute("ALTER TABLE encoding_queue ADD COLUMN target_codec TEXT DEFAULT 'hevc'")
         except Exception:
             pass  # Column already exists
 
@@ -168,24 +176,24 @@ class SQLiteStore:
 
     def queue_encode(self, file_path: str, size_bytes: int = 0, target_codec: str = 'hevc') -> Optional[int]:
         """Add a file to the encoding queue. Returns job ID or None if already pending."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
 
         safe_path = self._get_safe_path(file_path)
         # Check-then-insert must hold the lock, or two callers both find no
         # pending job and both insert one for the same file.
         with self._write_lock:
-            cursor = self._conn.execute(
+            cursor = conn.execute(
                 "SELECT id FROM encoding_queue WHERE file_path = ? AND status IN ('pending', 'downloading', 'encoding', 'uploading')",
                 (safe_path,)
             )
             if cursor.fetchone():
                 return None  # Already queued
 
-            self._conn.execute(
+            conn.execute(
                 "INSERT INTO encoding_queue (file_path, status, size_bytes, target_codec, created_at) VALUES (?, 'pending', ?, ?, ?)",
                 (safe_path, size_bytes, target_codec, int(time.time()))
             )
-            cursor = self._conn.execute("SELECT last_insert_rowid()")
+            cursor = conn.execute("SELECT last_insert_rowid()")
             return cursor.fetchone()[0]
 
     def get_next_pending(self, worker_id: str = "") -> Optional[dict]:
@@ -197,11 +205,11 @@ class SQLiteStore:
         does not own. Without that check two workers encode the same file and
         race on the same output path.
         """
-        self._ensure_connection()
+        conn = self._ensure_connection()
 
         with self._write_lock:
             while True:
-                cursor = self._conn.execute(
+                cursor = conn.execute(
                     "SELECT id, file_path, size_bytes, target_codec FROM encoding_queue WHERE status = 'pending' ORDER BY created_at ASC LIMIT 1"
                 )
                 row = cursor.fetchone()
@@ -209,7 +217,7 @@ class SQLiteStore:
                     return None
 
                 job_id = row["id"]
-                cursor = self._conn.execute(
+                cursor = conn.execute(
                     "UPDATE encoding_queue SET status = 'downloading', started_at = ?, worker_id = ? WHERE id = ? AND status = 'pending'",
                     (int(time.time()), worker_id, job_id)
                 )
@@ -223,12 +231,12 @@ class SQLiteStore:
                     "target_codec": row["target_codec"] or "hevc",
                 }
 
-    def update_job_status(self, job_id: int, status: str, **kwargs) -> None:
+    def update_job_status(self, job_id: int, status: str, **kwargs: Any) -> None:
         """Update a job's status and optional fields (result_message, saved_bytes, completed_at)."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
 
         sets = ["status = ?"]
-        vals = [status]
+        vals: List[Any] = [status]
 
         if status in ("done", "failed"):
             sets.append("completed_at = ?")
@@ -241,16 +249,16 @@ class SQLiteStore:
 
         vals.append(job_id)
         with self._write_lock:
-            self._conn.execute(
+            conn.execute(
                 f"UPDATE encoding_queue SET {', '.join(sets)} WHERE id = ?",
                 tuple(vals)
             )
 
     def get_queue_status(self, limit: int = 20) -> List[dict]:
         """Return active + recent jobs for the UI."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         with self._write_lock:
-            cursor = self._conn.execute(
+            cursor = conn.execute(
                 """SELECT id, file_path, status, size_bytes, created_at, started_at,
                           completed_at, worker_id, result_message, saved_bytes
                    FROM encoding_queue
@@ -269,15 +277,16 @@ class SQLiteStore:
             return self._cancel_job_locked(job_id)
 
     def _cancel_job_locked(self, job_id: int) -> bool:
+        conn = self._ensure_connection()
         # Delete if still pending
-        cursor = self._conn.execute(
+        cursor = conn.execute(
             "DELETE FROM encoding_queue WHERE id = ? AND status = 'pending'",
             (job_id,)
         )
         if cursor.rowcount > 0:
             return True
         # Mark active jobs as cancelled so the worker can detect it
-        cursor = self._conn.execute(
+        cursor = conn.execute(
             "UPDATE encoding_queue SET status = 'cancelled', result_message = 'Cancelled by user' "
             "WHERE id = ? AND status IN ('downloading', 'encoding', 'uploading')",
             (job_id,)
@@ -286,9 +295,9 @@ class SQLiteStore:
 
     def is_job_cancelled(self, job_id: int) -> bool:
         """Check if a job has been cancelled (worker polls this)."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         with self._write_lock:
-            row = self._conn.execute(
+            row = conn.execute(
                 "SELECT status FROM encoding_queue WHERE id = ?", (job_id,)
             ).fetchone()
         return row is not None and row[0] == 'cancelled'
@@ -315,12 +324,12 @@ class SQLiteStore:
 
     def get_all(self) -> List[VideoEntry]:
         """Return all entries as VideoEntry models."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         # Shared connection: readers running the same SQL share one cached
         # prepared statement, and stepping it from two threads makes them
         # consume each other's rows -- silently, with no exception.
         with self._write_lock:
-            cursor = self._conn.execute("SELECT * FROM media")
+            cursor = conn.execute("SELECT * FROM media")
             results = []
             for row in cursor:
                 try:
@@ -335,12 +344,12 @@ class SQLiteStore:
         This is much more memory efficient than get_all() for large libraries,
         as it avoids Pydantic model overhead.
         """
-        self._ensure_connection()
+        conn = self._ensure_connection()
         # Shared connection: readers running the same SQL share one cached
         # prepared statement, and stepping it from two threads makes them
         # consume each other's rows -- silently, with no exception.
         with self._write_lock:
-            cursor = self._conn.execute("SELECT * FROM media")
+            cursor = conn.execute("SELECT * FROM media")
             results = []
             for row in cursor:
                 try:
@@ -351,14 +360,14 @@ class SQLiteStore:
 
     def get(self, path: str) -> Optional[VideoEntry]:
         """Lookup a single entry by file_path. O(1) indexed."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         # Shared connection: readers running the same SQL share one cached
         # prepared statement, and stepping it from two threads makes them
         # consume each other's rows -- silently, with no exception.
         with self._write_lock:
             # Handle surrogate-escaped paths by using hybrid str/bytes for SQLite
             safe_path = self._get_safe_path(path)
-            cursor = self._conn.execute(
+            cursor = conn.execute(
                 "SELECT * FROM media WHERE file_path = ?", (safe_path,)
             )
             row = cursor.fetchone()
@@ -372,12 +381,12 @@ class SQLiteStore:
 
     def get_by_thumb(self, thumb_name: str) -> Optional[VideoEntry]:
         """Fetch a single entry by thumb name."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         # Shared connection: readers running the same SQL share one cached
         # prepared statement, and stepping it from two threads makes them
         # consume each other's rows -- silently, with no exception.
         with self._write_lock:
-            cursor = self._conn.execute(
+            cursor = conn.execute(
                 "SELECT * FROM media WHERE thumb = ?", (thumb_name,)
             )
             row = cursor.fetchone()
@@ -394,7 +403,7 @@ class SQLiteStore:
         from ..models.media_asset import MediaAsset
 
         with self._write_lock:
-            self._ensure_connection()
+            conn = self._ensure_connection()
             if isinstance(entry, MediaAsset):
                 entry = self._asset_to_video_entry(entry)
 
@@ -402,7 +411,7 @@ class SQLiteStore:
             col_names = ", ".join(name for name, _ in _COLUMNS)
             values = self._entry_to_tuple(entry)
 
-            self._conn.execute(
+            conn.execute(
                 f"INSERT OR REPLACE INTO media ({col_names}) VALUES ({placeholders})",
                 values,
             )
@@ -415,7 +424,7 @@ class SQLiteStore:
             return
 
         with self._write_lock:
-            self._ensure_connection()
+            conn = self._ensure_connection()
 
             placeholders = ", ".join("?" for _ in _COLUMNS)
             col_names = ", ".join(name for name, _ in _COLUMNS)
@@ -426,31 +435,31 @@ class SQLiteStore:
                     entry = self._asset_to_video_entry(entry)
                 data.append(self._entry_to_tuple(entry))
 
-            self._conn.execute("BEGIN")
+            conn.execute("BEGIN")
             try:
-                self._conn.executemany(
+                conn.executemany(
                     f"INSERT OR REPLACE INTO media ({col_names}) VALUES ({placeholders})",
                     data,
                 )
-                self._conn.execute("COMMIT")
+                conn.execute("COMMIT")
             except Exception:
-                self._conn.execute("ROLLBACK")
+                conn.execute("ROLLBACK")
                 raise
             self._notify_change()
 
     def remove(self, path: str) -> None:
         """Delete an entry by file_path."""
         with self._write_lock:
-            self._ensure_connection()
+            conn = self._ensure_connection()
             safe_path = self._get_safe_path(path)
-            self._conn.execute("DELETE FROM media WHERE file_path = ?", (safe_path,))
+            conn.execute("DELETE FROM media WHERE file_path = ?", (safe_path,))
             self._notify_change()
 
     def delete_all_photos(self) -> int:
         """Delete all entries where media_type = 'image'. Returns the number of deleted rows."""
         with self._write_lock:
-            self._ensure_connection()
-            cursor = self._conn.execute("DELETE FROM media WHERE media_type = 'image'")
+            conn = self._ensure_connection()
+            cursor = conn.execute("DELETE FROM media WHERE media_type = 'image'")
             deleted = cursor.rowcount
             if deleted > 0:
                 logger.info("Deleted %d photo entries from DB (include_photos disabled)", deleted)
@@ -462,13 +471,13 @@ class SQLiteStore:
         This avoids loading the entire library into memory for large collections.
         Use together with count() to build pagination UI.
         """
-        self._ensure_connection()
+        conn = self._ensure_connection()
         # Shared connection: readers running the same SQL share one cached
         # prepared statement, and stepping it from two threads makes them
         # consume each other's rows -- silently, with no exception.
         with self._write_lock:
             offset = page * page_size
-            cursor = self._conn.execute(
+            cursor = conn.execute(
                 "SELECT * FROM media ORDER BY mtime DESC LIMIT ? OFFSET ?",
                 (page_size, offset),
             )
@@ -482,20 +491,20 @@ class SQLiteStore:
 
     def count(self) -> int:
         """Return the total number of entries in the store."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         # Shared connection: readers running the same SQL share one cached
         # prepared statement, and stepping it from two threads makes them
         # consume each other's rows -- silently, with no exception.
         with self._write_lock:
-            cursor = self._conn.execute("SELECT COUNT(*) FROM media")
+            cursor = conn.execute("SELECT COUNT(*) FROM media")
             return cursor.fetchone()[0]
 
     def cleanup_old_jobs(self, older_than_days: int = 30) -> int:
         """Delete completed/failed/cancelled jobs older than N days. Returns number of deleted rows."""
-        self._ensure_connection()
+        conn = self._ensure_connection()
         cutoff = int(time.time()) - (older_than_days * 86400)
         with self._write_lock:
-            cursor = self._conn.execute(
+            cursor = conn.execute(
                 "DELETE FROM encoding_queue "
                 "WHERE status IN ('done', 'failed', 'cancelled') "
                 "  AND completed_at > 0 AND completed_at < ?",
@@ -612,14 +621,15 @@ class SQLiteStore:
             original_path=entry.original_path,
         )
 
-    def _migrate_from_json(self):
+    def _migrate_from_json(self) -> None:
         """One-time migration: import all entries from video_cache.json into SQLite."""
         json_path = config.cache_file  # video_cache.json
         if not os.path.exists(json_path):
             return
 
+        conn = self._ensure_connection()
         # Check if we already have data (migration already done)
-        cursor = self._conn.execute("SELECT COUNT(*) FROM media")
+        cursor = conn.execute("SELECT COUNT(*) FROM media")
         count = cursor.fetchone()[0]
         if count > 0:
             return  # Already migrated
@@ -635,7 +645,7 @@ class SQLiteStore:
 
             migrated = 0
             # Use a transaction for bulk insert performance
-            self._conn.execute("BEGIN")
+            conn.execute("BEGIN")
             try:
                 for path, entry_dict in raw_data.items():
                     try:
@@ -644,16 +654,16 @@ class SQLiteStore:
                         ve = VideoEntry(**entry_dict)
                         placeholders = ", ".join("?" for _ in _COLUMNS)
                         col_names = ", ".join(name for name, _ in _COLUMNS)
-                        self._conn.execute(
+                        conn.execute(
                             f"INSERT OR REPLACE INTO media ({col_names}) VALUES ({placeholders})",
                             self._entry_to_tuple(ve),
                         )
                         migrated += 1
                     except Exception as e:
                         print(f"⚠️ Skipping entry {path}: {e}")
-                self._conn.execute("COMMIT")
+                conn.execute("COMMIT")
             except Exception:
-                self._conn.execute("ROLLBACK")
+                conn.execute("ROLLBACK")
                 raise
 
             print(f"✅ Migrated {migrated} entries from JSON → SQLite")

--- a/arcade_scanner/onboarding.py
+++ b/arcade_scanner/onboarding.py
@@ -5,7 +5,7 @@ Provides an interactive ASCII terminal experience for initial configuration.
 import os
 import shutil
 import sys
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 
 # ANSI color codes
@@ -171,7 +171,7 @@ def run_setup_wizard() -> dict:
     print(f"  {Colors.DIM}Press Enter to accept defaults shown in [brackets].{Colors.RESET}")
     print()
 
-    config = {
+    config: Dict[str, Any] = {
         "scan_targets": [],
         "exclude_paths": [],
         "min_size_mb": 100,
@@ -469,9 +469,9 @@ def apply_configuration(config: dict):
                 admin.data.scan_targets.append(t)
 
         # Add exclusions
-        for e in config["exclude_paths"]:
-            if e not in admin.data.exclude_paths:
-                admin.data.exclude_paths.append(e)
+        for excl in config["exclude_paths"]:
+            if excl not in admin.data.exclude_paths:
+                admin.data.exclude_paths.append(excl)
 
         user_db.add_user(admin)
 

--- a/arcade_scanner/scanner/file_system.py
+++ b/arcade_scanner/scanner/file_system.py
@@ -4,7 +4,7 @@ import json
 import os
 import threading
 import time
-from typing import AsyncIterator, List, Set
+from typing import AsyncIterator, List, Set, Tuple
 
 from ..config import config
 
@@ -59,9 +59,10 @@ class AsyncFileSystem:
         except Exception as e:
             print(f"⚠️ Could not save scan time: {e}")
 
-    async def scan_directories(self, targets: List[str]) -> AsyncIterator[str]:
+    async def scan_directories(self, targets: List[str]) -> AsyncIterator[Tuple[str, bool]]:
         """
-        Asynchronously yields absolute paths of valid video files found in targets.
+        Asynchronously yields ``(absolute_path, dir_changed)`` tuples for valid
+        media files found in targets.
         """
         # Reload settings fresh (picks up any changes to exclusions/min_size)
         self._load_settings()

--- a/arcade_scanner/scanner/image_inspector.py
+++ b/arcade_scanner/scanner/image_inspector.py
@@ -170,8 +170,8 @@ class ImageInspector(MediaInspector):
         mtime = int(file_stat.st_mtime)
 
         return MediaAsset(
-            FilePath=filepath,
-            Size_MB=size_mb,
+            file_path=filepath,
+            size_mb=size_mb,
             media_type=MediaType.IMAGE,
             image_metadata=i_meta,
             mtime=mtime,
@@ -259,8 +259,8 @@ class ImageInspector(MediaInspector):
             mtime = int(file_stat.st_mtime)
 
             return MediaAsset(
-                FilePath=filepath,
-                Size_MB=size_mb,
+                file_path=filepath,
+                size_mb=size_mb,
                 media_type=MediaType.IMAGE,
                 image_metadata=i_meta,
                 mtime=mtime,

--- a/arcade_scanner/scanner/manager.py
+++ b/arcade_scanner/scanner/manager.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import threading
 import time
-from typing import Callable, Optional, Set
+from typing import Any, Callable, List, Optional, Set, Tuple
 
 from ..config import config
 from ..database import db
@@ -91,10 +91,11 @@ class ScannerManager:
         discovery_complete = True
 
         processed_count = 0
-        batch_entries = []
+        batch_entries: List[Any] = []
 
         # 2. Worker Queue Pattern
-        queue = asyncio.Queue(maxsize=100) # Buffer for discovered paths
+        # Items are (file_path, dir_changed, index, retries); None signals shutdown.
+        queue: "asyncio.Queue[Optional[Tuple[str, bool, int, int]]]" = asyncio.Queue(maxsize=100)
         workers = []
         # Number of workers should match concurrency settings to avoid process pile-up
         num_workers = config.settings.max_concurrent_video_scans
@@ -239,7 +240,7 @@ class ScannerManager:
                         entry.favorite = cached_entry.favorite
                         entry.vaulted = cached_entry.vaulted
                         entry.tags = cached_entry.tags
-                        if cached_entry.imported_at > 0:
+                        if cached_entry.imported_at and cached_entry.imported_at > 0:
                             entry.imported_at = cached_entry.imported_at
 
                     entry.mtime = int(file_stat.st_mtime)

--- a/arcade_scanner/scanner/media_probe.py
+++ b/arcade_scanner/scanner/media_probe.py
@@ -84,8 +84,8 @@ class MediaProbe:
             if not raw_data or "streams" not in raw_data or not raw_data["streams"]:
                 return None
             # Find video and audio streams
-            video_stream = next((s for s in raw_data["streams"] if s.get("codec_type") == "video"), {})
-            audio_stream = next((s for s in raw_data["streams"] if s.get("codec_type") == "audio"), {})
+            video_stream: Dict[str, Any] = next((s for s in raw_data["streams"] if s.get("codec_type") == "video"), {})
+            audio_stream: Dict[str, Any] = next((s for s in raw_data["streams"] if s.get("codec_type") == "audio"), {})
 
             fmt = raw_data.get("format", {})
 
@@ -130,8 +130,8 @@ class MediaProbe:
             status = "OK"
 
             return VideoEntry(
-                FilePath=filepath,
-                Size_MB=round(size_mb, 2),
+                file_path=filepath,
+                size_mb=round(size_mb, 2),
                 Bitrate_Mbps=round(bitrate_bps / 1_000_000, 2),
                 Status=status,
                 codec=video_codec,

--- a/arcade_scanner/scanner/video_inspector.py
+++ b/arcade_scanner/scanner/video_inspector.py
@@ -47,8 +47,8 @@ class VideoInspector(MediaInspector):
 
         # 2. Create Asset
         asset = MediaAsset(
-            FilePath=legacy_entry.file_path,
-            Size_MB=legacy_entry.size_mb,
+            file_path=legacy_entry.file_path,
+            size_mb=legacy_entry.size_mb,
             media_type=MediaType.VIDEO,
             video_metadata=v_meta,
             status=legacy_entry.status,

--- a/arcade_scanner/server/response_helpers.py
+++ b/arcade_scanner/server/response_helpers.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 import gzip
 import json
 from http.server import BaseHTTPRequestHandler
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Nur zur Typprüfung importiert, um einen Zirkelimport zur Laufzeit zu
+    # vermeiden. FinderHandler ergänzt BaseHTTPRequestHandler um get_current_user().
+    from arcade_scanner.server.api_handler import FinderHandler
 
 # Bodies smaller than this aren't worth the gzip CPU/header overhead.
 GZIP_MIN_SIZE = 512
@@ -97,7 +103,7 @@ def send_json_error(handler: BaseHTTPRequestHandler, status: int, message: str) 
     send_json(handler, {"error": message}, status=status)
 
 
-def require_auth(handler: BaseHTTPRequestHandler) -> str | None:
+def require_auth(handler: "FinderHandler") -> str | None:
     """Prüft ob der Request authentifiziert ist.
 
     Gibt den Benutzernamen zurück wenn authentifiziert, sendet ansonsten

--- a/arcade_scanner/server/routes/files.py
+++ b/arcade_scanner/server/routes/files.py
@@ -201,13 +201,13 @@ def _handle_mark_optimized(handler) -> None:
         if entry:
             entry.status = "OK"
         else:
-            size_mb = 0
+            size_mb = 0.0
             try:
                 if os.path.exists(abs_path):
                     size_mb = os.path.getsize(abs_path) / (1024 * 1024)
             except OSError as e:
                 print(f"⚠️ Could not stat file {abs_path}: {e}")
-            entry = VideoEntry(FilePath=abs_path, Size_MB=size_mb, Status="OK")
+            entry = VideoEntry(file_path=abs_path, size_mb=size_mb, Status="OK")
         db.upsert(entry)
         db.save()
         _get_media_cache().invalidate()
@@ -284,7 +284,9 @@ def _handle_compress(handler) -> None:
 
         if IS_WIN:
             print(f"🚀 Launching Optimizer (Win): {' '.join(cmd_parts)}")
-            subprocess.Popen(cmd_parts, creationflags=subprocess.CREATE_NEW_CONSOLE)
+            # CREATE_NEW_CONSOLE only exists in subprocess on Windows; this branch
+            # is guarded by IS_WIN, but mypy checks against the current (non-Win) stubs.
+            subprocess.Popen(cmd_parts, creationflags=subprocess.CREATE_NEW_CONSOLE)  # type: ignore[attr-defined]
         else:
             safe_cmd = ' '.join(shlex.quote(str(p)) for p in cmd_parts)
             print(f"🚀 Launching Optimizer (Mac): {safe_cmd}")
@@ -626,7 +628,8 @@ def _handle_batch_compress(handler) -> None:
         ]
 
         if IS_WIN:
-            subprocess.Popen(cmd_parts, creationflags=subprocess.CREATE_NEW_CONSOLE)
+            # CREATE_NEW_CONSOLE only exists in subprocess on Windows; guarded by IS_WIN.
+            subprocess.Popen(cmd_parts, creationflags=subprocess.CREATE_NEW_CONSOLE)  # type: ignore[attr-defined]
         else:
             safe_cmd = ' '.join(shlex.quote(str(p)) for p in cmd_parts)
             print(f"🚀 Launching Batch Controller: {len(validated_paths)} files")

--- a/arcade_scanner/server/routes/queue.py
+++ b/arcade_scanner/server/routes/queue.py
@@ -150,8 +150,8 @@ def handle_get(handler) -> bool:
         user_name = require_auth(handler)
         if user_name is None:
             return True
-        job_id = path.split("/api/export/gif/status/")[1].split("?")[0]
-        job = GIF_JOBS.get(job_id)
+        gif_job_id = path.split("/api/export/gif/status/")[1].split("?")[0]
+        job = GIF_JOBS.get(gif_job_id)
         if job is None:
             handler.send_error(404, "Job not found")
         else:
@@ -367,12 +367,12 @@ def handle_post(handler) -> bool:
             os.makedirs(gif_export_dir, exist_ok=True)
             output_path = os.path.join(gif_export_dir, output_filename)
 
-            job_id = str(uuid.uuid4())[:8]
-            palette_path = os.path.join(gif_export_dir, f"palette_{job_id}.png")
+            gif_job_id = str(uuid.uuid4())[:8]
+            palette_path = os.path.join(gif_export_dir, f"palette_{gif_job_id}.png")
 
             t = threading.Thread(
                 target=convert_to_gif,
-                args=(video_path, output_path, palette_path, job_id, fps, width, height, quality, start_time, end_time, loop, speed),
+                args=(video_path, output_path, palette_path, gif_job_id, fps, width, height, quality, start_time, end_time, loop, speed),
                 daemon=True,
             )
 
@@ -380,7 +380,7 @@ def handle_post(handler) -> bool:
 
             send_json(handler, {
                 "status": "processing",
-                "job_id": job_id,
+                "gif_job_id": gif_job_id,
                 "output_filename": output_filename,
                 "output_path": output_path,
                 "estimated_size_mb": round(estimated_size_mb, 2),

--- a/arcade_scanner/server/routes/queue.py
+++ b/arcade_scanner/server/routes/queue.py
@@ -380,7 +380,8 @@ def handle_post(handler) -> bool:
 
             send_json(handler, {
                 "status": "processing",
-                "gif_job_id": gif_job_id,
+                # Wire key stays "job_id" — gif_export.js reads result.job_id to poll status.
+                "job_id": gif_job_id,
                 "output_filename": output_filename,
                 "output_path": output_path,
                 "estimated_size_mb": round(estimated_size_mb, 2),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,20 @@ line-length = 100
 target-version = "py38"
 select = ["E", "F", "W", "I"]
 ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+plugins = ["pydantic.mypy"]
+ignore_missing_imports = true
+
+[tool.pydantic-mypy]
+warn_untyped_fields = true
+
+# numpy is only a transitive dependency (via ImageHash/PIL) and is not used
+# directly in arcade_scanner. Its bundled stubs use the PEP 695 `type`
+# statement, which mypy rejects when parsed at our target python_version.
+# Skip following numpy imports so its stubs are not type-checked.
+[[tool.mypy.overrides]]
+module = ["numpy.*"]
+follow_imports = "skip"
+follow_imports_for_stubs = true


### PR DESCRIPTION
## Ziel
`mypy arcade_scanner` von **131 Fehlern auf 0** bringen und den typecheck-Step im CI-Caller blockierend machen.

## Fehler vorher -> nachher (nach Code)
Baseline (131): `call-arg` 57, `union-attr` 24, `arg-type` 14, `attr-defined` 11, `assignment` 10, `var-annotated` 4, `operator` 3, `valid-type` 2, `misc` 2, `typeddict-unknown-key` 1, `str-unpack` 1, `return-value` 1, `call-overload` 1 (+ `annotation-unchecked`-Notes).

**Nachher: 0 Fehler** (`Success: no issues found in 45 source files`).

## Wichtigster Hebel: pydantic-mypy-Plugin
Es gab keine `[tool.mypy]`-Sektion. Neu hinzugefügt (Ziel python 3.11, passend zur CI):
- `plugins = ["pydantic.mypy"]` — modelliert Alias-/Default-Felder korrekt und beseitigt allein ~44 falsche `call-arg`-Meldungen der pydantic-Modelle (`VideoEntry`, `MediaAsset`).
- `ignore_missing_imports = true` — für optionale Libs ohne Stubs (`imagehash`, `PIL`).
- Per-Modul-Override `numpy.* -> follow_imports = skip`: numpy ist nur transitiv (über ImageHash/PIL), wird nicht direkt genutzt, und seine gebündelten Stubs verwenden PEP-695-`type`-Syntax.

Es waren **keine zusätzlichen Stub-Pakete** (`types-*`) nötig: das pydantic-Plugin kommt mit pydantic, und die verbleibenden Dritt-Libs sind optional und über `ignore_missing_imports` abgedeckt.

## Gefundene echte Bugs (als `fix:` separat)
1. **`queue.py` — Typverwechslung `job_id`**: In `handle_get`/`handle_post` wurde dieselbe Variable `job_id` sowohl als GIF-Export-String (`uuid`) als auch als numerische Queue-Job-ID (`int`) benutzt. Die GIF-Varianten heißen jetzt `gif_job_id`, sodass die an `cancel_job`/`update_job_status` (erwarten `int`) übergebenen IDs korrekt typisiert sind.
2. **`file_system.scan_directories` — falscher Rückgabetyp**: deklarierte `AsyncIterator[str]`, liefert aber tatsächlich `(pfad, dir_changed)`-Tupel (der Consumer entpackt bereits ein 2-Tupel). Korrigiert auf `AsyncIterator[Tuple[str, bool]]`.

## Weitere Kernänderungen (Annotationen/Narrowing, verhaltensneutral)
- **`sqlite_store`**: `_ensure_connection()` gibt jetzt eine nicht-optionale `Connection` zurück; Methoden binden sie lokal (`conn`) — beseitigt ~24 `union-attr` auf `Optional[Connection]` durch echtes Narrowing statt `ignore`.
- **`config`**: `SettingsConfigDict` statt `ConfigDict` für `BaseSettings` (`env_prefix`); `file_data: Dict[str, Any]`.
- **`duplicate_detector`**: `Tuple[Any, ...]` statt versehentlich `builtins.any`; `_popcount` als eine Funktion mit stabiler Signatur; `convert()` in eigene Variable (löst `ImageFile`/`Image`-Konflikt).
- **`hw_encode_detect` / `video_processor`**: `Optional[...]`-Defaults/-Rückgaben, `List[Union[str, bytes]]` für ffmpeg-Kommandos mit `os.fsencode`.
- **`manager` / `onboarding`**: Container-Annotationen, None-Narrowing, Schleifenvariable `e -> excl`.
- **pydantic-Pflichtfelder** (`media_probe`/`image_inspector`/`video_inspector`/`files`): Konstruktion über Feldnamen `file_path`/`size_mb` statt Aliase — verhaltensgleich dank `populate_by_name=True`.
- **`response_helpers`**: `require_auth` über `TYPE_CHECKING`-Import von `FinderHandler` typisiert (hat `get_current_user`), kein Zirkelimport zur Laufzeit.

## `# type: ignore`
Genau **2**, beide begründet und mit spezifischem Code:
`files.py` Z.289/632 — `subprocess.CREATE_NEW_CONSOLE` existiert nur unter Windows, ist durch `IS_WIN` abgesichert, wird aber gegen die aktuellen (Nicht-Windows-)Stubs geprüft: `# type: ignore[attr-defined]` mit Kommentar.

## Verifikation
- `mypy arcade_scanner` -> **0 Fehler**
- `pytest` -> **545 passed**
- `ruff check .` -> **All checks passed** (blockierendes Gate bleibt grün)

## Flip
`.github/workflows/ci.yml`: `typecheck-blocking: true` ergänzt (der Reusable-Workflow unterstützt diesen Input) — mypy ist jetzt blockierend, um Regressionen zu verhindern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)