### PR TITLE
feat: Optimizer-Kandidaten-Ansicht (/candidates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Optimizer Candidates View
+- **Kandidaten-Ansicht** (`/candidates`): ranks the library by expected re-encode
+  savings (bitrate-per-resolution heuristic + codec efficiency), refined by real
+  results from `encode_history.jsonl` once a resolution/bitrate class has ≥3
+  encodes. Header shows the total possible savings; rows queue directly into the
+  existing encoding queue (HEVC/AV1 toggle).
+- **`optimized_at` marker**: successful optimizations now stamp the media entry;
+  optimized files no longer appear as candidates (rescan-safe).
+
 ### Changed — Video Optimizer V2.5
 - **Downscaling**: New `--scale-height H` option scales the encode to H pixels height while keeping the source aspect ratio (width `-2`). Upscaling is refused, the SSIM reference is scaled to match so quality checks stay valid, and the constrained-VBR ladder is adjusted to the target resolution (~pixels^0.75) so a downscale actually converts into savings.
 - **Sample-Clip Pre-Search**: The quality binary search now runs on a ~24s stream-copied probe clip first, then narrows the full-encode search to predicted ±1 — typically 1-2 full passes instead of 3-4 (files ≥ 120s; `--no-presearch` to disable).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,13 @@ This document outlines planned features and improvements for the Arcade Media Sc
 
 ## Completed Features
 
+### ✅ Optimizer-Kandidaten-Ansicht (2026-08-07)
+- **Kandidaten-Ansicht**: Ranks library by expected re-encode savings using bitrate-per-resolution heuristic and codec efficiency metrics.
+- **Real-World Refinement**: Results refined by actual outcomes from `encode_history.jsonl` once a resolution/bitrate class has 3+ encodes.
+- **Quick Queuing**: Row entries queue directly into the existing encoding queue with HEVC/AV1 toggle.
+- **Total Savings Display**: Header shows aggregate possible savings for the entire library.
+- **`optimized_at` Marker**: Successful optimizations now stamp media entries; optimized files are excluded from candidates (rescan-safe).
+
 ### ✅ Version 6.8.0 (2026-01-18)
 - **Visual Timeline Scrubber**: Professional timeline with frame-accurate seeking and thumbnail previews.
 - **GIF Export Panel**: Redesigned bottom panel UI with presets and size estimation.

--- a/arcade_scanner/core/optimization_advisor.py
+++ b/arcade_scanner/core/optimization_advisor.py
@@ -7,6 +7,8 @@ codec efficiency; overridden by real results from encode_history.jsonl
 """
 from __future__ import annotations
 
+import json
+import statistics
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -115,3 +117,64 @@ class CandidateEstimate:
     confidence: str  # "high" | "medium" | "low"
     source: str      # "history" | "heuristic"
     reason: str
+
+
+# --- EncodeHistory --------------------------------------------------------
+# History `codec` holds encoder-profile names (hevc_nvenc, libx265, av1_nvenc…);
+# match the requested target codec by substring.
+_TARGET_SUBSTRINGS = {"hevc": ("hevc", "265"), "av1": ("av1",)}
+
+
+class EncodeHistory:
+    """mtime-cached reader over encode_history.jsonl (best-effort, never raises)."""
+
+    def __init__(self, path: Path = DEFAULT_HISTORY_PATH) -> None:
+        self.path = path
+        self._mtime: float = -1.0
+        self._records: list[dict] = []
+
+    def _load(self) -> list[dict]:
+        try:
+            mtime = self.path.stat().st_mtime
+        except OSError:
+            self._records = []
+            self._mtime = -1.0
+            return self._records
+        if mtime == self._mtime:
+            return self._records
+        records: list[dict] = []
+        try:
+            with open(self.path, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(rec, dict) and rec.get("saved_pct") is not None:
+                        records.append(rec)
+        except OSError:
+            records = []
+        self._records = records
+        self._mtime = mtime
+        return self._records
+
+    def median_saved_pct(self, target_codec: str, height: int, source_kbps: float,
+                         min_samples: int = 3) -> Optional[tuple[float, int]]:
+        """Median real saved_pct for the (target, resolution class, bitrate class) bucket."""
+        substrings = _TARGET_SUBSTRINGS.get(target_codec, (target_codec,))
+        want = (resolution_class(height), bitrate_class(source_kbps))
+        samples: list[float] = []
+        for rec in self._load():
+            codec_str = f"{rec.get('codec', '')}{rec.get('encoder', '')}".lower()
+            if not any(s in codec_str for s in substrings):
+                continue
+            try:
+                key = (resolution_class(int(rec.get("height", 0))),
+                       bitrate_class(float(rec.get("source_kbps", 0))))
+                if key == want:
+                    samples.append(float(rec["saved_pct"]))
+            except (TypeError, ValueError):
+                continue
+        if len(samples) < min_samples:
+            return None
+        return (float(statistics.median(samples)), len(samples))

--- a/arcade_scanner/core/optimization_advisor.py
+++ b/arcade_scanner/core/optimization_advisor.py
@@ -55,15 +55,15 @@ _MAX_SAVED_PCT = 85.0     # never predict more than this
 _TARGET_ALIASES = {"hevc": {"hevc", "h265"}, "av1": {"av1"}}
 
 
-def _codec_efficiency(source_codec: str, target_codec: str) -> tuple[float, bool]:
-    """(bitrate multiplier source→target, is the pair actually known?)."""
+def _codec_efficiency(source_codec: str, target_codec: str) -> tuple[float, bool, bool]:
+    """(bitrate multiplier source→target, is the pair actually known?, is_same_codec)."""
     src = (source_codec or "").lower()
     if src in _TARGET_ALIASES.get(target_codec, {target_codec}):
-        return _SAME_CODEC_EFF, True
+        return _SAME_CODEC_EFF, True, True
     eff = CODEC_EFFICIENCY.get((src, target_codec))
     if eff is not None:
-        return eff, True
-    return _DEFAULT_EFF, False
+        return eff, True, False
+    return _DEFAULT_EFF, False, False
 
 
 def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[float, bool]]:
@@ -77,7 +77,7 @@ def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[f
     if source_kbps <= 0 or height <= 0:
         return None
 
-    eff, known = _codec_efficiency(entry.codec or "", target_codec)
+    eff, known, is_same_codec = _codec_efficiency(entry.codec or "", target_codec)
 
     ref = _REF_KBPS[resolution_class(height)]
     if target_codec == "av1":
@@ -89,7 +89,7 @@ def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[f
     # Predicted output: codec factor applied to the source, but never above
     # what a clean target-codec encode needs at this resolution (`ref`).
     # For same-codec re-encoding, minimal gains from re-optimization; don't cap at ref.
-    if eff == _SAME_CODEC_EFF:
+    if is_same_codec:
         # Same-codec: apply efficiency without ref cap (already efficiently encoded)
         predicted_kbps = source_kbps * eff
         predicted_kbps = max(predicted_kbps, source_kbps * (1 - _MAX_SAVED_PCT / 100))

--- a/arcade_scanner/core/optimization_advisor.py
+++ b/arcade_scanner/core/optimization_advisor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import statistics
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -57,15 +58,31 @@ _MAX_SAVED_PCT = 85.0     # never predict more than this
 _TARGET_ALIASES = {"hevc": {"hevc", "h265"}, "av1": {"av1"}}
 
 
+def _is_same_codec(source_codec: str, target_codec: str) -> bool:
+    """True when re-encoding `source_codec` to `target_codec` is a same-codec pass."""
+    src = (source_codec or "").lower()
+    return src in _TARGET_ALIASES.get(target_codec, {target_codec})
+
+
 def _codec_efficiency(source_codec: str, target_codec: str) -> tuple[float, bool, bool]:
     """(bitrate multiplier source→target, is the pair actually known?, is_same_codec)."""
-    src = (source_codec or "").lower()
-    if src in _TARGET_ALIASES.get(target_codec, {target_codec}):
+    if _is_same_codec(source_codec, target_codec):
         return _SAME_CODEC_EFF, True, True
+    src = (source_codec or "").lower()
     eff = CODEC_EFFICIENCY.get((src, target_codec))
     if eff is not None:
         return eff, True, False
     return _DEFAULT_EFF, False, False
+
+
+def _reference_kbps(height: int, target_codec: str, fps: float) -> float:
+    """Reference bitrate (kbps) for a clean target-codec encode at this resolution/fps."""
+    ref = _REF_KBPS[resolution_class(height)]
+    if target_codec == "av1":
+        ref *= _AV1_REF_FACTOR
+    if fps > 0:
+        ref *= min(max(fps / 30.0, 0.5), 2.0)
+    return ref
 
 
 def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[float, bool]]:
@@ -81,12 +98,8 @@ def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[f
 
     eff, known, is_same_codec = _codec_efficiency(entry.codec or "", target_codec)
 
-    ref = _REF_KBPS[resolution_class(height)]
-    if target_codec == "av1":
-        ref *= _AV1_REF_FACTOR
     fps = entry.frame_rate or 0.0
-    if fps > 0:
-        ref *= min(max(fps / 30.0, 0.5), 2.0)
+    ref = _reference_kbps(height, target_codec, fps)
 
     # Predicted output: codec factor applied to the source, but never above
     # what a clean target-codec encode needs at this resolution (`ref`).
@@ -126,55 +139,65 @@ _TARGET_SUBSTRINGS = {"hevc": ("hevc", "265"), "av1": ("av1",)}
 
 
 class EncodeHistory:
-    """mtime-cached reader over encode_history.jsonl (best-effort, never raises)."""
+    """mtime-cached reader over encode_history.jsonl (best-effort, never raises).
+
+    Records are pre-parsed and bucketed by (resolution class, bitrate class) at
+    load time, so `median_saved_pct` is a bucket lookup + substring filter over
+    only the matching bucket, not a full linear scan of every record. Reload
+    (triggered by an mtime check) and bucket access are both guarded by a lock
+    since the instance is shared across server threads.
+    """
 
     def __init__(self, path: Path = DEFAULT_HISTORY_PATH) -> None:
         self.path = path
         self._mtime: float = -1.0
-        self._records: list[dict] = []
+        # bucket (resolution_class, bitrate_class) -> [(lowered codec str, saved_pct), ...]
+        self._index: dict[tuple[str, str], list[tuple[str, float]]] = {}
+        self._lock = threading.Lock()
 
-    def _load(self) -> list[dict]:
-        try:
-            mtime = self.path.stat().st_mtime
-        except OSError:
-            self._records = []
-            self._mtime = -1.0
-            return self._records
-        if mtime == self._mtime:
-            return self._records
-        records: list[dict] = []
-        try:
-            with open(self.path, encoding="utf-8") as f:
-                for line in f:
-                    try:
-                        rec = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if isinstance(rec, dict) and rec.get("saved_pct") is not None:
-                        records.append(rec)
-        except OSError:
-            records = []
-        self._records = records
-        self._mtime = mtime
-        return self._records
+    def _reload_if_stale(self) -> None:
+        with self._lock:
+            try:
+                mtime = self.path.stat().st_mtime
+            except OSError:
+                self._index = {}
+                self._mtime = -1.0
+                return
+            if mtime == self._mtime:
+                return
+            index: dict[tuple[str, str], list[tuple[str, float]]] = {}
+            try:
+                with open(self.path, encoding="utf-8") as f:
+                    for line in f:
+                        try:
+                            rec = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if not isinstance(rec, dict) or rec.get("saved_pct") is None:
+                            continue
+                        try:
+                            bucket = (resolution_class(int(rec.get("height", 0))),
+                                     bitrate_class(float(rec.get("source_kbps", 0))))
+                            saved_pct = float(rec["saved_pct"])
+                        except (TypeError, ValueError):
+                            continue
+                        codec_str = str(rec.get("codec", "")).lower()
+                        index.setdefault(bucket, []).append((codec_str, saved_pct))
+            except OSError:
+                index = {}
+            self._index = index
+            self._mtime = mtime
 
     def median_saved_pct(self, target_codec: str, height: int, source_kbps: float,
                          min_samples: int = 3) -> Optional[tuple[float, int]]:
         """Median real saved_pct for the (target, resolution class, bitrate class) bucket."""
+        self._reload_if_stale()
         substrings = _TARGET_SUBSTRINGS.get(target_codec, (target_codec,))
-        want = (resolution_class(height), bitrate_class(source_kbps))
-        samples: list[float] = []
-        for rec in self._load():
-            codec_str = str(rec.get("codec", "")).lower()
-            if not any(s in codec_str for s in substrings):
-                continue
-            try:
-                key = (resolution_class(int(rec.get("height", 0))),
-                       bitrate_class(float(rec.get("source_kbps", 0))))
-                if key == want:
-                    samples.append(float(rec["saved_pct"]))
-            except (TypeError, ValueError):
-                continue
+        bucket = (resolution_class(height), bitrate_class(source_kbps))
+        with self._lock:
+            entries = list(self._index.get(bucket, ()))
+        samples = [saved_pct for codec_str, saved_pct in entries
+                  if any(s in codec_str for s in substrings)]
         if len(samples) < min_samples:
             return None
         return (float(statistics.median(samples)), len(samples))
@@ -185,13 +208,18 @@ class EncodeHistory:
 MIN_LISTED_SAVED_PCT = 10.0
 
 
-def _reason(entry: VideoEntry, saved_pct: float, source: str, samples: int) -> str:
+def _reason(entry: VideoEntry, saved_pct: float, source: str, samples: int,
+           is_same_codec: bool, above_reference: bool) -> str:
     codec = (entry.codec or "unknown").upper()
     res = f"{entry.height}p" if (entry.height or 0) > 0 else "?"
     rate = f"{entry.bitrate_mbps:.1f} Mbit/s"
     if source == "history":
         return f"{codec}, {res}, {rate} — {samples} echte Encodes in dieser Klasse"
-    return f"{codec}, {res}, {rate} — deutlich über Referenz"
+    if is_same_codec:
+        return f"{codec}, {res}, {rate} — gleicher Codec, geringes Potenzial"
+    if above_reference:
+        return f"{codec}, {res}, {rate} — deutlich über Referenz"
+    return f"{codec}, {res}, {rate} — Codec-Wechsel lohnt"
 
 
 def build_candidates(entries: list[VideoEntry], target_codec: str,
@@ -213,13 +241,21 @@ def build_candidates(entries: list[VideoEntry], target_codec: str,
         source = "heuristic"
         confidence = "medium" if known_pair else "low"
         samples = 0
-        hist = history.median_saved_pct(
-            target_codec, entry.height or 0, (entry.bitrate_mbps or 0.0) * 1000.0)
-        if hist is not None:
-            saved_pct, samples = hist
-            source, confidence = "history", "high"
+        is_same_codec = _is_same_codec(entry.codec or "", target_codec)
+        # History carries no source codec, so a same-codec entry (already HEVC,
+        # re-checking against HEVC) would otherwise inherit the median of
+        # unrelated h264-source encodes in the same bucket. Skip the override.
+        if not is_same_codec:
+            hist = history.median_saved_pct(
+                target_codec, entry.height or 0, (entry.bitrate_mbps or 0.0) * 1000.0)
+            if hist is not None:
+                saved_pct, samples = hist
+                source, confidence = "history", "high"
         if saved_pct < MIN_LISTED_SAVED_PCT:
             continue
+        source_kbps = (entry.bitrate_mbps or 0.0) * 1000.0
+        ref_kbps = _reference_kbps(entry.height or 0, target_codec, entry.frame_rate or 0.0)
+        above_reference = source_kbps > ref_kbps
         candidates.append(CandidateEstimate(
             file_path=entry.file_path,
             size_mb=entry.size_mb,
@@ -232,7 +268,7 @@ def build_candidates(entries: list[VideoEntry], target_codec: str,
             estimated_saved_pct=round(saved_pct, 1),
             confidence=confidence,
             source=source,
-            reason=_reason(entry, saved_pct, source, samples),
+            reason=_reason(entry, saved_pct, source, samples, is_same_codec, above_reference),
         ))
 
     candidates.sort(key=lambda c: c.estimated_saved_mb, reverse=True)

--- a/arcade_scanner/core/optimization_advisor.py
+++ b/arcade_scanner/core/optimization_advisor.py
@@ -1,0 +1,117 @@
+"""Optimization advisor — ranks videos by expected savings from re-encoding.
+
+Pure logic (no ffmpeg/subprocess): unit-testable, consumed by the
+/api/candidates route. Heuristic baseline from bitrate-per-resolution +
+codec efficiency; overridden by real results from encode_history.jsonl
+(written by scripts/video_optimizer.py) when a bucket has enough samples.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..models.video_entry import VideoEntry
+from .bitrate_analyzer import CODEC_EFFICIENCY
+
+DEFAULT_HISTORY_PATH = Path.home() / ".arcade-scanner" / "logs" / "encode_history.jsonl"
+
+# --- bucket helpers -------------------------------------------------------
+# Deliberately duplicated from scripts/optimizer_utils.py (that module stays
+# import-standalone for the optimizer scripts); parity is pinned by
+# tests/test_optimization_advisor.py::test_bucket_helpers_parity_with_optimizer_utils.
+
+
+def bitrate_class(kbps: float) -> str:
+    if kbps < 2500:
+        return "low"
+    if kbps < 8000:
+        return "med"
+    if kbps < 20000:
+        return "high"
+    return "ultra"
+
+
+def resolution_class(height: int) -> str:
+    if height <= 576:
+        return "sd"
+    if height <= 800:
+        return "720"
+    if height <= 1200:
+        return "1080"
+    if height <= 1600:
+        return "1440"
+    return "2160"
+
+
+# --- heuristic ------------------------------------------------------------
+
+# Reference bitrates (kbps) for a well-compressed HEVC encode at ~30 fps.
+_REF_KBPS = {"sd": 1500.0, "720": 2500.0, "1080": 4000.0, "1440": 8000.0, "2160": 12000.0}
+_AV1_REF_FACTOR = 0.85    # AV1 hits the same quality a bit leaner
+_SAME_CODEC_EFF = 0.85    # re-encoding within the same codec gains little
+_DEFAULT_EFF = 0.65       # unknown source codec: assume h264-like gains
+_MAX_SAVED_PCT = 85.0     # never predict more than this
+_TARGET_ALIASES = {"hevc": {"hevc", "h265"}, "av1": {"av1"}}
+
+
+def _codec_efficiency(source_codec: str, target_codec: str) -> tuple[float, bool]:
+    """(bitrate multiplier source→target, is the pair actually known?)."""
+    src = (source_codec or "").lower()
+    if src in _TARGET_ALIASES.get(target_codec, {target_codec}):
+        return _SAME_CODEC_EFF, True
+    eff = CODEC_EFFICIENCY.get((src, target_codec))
+    if eff is not None:
+        return eff, True
+    return _DEFAULT_EFF, False
+
+
+def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[float, bool]]:
+    """Estimated saved percentage (0-100) for re-encoding `entry`.
+
+    Returns (saved_pct, known_codec_pair) or None when the entry lacks the
+    metadata to say anything (no bitrate / no height from ffprobe).
+    """
+    source_kbps = (entry.bitrate_mbps or 0.0) * 1000.0
+    height = entry.height or 0
+    if source_kbps <= 0 or height <= 0:
+        return None
+
+    eff, known = _codec_efficiency(entry.codec or "", target_codec)
+
+    ref = _REF_KBPS[resolution_class(height)]
+    if target_codec == "av1":
+        ref *= _AV1_REF_FACTOR
+    fps = entry.frame_rate or 0.0
+    if fps > 0:
+        ref *= min(max(fps / 30.0, 0.5), 2.0)
+
+    # Predicted output: codec factor applied to the source, but never above
+    # what a clean target-codec encode needs at this resolution (`ref`).
+    # For same-codec re-encoding, minimal gains from re-optimization; don't cap at ref.
+    if eff == _SAME_CODEC_EFF:
+        # Same-codec: apply efficiency without ref cap (already efficiently encoded)
+        predicted_kbps = source_kbps * eff
+        predicted_kbps = max(predicted_kbps, source_kbps * (1 - _MAX_SAVED_PCT / 100))
+    else:
+        # Different-codec: cap at reference rate
+        predicted_kbps = min(source_kbps * eff, max(ref, source_kbps * (1 - _MAX_SAVED_PCT / 100)))
+
+    saved_pct = max(0.0, (1.0 - predicted_kbps / source_kbps) * 100.0)
+    return min(saved_pct, _MAX_SAVED_PCT), known
+
+
+@dataclass
+class CandidateEstimate:
+    file_path: str
+    size_mb: float
+    codec: str
+    width: int
+    height: int
+    bitrate_mbps: float
+    thumb: str
+    estimated_saved_mb: float
+    estimated_saved_pct: float
+    confidence: str  # "high" | "medium" | "low"
+    source: str      # "history" | "heuristic"
+    reason: str

--- a/arcade_scanner/core/optimization_advisor.py
+++ b/arcade_scanner/core/optimization_advisor.py
@@ -165,7 +165,7 @@ class EncodeHistory:
         want = (resolution_class(height), bitrate_class(source_kbps))
         samples: list[float] = []
         for rec in self._load():
-            codec_str = f"{rec.get('codec', '')}{rec.get('encoder', '')}".lower()
+            codec_str = str(rec.get("codec", "")).lower()
             if not any(s in codec_str for s in substrings):
                 continue
             try:

--- a/arcade_scanner/core/optimization_advisor.py
+++ b/arcade_scanner/core/optimization_advisor.py
@@ -178,3 +178,69 @@ class EncodeHistory:
         if len(samples) < min_samples:
             return None
         return (float(statistics.median(samples)), len(samples))
+
+
+# --- build_candidates -------------------------------------------------------
+
+MIN_LISTED_SAVED_PCT = 10.0
+
+
+def _reason(entry: VideoEntry, saved_pct: float, source: str, samples: int) -> str:
+    codec = (entry.codec or "unknown").upper()
+    res = f"{entry.height}p" if (entry.height or 0) > 0 else "?"
+    rate = f"{entry.bitrate_mbps:.1f} Mbit/s"
+    if source == "history":
+        return f"{codec}, {res}, {rate} — {samples} echte Encodes in dieser Klasse"
+    return f"{codec}, {res}, {rate} — deutlich über Referenz"
+
+
+def build_candidates(entries: list[VideoEntry], target_codec: str,
+                     history: EncodeHistory, exclude_paths: set[str],
+                     limit: int = 100) -> dict:
+    """Rank re-encode candidates by absolute expected savings (MB, desc)."""
+    candidates: list[CandidateEstimate] = []
+    for entry in entries:
+        if entry.media_type != "video":
+            continue
+        if getattr(entry, "optimized_at", 0):
+            continue
+        if entry.file_path in exclude_paths:
+            continue
+        heur = estimate_heuristic(entry, target_codec)
+        if heur is None:
+            continue
+        saved_pct, known_pair = heur
+        source = "heuristic"
+        confidence = "medium" if known_pair else "low"
+        samples = 0
+        hist = history.median_saved_pct(
+            target_codec, entry.height or 0, (entry.bitrate_mbps or 0.0) * 1000.0)
+        if hist is not None:
+            saved_pct, samples = hist
+            source, confidence = "history", "high"
+        if saved_pct < MIN_LISTED_SAVED_PCT:
+            continue
+        candidates.append(CandidateEstimate(
+            file_path=entry.file_path,
+            size_mb=entry.size_mb,
+            codec=entry.codec or "unknown",
+            width=entry.width or 0,
+            height=entry.height or 0,
+            bitrate_mbps=entry.bitrate_mbps or 0.0,
+            thumb=entry.thumb or "",
+            estimated_saved_mb=round(entry.size_mb * saved_pct / 100.0, 1),
+            estimated_saved_pct=round(saved_pct, 1),
+            confidence=confidence,
+            source=source,
+            reason=_reason(entry, saved_pct, source, samples),
+        ))
+
+    candidates.sort(key=lambda c: c.estimated_saved_mb, reverse=True)
+    return {
+        "summary": {
+            "total_files": len(candidates),
+            "total_estimated_saved_mb": round(sum(c.estimated_saved_mb for c in candidates), 1),
+            "history_based": sum(1 for c in candidates if c.source == "history"),
+        },
+        "results": [c.__dict__.copy() for c in candidates[:limit]],
+    }

--- a/arcade_scanner/database/sqlite_store.py
+++ b/arcade_scanner/database/sqlite_store.py
@@ -49,6 +49,7 @@ _COLUMNS = [
     ("imported_at", "INTEGER DEFAULT 0"),
     ("mtime", "INTEGER DEFAULT 0"),
     ("original_path", "TEXT DEFAULT ''"),
+    ("optimized_at", "INTEGER DEFAULT 0"),
 ]
 
 
@@ -147,6 +148,12 @@ class SQLiteStore:
             conn.execute("ALTER TABLE media ADD COLUMN original_path TEXT DEFAULT ''")
         except Exception:
             pass # Already exists
+
+        # Migration: optimized_at marks files already processed by the optimizer
+        try:
+            conn.execute("ALTER TABLE media ADD COLUMN optimized_at INTEGER DEFAULT 0")
+        except Exception:
+            pass  # Already exists
 
         # Encoding queue for remote optimization
         conn.execute("""
@@ -269,6 +276,16 @@ class SQLiteStore:
                 (limit,)
             )
             return [dict(row) for row in cursor.fetchall()]
+
+    def get_active_queue_paths(self) -> set:
+        """file_paths of jobs currently pending or being processed."""
+        conn = self._ensure_connection()
+        with self._write_lock:
+            cursor = conn.execute(
+                "SELECT file_path FROM encoding_queue "
+                "WHERE status IN ('pending', 'downloading', 'encoding', 'uploading')"
+            )
+            return {self._decode_safe_path(row["file_path"]) for row in cursor}
 
     def cancel_job(self, job_id: int) -> bool:
         """Cancel a pending or active job. Returns True if cancelled."""
@@ -559,6 +576,7 @@ class SQLiteStore:
             "imported_at": row["imported_at"] or 0,
             "mtime": row["mtime"] or 0,
             "OriginalPath": row["original_path"] or "",
+            "optimized_at": row["optimized_at"] or 0,
         }
 
     def _entry_to_tuple(self, entry: VideoEntry) -> tuple:
@@ -591,6 +609,7 @@ class SQLiteStore:
             entry.imported_at or 0,
             entry.mtime or 0,
             entry.original_path or "",
+            entry.optimized_at or 0,
         )
 
     def _asset_to_video_entry(self, entry) -> VideoEntry:
@@ -619,6 +638,7 @@ class SQLiteStore:
             imported_at=entry.imported_at,
             mtime=entry.mtime,
             original_path=entry.original_path,
+            optimized_at=entry.optimized_at,
         )
 
     def _migrate_from_json(self) -> None:

--- a/arcade_scanner/models/media_asset.py
+++ b/arcade_scanner/models/media_asset.py
@@ -70,6 +70,7 @@ class MediaAsset(BaseModel):
     imported_at: int = Field(default_factory=lambda: int(time.time()), description="Timestamp when first imported")
     mtime: int = Field(0, description="Last modification timestamp of the file")
     original_path: Optional[str] = Field(None, alias="OriginalPath", description="Source path before moving to review")
+    optimized_at: Optional[int] = Field(0, description="Unix timestamp of last successful optimization (0 = never)")
 
     # --- LEGACY COMPATIBILITY PROPERTIES (Snake Case) ---
     @property

--- a/arcade_scanner/models/video_entry.py
+++ b/arcade_scanner/models/video_entry.py
@@ -39,6 +39,7 @@ class VideoEntry(BaseModel):
     imported_at: Optional[int] = Field(0, description="Timestamp when first imported/scanned")
     mtime: Optional[int] = Field(0, description="Last modification timestamp of the file")
     original_path: Optional[str] = Field(None, alias="OriginalPath", description="Source path of the file before it was moved to review")
+    optimized_at: Optional[int] = Field(0, description="Unix timestamp of last successful optimization (0 = never)")
 
 
     model_config = ConfigDict(

--- a/arcade_scanner/scanner/manager.py
+++ b/arcade_scanner/scanner/manager.py
@@ -240,6 +240,7 @@ class ScannerManager:
                         entry.favorite = cached_entry.favorite
                         entry.vaulted = cached_entry.vaulted
                         entry.tags = cached_entry.tags
+                        entry.optimized_at = cached_entry.optimized_at
                         if cached_entry.imported_at and cached_entry.imported_at > 0:
                             entry.imported_at = cached_entry.imported_at
 

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -13,6 +13,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 from arcade_scanner.config import (
     ALLOWED_THUMBNAIL_PREFIX,
     DUPLICATES_CACHE_FILE,
+    MAX_REQUEST_SIZE,  # noqa: F401 — re-exported for routes/* lazy imports
     config,
 )
 from arcade_scanner.database import db, user_db

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -394,7 +394,7 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         self._response_started = False
         try:
-            from .routes import duplicates, files, queue, settings, tags
+            from .routes import candidates, duplicates, files, queue, settings, tags
             if queue.handle_get(self):
                 return
             if settings.handle_get(self):
@@ -402,6 +402,8 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
             if duplicates.handle_get(self):
                 return
             if tags.handle_get(self):
+                return
+            if candidates.handle_get(self):
                 return
             if files.handle_get(self):
                 return
@@ -435,7 +437,7 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
 
 
             # 1. ROOT / INDEX -> Serve REPORT_FILE
-            spa_routes = ["/", "/index.html", "/lobby", "/favorites", "/review", "/vault", "/treeview", "/duplicates"]
+            spa_routes = ["/", "/index.html", "/lobby", "/favorites", "/review", "/vault", "/treeview", "/duplicates", "/candidates"]
             clean_path = self.path.split('?')[0]
             if clean_path in spa_routes or clean_path.startswith("/collections/"):
 

--- a/arcade_scanner/server/routes/candidates.py
+++ b/arcade_scanner/server/routes/candidates.py
@@ -1,0 +1,50 @@
+"""GET /api/candidates — re-encode candidates ranked by expected savings."""
+import os
+from urllib.parse import parse_qs, urlparse
+
+from arcade_scanner.core.optimization_advisor import EncodeHistory, build_candidates
+from arcade_scanner.server.response_helpers import send_json
+
+VALID_CODECS = {"hevc", "av1"}
+
+# Module-level: EncodeHistory caches by mtime, so reuse across requests.
+_history = EncodeHistory()
+
+
+def _get_deps():
+    from arcade_scanner.server.api_handler import db, user_db
+    return db, user_db
+
+
+def handle_get(handler) -> bool:
+    parsed = urlparse(handler.path)
+    if parsed.path != "/api/candidates":
+        return False
+
+    user_name = handler.get_current_user()
+    if not user_name:
+        handler.send_error(401, "Unauthorized")
+        return True
+
+    params = parse_qs(parsed.query)
+    codec = params.get("codec", ["hevc"])[0]
+    if codec not in VALID_CODECS:
+        handler.send_error(400, "Invalid codec (hevc|av1)")
+        return True
+    try:
+        limit = max(1, min(int(params.get("limit", ["100"])[0]), 500))
+    except ValueError:
+        limit = 100
+
+    try:
+        db, user_db = _get_deps()
+        exclude = set(db.get_active_queue_paths())
+        u = user_db.get_user(user_name)
+        if u and u.data.vaulted:
+            exclude.update(os.path.abspath(p) for p in u.data.vaulted)
+        payload = build_candidates(db.get_all(), codec, _history, exclude, limit)
+        send_json(handler, payload)
+    except Exception as e:
+        print(f"❌ Error building candidates: {e}")
+        handler.send_error(500, str(e))
+    return True

--- a/arcade_scanner/server/routes/files.py
+++ b/arcade_scanner/server/routes/files.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import subprocess
 import sys
+import time
 from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
 
@@ -197,9 +198,11 @@ def _handle_mark_optimized(handler) -> None:
             handler.send_error(403, "Forbidden - Path not in scan directories")
             return
 
+        now = int(time.time())
         entry = db.get(abs_path)
         if entry:
             entry.status = "OK"
+            entry.optimized_at = now
         else:
             size_mb = 0.0
             try:
@@ -207,7 +210,8 @@ def _handle_mark_optimized(handler) -> None:
                     size_mb = os.path.getsize(abs_path) / (1024 * 1024)
             except OSError as e:
                 print(f"⚠️ Could not stat file {abs_path}: {e}")
-            entry = VideoEntry(file_path=abs_path, size_mb=size_mb, Status="OK")
+            entry = VideoEntry(file_path=abs_path, size_mb=size_mb, Status="OK",
+                               optimized_at=now)
         db.upsert(entry)
         db.save()
         _get_media_cache().invalidate()

--- a/arcade_scanner/server/static/candidates.js
+++ b/arcade_scanner/server/static/candidates.js
@@ -1,0 +1,149 @@
+/**
+ * Candidates View — ranks the library by expected re-encode savings.
+ * Data: GET /api/candidates (see routes/candidates.py). Queueing reuses
+ * POST /api/queue/add like optimizer.js does.
+ */
+
+let candState = {
+    codec: 'hevc',
+    results: [],
+    summary: null,
+    selected: new Set(),   // file paths
+    loading: false,
+};
+
+function renderCandidatesView() {
+    const grid = document.getElementById('videoGrid');
+    if (!grid) return;
+    grid.innerHTML = '<div class="p-8 text-center text-gray-400">Analysiere Bibliothek…</div>';
+    candState.loading = true;
+
+    fetch(`/api/candidates?codec=${candState.codec}&limit=200`)
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(data => {
+            candState.results = data.results || [];
+            candState.summary = data.summary || null;
+            candState.selected.clear();
+            candState.loading = false;
+            _renderCandidates(grid);
+        })
+        .catch(err => {
+            candState.loading = false;
+            grid.innerHTML = `<div class="p-8 text-center text-red-400">Kandidaten-Analyse fehlgeschlagen: ${err.message}</div>`;
+        });
+}
+
+function _fmtGB(mb) {
+    return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
+}
+
+function _candHeader() {
+    const s = candState.summary || { total_files: 0, total_estimated_saved_mb: 0, history_based: 0 };
+    const codecBtn = (c, label) => `
+        <button onclick="setCandidatesCodec('${c}')"
+                class="px-3 py-1 rounded text-xs font-bold ${candState.codec === c
+                    ? 'bg-arcade-cyan text-black'
+                    : 'bg-white/10 text-gray-300 hover:bg-white/20'}">${label}</button>`;
+    return `
+    <div id="candidatesHeader" class="col-span-full p-4 rounded-xl bg-white/5 mb-2">
+        <div class="flex flex-wrap items-center gap-4">
+            <div>
+                <div class="text-2xl font-bold text-arcade-cyan">~${_fmtGB(s.total_estimated_saved_mb)}</div>
+                <div class="text-xs text-gray-400">geschätzte Ersparnis · ${s.total_files} Kandidaten
+                     · ${s.history_based} mit echter Encode-Historie</div>
+            </div>
+            <div class="flex items-center gap-2 ml-auto">
+                ${codecBtn('hevc', 'HEVC')}${codecBtn('av1', 'AV1')}
+                <button id="candQueueSelectedBtn" onclick="queueSelectedCandidates()"
+                        class="px-3 py-1 rounded text-xs font-bold bg-arcade-cyan/20 text-arcade-cyan hover:bg-arcade-cyan/30">
+                    Auswahl in Queue (${candState.selected.size})
+                </button>
+            </div>
+        </div>
+    </div>`;
+}
+
+function _candRow(r, idx) {
+    const enc = encodeURIComponent(r.file_path);
+    const name = r.file_path.split(/[/\\]/).pop();
+    const checked = candState.selected.has(r.file_path) ? 'checked' : '';
+    const confColors = { high: 'text-green-400', medium: 'text-yellow-400', low: 'text-gray-400' };
+    const confLabel = r.source === 'history' ? 'Historie' : 'Schätzung';
+    const thumb = r.thumb ? `<img src="/thumbnails/${r.thumb}" class="w-24 h-14 object-cover rounded" loading="lazy">`
+                          : '<div class="w-24 h-14 rounded bg-white/10"></div>';
+    return `
+    <div id="cand-${idx}" class="col-span-full flex items-center gap-3 p-2 rounded-lg bg-white/5 hover:bg-white/10">
+        <input type="checkbox" ${checked} onclick="toggleCandidateSelect('${enc}')">
+        <div class="cursor-pointer" onclick="openCinema(this)" data-path="${r.file_path}">${thumb}</div>
+        <div class="min-w-0 flex-1">
+            <div class="truncate text-sm font-medium">${name}</div>
+            <div class="text-xs text-gray-400">${r.codec.toUpperCase()} · ${r.height}p · ${r.bitrate_mbps.toFixed(1)} Mbit/s · ${_fmtGB(r.size_mb)}</div>
+            <div class="text-[11px] text-gray-500">${r.reason}</div>
+        </div>
+        <div class="text-right shrink-0">
+            <div class="text-sm font-bold text-arcade-cyan">−${_fmtGB(r.estimated_saved_mb)}</div>
+            <div class="text-[11px] ${confColors[r.confidence] || ''}">${r.estimated_saved_pct}% · ${confLabel}</div>
+        </div>
+        <button onclick="queueCandidate('${enc}')"
+                class="shrink-0 px-3 py-1.5 rounded text-xs font-bold bg-white/10 hover:bg-arcade-cyan/30">
+            In Queue
+        </button>
+    </div>`;
+}
+
+function _renderCandidates(grid) {
+    if (!candState.results.length) {
+        grid.innerHTML = _candHeader() +
+            '<div class="col-span-full p-8 text-center text-gray-400">Keine Kandidaten — Bibliothek sieht gut optimiert aus. 🎉</div>';
+        return;
+    }
+    grid.innerHTML = _candHeader() + candState.results.map(_candRow).join('');
+}
+
+function setCandidatesCodec(codec) {
+    candState.codec = codec;
+    renderCandidatesView();
+}
+
+function toggleCandidateSelect(encodedPath) {
+    const p = decodeURIComponent(encodedPath);
+    if (candState.selected.has(p)) candState.selected.delete(p);
+    else candState.selected.add(p);
+    const btn = document.getElementById('candQueueSelectedBtn');
+    if (btn) btn.textContent = `Auswahl in Queue (${candState.selected.size})`;
+}
+
+function _queuePaths(paths) {
+    let queued = 0, skipped = 0;
+    const requests = paths.map(p =>
+        fetch('/api/queue/add', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ file_path: p, codec: candState.codec })
+        }).then(r => r.json())
+          .then(d => { if (d.success) queued++; else skipped++; })
+          .catch(() => { skipped++; })
+    );
+    Promise.all(requests).then(() => {
+        if (typeof showToast === 'function') {
+            showToast(`${queued} eingereiht${skipped ? `, ${skipped} übersprungen` : ''}`,
+                      skipped ? 'warning' : 'success');
+        }
+        renderCandidatesView();  // queued files drop out server-side
+    });
+}
+
+function queueCandidate(encodedPath) {
+    _queuePaths([decodeURIComponent(encodedPath)]);
+}
+
+function queueSelectedCandidates() {
+    if (!candState.selected.size) {
+        if (typeof showToast === 'function') showToast('Nichts ausgewählt', 'warning');
+        return;
+    }
+    _queuePaths([...candState.selected]);
+}

--- a/arcade_scanner/server/static/candidates.js
+++ b/arcade_scanner/server/static/candidates.js
@@ -52,7 +52,7 @@ function _candHeader() {
         <div class="flex flex-wrap items-center gap-4">
             <div>
                 <div class="text-2xl font-bold text-arcade-cyan">~${_fmtGB(s.total_estimated_saved_mb)}</div>
-                <div class="text-xs text-gray-400">geschätzte Ersparnis · ${s.total_files} Kandidaten
+                <div class="text-xs text-gray-400">bis zu ${_fmtGB(s.total_estimated_saved_mb)} Ersparnis möglich (Schätzung) · ${s.total_files} Kandidaten
                      · ${s.history_based} mit echter Encode-Historie</div>
             </div>
             <div class="flex items-center gap-2 ml-auto">

--- a/arcade_scanner/server/static/filter_engine.js
+++ b/arcade_scanner/server/static/filter_engine.js
@@ -117,8 +117,8 @@ function setSort(s) {
  */
 function filterAndSort(scrollToTop = false) {
     try {
-        // Duplicates mode has its own rendering logic
-        if (workspaceMode === 'duplicates') {
+        // Duplicates/Candidates modes have their own rendering logic
+        if (workspaceMode === 'duplicates' || workspaceMode === 'candidates') {
             return;
         }
 
@@ -298,7 +298,7 @@ function filterAndSort(scrollToTop = false) {
         if (sizeEl) sizeEl.innerText = formatSize(tSize);
 
         // Update Quick Stats Ribbon
-        if (workspaceMode !== 'optimized' && workspaceMode !== 'duplicates') {
+        if (workspaceMode !== 'optimized' && workspaceMode !== 'duplicates' && workspaceMode !== 'candidates') {
             // Stats are now updated during the filter loop pass
         } else {
             const ribbon = document.getElementById('quickStatsRibbon');
@@ -325,7 +325,7 @@ function _updateQuickStats(stats, workspaceMode) {
     const ribbon = document.getElementById('quickStatsRibbon');
     if (!ribbon) return;
 
-    if (workspaceMode === 'optimized' || workspaceMode === 'duplicates') {
+    if (workspaceMode === 'optimized' || workspaceMode === 'duplicates' || workspaceMode === 'candidates') {
         ribbon.style.display = 'none';
         return;
     }

--- a/arcade_scanner/server/static/workspace.js
+++ b/arcade_scanner/server/static/workspace.js
@@ -63,7 +63,8 @@ function setWorkspaceMode(mode, preserveCollection = false) {
             optimized: { accent: '#00ffd0', bg: 'rgba(0, 255, 208, 0.05)' },
             review: { accent: '#00ffd0', bg: 'rgba(0, 255, 208, 0.05)' },
             vault: { accent: '#8F0177', bg: 'rgba(143, 1, 119, 0.05)' },
-            duplicates: { accent: '#a855f7', bg: 'rgba(168, 85, 247, 0.05)' }
+            duplicates: { accent: '#a855f7', bg: 'rgba(168, 85, 247, 0.05)' },
+            candidates: { accent: '#F4B342', bg: 'rgba(244, 179, 66, 0.05)' }
         };
         const colors = wsColors[mode] || wsColors.lobby;
         const wsIndicator = document.querySelector('.workspace-indicator');
@@ -86,8 +87,8 @@ function setWorkspaceMode(mode, preserveCollection = false) {
             treemap.classList.add('animating');
         }
 
-        // Special handling for duplicates mode
-        if (mode === 'duplicates') {
+        // Special handling for duplicates/candidates modes
+        if (mode === 'duplicates' || mode === 'candidates') {
             // Ensure grid is visible (might be hidden from treemap mode)
             const videoGrid = document.getElementById('videoGrid');
             const treemapContainer = document.getElementById('treemapContainer');
@@ -96,9 +97,10 @@ function setWorkspaceMode(mode, preserveCollection = false) {
             if (treemapContainer) treemapContainer.style.display = 'none';
             if (loadingSentinel) loadingSentinel.style.display = 'none';
 
-            renderDuplicatesView();
+            if (mode === 'duplicates') renderDuplicatesView();
+            else renderCandidatesView();
         } else {
-            // Restore sentinel for infinite scroll (may have been hidden by duplicates mode)
+            // Restore sentinel for infinite scroll (may have been hidden by duplicates/candidates mode)
             const loadingSentinel = document.getElementById('loadingSentinel');
             if (loadingSentinel) loadingSentinel.style.display = '';
 
@@ -323,6 +325,7 @@ function updateURL() {
         else if (workspaceMode === 'favorites') path = '/favorites';
         else if (workspaceMode === 'vault') path = '/vault';
         else if (workspaceMode === 'duplicates') path = '/duplicates';
+        else if (workspaceMode === 'candidates') path = '/candidates';
         else if (path.startsWith('/collections/')) { } // Keep existing path for collections
         else path = '/lobby';
 
@@ -371,6 +374,7 @@ function loadFromURL() {
     else if (path === '/review') mode = 'optimized';
     else if (path === '/vault') mode = 'vault';
     else if (path === '/duplicates') mode = 'duplicates';
+    else if (path === '/candidates') mode = 'candidates';
     else if (path === '/treeview') {
         mode = 'lobby';
         layout = 'treemap';

--- a/arcade_scanner/templates/dashboard_template.py
+++ b/arcade_scanner/templates/dashboard_template.py
@@ -205,6 +205,7 @@ def generate_html_report(results, report_file, server_port=8000):
     <script src="/static/treemap.js?v={int(time.time())}"></script>
     <script src="/static/settings.js?v={int(time.time())}"></script>
     <script src="/static/duplicates.js?v={int(time.time())}"></script>
+    <script src="/static/candidates.js?v={int(time.time())}"></script>
     <script src="/static/filter_engine.js?v={int(time.time())}"></script>
     <script src="/static/workspace.js?v={int(time.time())}"></script>
     <script src="/static/cards.js?v={int(time.time())}"></script>

--- a/arcade_scanner/templates/ui_components.py
+++ b/arcade_scanner/templates/ui_components.py
@@ -171,6 +171,7 @@ def render_navigation(theme: BaseTheme) -> str:
     {nav_btn("m-optimized", "setWorkspaceMode('optimized')", "offline_bolt", "Review", "arcade-cyan")}
     {nav_btn("m-vault", "setWorkspaceMode('vault')", "archive", "Vault", "arcade-magenta")}
     {nav_btn("m-duplicates", "setWorkspaceMode('duplicates')", "content_copy", "Duplicates", "purple")}
+    {nav_btn("m-candidates", "setWorkspaceMode('candidates')", "savings", "Kandidaten", "arcade-gold")}
 
     <!-- Smart Collections Section -->
     <div class="mt-4 border-t border-black/5 dark:border-white/5 pt-3">

--- a/docs/superpowers/plans/2026-08-07-optimizer-candidates.md
+++ b/docs/superpowers/plans/2026-08-07-optimizer-candidates.md
@@ -1,0 +1,1279 @@
+# Optimizer Candidates View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `/candidates` view ranking the library by expected re-encode savings (heuristic + real encode history), with direct add-to-queue actions.
+
+**Architecture:** A pure-logic advisor module in `arcade_scanner/core/` scores every video (bitrate-per-pixel heuristic, overridden by median real `saved_pct` from `encode_history.jsonl` when a bucket has ≥3 samples). A new session-guarded route serves the ranked list; a new frontend view (cloned from the duplicates-view pattern) renders it and queues files via the existing encoding queue. A new `optimized_at` column marks finished files.
+
+**Tech Stack:** Python stdlib + pydantic (server), vanilla JS (frontend), SQLite, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-optimizer-candidates-design.md`
+
+## Global Constraints
+
+- No new runtime dependencies (server deps stay: pydantic, Pillow, imagehash).
+- CI is blocking: `.venv/bin/ruff check .` and `.venv/bin/mypy` must pass; all new code fully type-annotated. Line length 100 (E501 ignored, but stay reasonable).
+- Tests: `.venv/bin/pytest` (testpaths = tests/). JS files must pass `node --check` (`tests/test_js_syntax.py`) and the DOM contract (`tests/test_dom_contract.py`).
+- Conventional commits with scope (`feat(web): ...`, `feat(core): ...`). Work on the feature branch (worktree), not `dev` directly.
+- Comments may be German or English.
+- `INSERT OR REPLACE` upsert semantics: every media column MUST be in `_COLUMNS` + `VideoEntry` + `_entry_to_tuple` + `_row_to_api_dict`, and per-file user state must be re-copied in the scanner merge (`manager.py`) — otherwise a rescan wipes it.
+
+---
+
+### Task 1: Advisor core — classifiers + heuristic estimate
+
+**Files:**
+- Create: `arcade_scanner/core/optimization_advisor.py`
+- Test: `tests/test_optimization_advisor.py`
+
+**Interfaces:**
+- Consumes: `CODEC_EFFICIENCY` from `arcade_scanner/core/bitrate_analyzer.py:25`; `VideoEntry` from `arcade_scanner/models/video_entry.py`.
+- Produces: `bitrate_class(kbps: float) -> str`, `resolution_class(height: int) -> str`, `estimate_heuristic(entry: VideoEntry, target_codec: str) -> tuple[float, bool] | None` (saved_pct 0–100, known-codec-pair flag), dataclass `CandidateEstimate(file_path, size_mb, codec, width, height, bitrate_mbps, thumb, estimated_saved_mb, estimated_saved_pct, confidence, source, reason)`.
+
+Note on the bucket helpers: `resolution_class`/`bitrate_class` exist in `scripts/optimizer_utils.py:22-41`. That module is deliberately import-standalone for the optimizer scripts, so we DUPLICATE the two tiny functions here and pin them with a parity test (Task decision per spec; do NOT import from `scripts/` in server code).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_optimization_advisor.py
+"""Unit tests for the optimization advisor (pure logic, no ffmpeg/fs)."""
+from arcade_scanner.core import optimization_advisor as adv
+from arcade_scanner.models.video_entry import VideoEntry
+from scripts import optimizer_utils
+
+
+def _entry(**kw) -> VideoEntry:
+    base = dict(file_path="/lib/a.mp4", size_mb=1000.0, bitrate_mbps=45.0,
+                codec="h264", width=3840, height=2160, frame_rate=30.0,
+                media_type="video")
+    base.update(kw)
+    return VideoEntry(**base)
+
+
+def test_bucket_helpers_parity_with_optimizer_utils():
+    for kbps in (0, 1000, 2499, 2500, 7999, 8000, 19999, 20000, 50000):
+        assert adv.bitrate_class(kbps) == optimizer_utils.bitrate_class(kbps)
+    for h in (0, 480, 576, 577, 720, 800, 801, 1080, 1200, 1201, 1440, 1600, 1601, 2160):
+        assert adv.resolution_class(h) == optimizer_utils.resolution_class(h)
+
+
+def test_heuristic_high_bitrate_4k_h264_saves_a_lot():
+    result = adv.estimate_heuristic(_entry(), "hevc")
+    assert result is not None
+    saved_pct, known = result
+    assert known is True
+    assert saved_pct > 60  # 45 Mbit/s 4K h264 is far above the ~12 Mbit/s reference
+
+
+def test_heuristic_lean_1080p_h264_saves_moderately():
+    result = adv.estimate_heuristic(
+        _entry(bitrate_mbps=3.5, width=1920, height=1080), "hevc")
+    assert result is not None
+    saved_pct, _ = result
+    assert 20 < saved_pct < 50  # bounded by the codec factor, not the reference
+
+
+def test_heuristic_same_codec_saves_little():
+    fat = adv.estimate_heuristic(_entry(), "hevc")
+    same = adv.estimate_heuristic(_entry(codec="hevc"), "hevc")
+    assert same is not None and fat is not None
+    assert same[0] < fat[0]
+
+
+def test_heuristic_av1_target_beats_hevc_target():
+    h = adv.estimate_heuristic(_entry(), "hevc")
+    a = adv.estimate_heuristic(_entry(), "av1")
+    assert a is not None and h is not None
+    assert a[0] >= h[0]
+
+
+def test_heuristic_unknown_codec_pair_flagged():
+    result = adv.estimate_heuristic(_entry(codec="prores"), "hevc")
+    assert result is not None
+    assert result[1] is False
+
+
+def test_heuristic_missing_data_returns_none():
+    assert adv.estimate_heuristic(_entry(bitrate_mbps=0.0), "hevc") is None
+    assert adv.estimate_heuristic(_entry(height=0), "hevc") is None
+
+
+def test_heuristic_savings_capped():
+    result = adv.estimate_heuristic(_entry(bitrate_mbps=200.0), "hevc")
+    assert result is not None
+    assert result[0] <= 85.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_optimization_advisor.py -v`
+Expected: FAIL / errors with "No module named 'arcade_scanner.core.optimization_advisor'"
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# arcade_scanner/core/optimization_advisor.py
+"""Optimization advisor — ranks videos by expected savings from re-encoding.
+
+Pure logic (no ffmpeg/subprocess): unit-testable, consumed by the
+/api/candidates route. Heuristic baseline from bitrate-per-resolution +
+codec efficiency; overridden by real results from encode_history.jsonl
+(written by scripts/video_optimizer.py) when a bucket has enough samples.
+"""
+from __future__ import annotations
+
+import json
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..models.video_entry import VideoEntry
+from .bitrate_analyzer import CODEC_EFFICIENCY
+
+DEFAULT_HISTORY_PATH = Path.home() / ".arcade-scanner" / "logs" / "encode_history.jsonl"
+
+# --- bucket helpers -------------------------------------------------------
+# Deliberately duplicated from scripts/optimizer_utils.py (that module stays
+# import-standalone for the optimizer scripts); parity is pinned by
+# tests/test_optimization_advisor.py::test_bucket_helpers_parity_with_optimizer_utils.
+
+
+def bitrate_class(kbps: float) -> str:
+    if kbps < 2500:
+        return "low"
+    if kbps < 8000:
+        return "med"
+    if kbps < 20000:
+        return "high"
+    return "ultra"
+
+
+def resolution_class(height: int) -> str:
+    if height <= 576:
+        return "sd"
+    if height <= 800:
+        return "720"
+    if height <= 1200:
+        return "1080"
+    if height <= 1600:
+        return "1440"
+    return "2160"
+
+
+# --- heuristic ------------------------------------------------------------
+
+# Reference bitrates (kbps) for a well-compressed HEVC encode at ~30 fps.
+_REF_KBPS = {"sd": 1500.0, "720": 2500.0, "1080": 4000.0, "1440": 8000.0, "2160": 12000.0}
+_AV1_REF_FACTOR = 0.85    # AV1 hits the same quality a bit leaner
+_SAME_CODEC_EFF = 0.85    # re-encoding within the same codec gains little
+_DEFAULT_EFF = 0.65       # unknown source codec: assume h264-like gains
+_MAX_SAVED_PCT = 85.0     # never predict more than this
+_TARGET_ALIASES = {"hevc": {"hevc", "h265"}, "av1": {"av1"}}
+
+
+def _codec_efficiency(source_codec: str, target_codec: str) -> tuple[float, bool]:
+    """(bitrate multiplier source→target, is the pair actually known?)."""
+    src = (source_codec or "").lower()
+    if src in _TARGET_ALIASES.get(target_codec, {target_codec}):
+        return _SAME_CODEC_EFF, True
+    eff = CODEC_EFFICIENCY.get((src, target_codec))
+    if eff is not None:
+        return eff, True
+    return _DEFAULT_EFF, False
+
+
+def estimate_heuristic(entry: VideoEntry, target_codec: str) -> Optional[tuple[float, bool]]:
+    """Estimated saved percentage (0-100) for re-encoding `entry`.
+
+    Returns (saved_pct, known_codec_pair) or None when the entry lacks the
+    metadata to say anything (no bitrate / no height from ffprobe).
+    """
+    source_kbps = (entry.bitrate_mbps or 0.0) * 1000.0
+    height = entry.height or 0
+    if source_kbps <= 0 or height <= 0:
+        return None
+
+    eff, known = _codec_efficiency(entry.codec or "", target_codec)
+
+    ref = _REF_KBPS[resolution_class(height)]
+    if target_codec == "av1":
+        ref *= _AV1_REF_FACTOR
+    fps = entry.frame_rate or 0.0
+    if fps > 0:
+        ref *= min(max(fps / 30.0, 0.5), 2.0)
+
+    # Predicted output: codec factor applied to the source, but never above
+    # what a clean target-codec encode needs at this resolution (`ref`).
+    predicted_kbps = min(source_kbps * eff, max(ref, source_kbps * (1 - _MAX_SAVED_PCT / 100)))
+    saved_pct = max(0.0, (1.0 - predicted_kbps / source_kbps) * 100.0)
+    return min(saved_pct, _MAX_SAVED_PCT), known
+
+
+@dataclass
+class CandidateEstimate:
+    file_path: str
+    size_mb: float
+    codec: str
+    width: int
+    height: int
+    bitrate_mbps: float
+    thumb: str
+    estimated_saved_mb: float
+    estimated_saved_pct: float
+    confidence: str  # "high" | "medium" | "low"
+    source: str      # "history" | "heuristic"
+    reason: str
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_optimization_advisor.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+.venv/bin/ruff check arcade_scanner/core/optimization_advisor.py tests/test_optimization_advisor.py
+.venv/bin/mypy arcade_scanner/core/optimization_advisor.py
+git add arcade_scanner/core/optimization_advisor.py tests/test_optimization_advisor.py
+git commit -m "feat(core): optimization advisor — heuristic savings estimate"
+```
+
+---
+
+### Task 2: Advisor core — encode history override
+
+**Files:**
+- Modify: `arcade_scanner/core/optimization_advisor.py` (append)
+- Test: `tests/test_optimization_advisor.py` (append)
+
+**Interfaces:**
+- Consumes: history JSONL records as written by `scripts/video_optimizer.py:2043-2053`: `{ts, file, encoder, codec, height, source_kbps, q, ssim, saved_pct}`. `saved_pct` is a percentage 0–100. `codec` holds encoder-profile names like `hevc_nvenc`, `libx265`, `av1_nvenc` — target matching is by substring.
+- Produces: `class EncodeHistory` with `__init__(self, path: Path = DEFAULT_HISTORY_PATH)` and `median_saved_pct(self, target_codec: str, height: int, source_kbps: float, min_samples: int = 3) -> Optional[tuple[float, int]]` returning (median saved_pct, sample count). Reload is mtime-cached.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/test_optimization_advisor.py
+import json
+
+
+def _write_history(tmp_path, records):
+    p = tmp_path / "encode_history.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return p
+
+
+def _rec(**kw):
+    base = dict(ts="2026-08-01T00:00:00", file="x.mp4", encoder="hevc_nvenc",
+                codec="hevc_nvenc", height=2160, source_kbps=45000, q=30,
+                ssim=0.97, saved_pct=70.0)
+    base.update(kw)
+    return base
+
+
+def test_history_median_with_enough_samples(tmp_path):
+    p = _write_history(tmp_path, [_rec(saved_pct=60.0), _rec(saved_pct=70.0),
+                                  _rec(saved_pct=80.0)])
+    h = adv.EncodeHistory(p)
+    result = h.median_saved_pct("hevc", 2160, 45000)
+    assert result == (70.0, 3)
+
+
+def test_history_too_few_samples_returns_none(tmp_path):
+    p = _write_history(tmp_path, [_rec(), _rec()])
+    assert adv.EncodeHistory(p).median_saved_pct("hevc", 2160, 45000) is None
+
+
+def test_history_bucket_mismatch_returns_none(tmp_path):
+    p = _write_history(tmp_path, [_rec(), _rec(), _rec()])
+    h = adv.EncodeHistory(p)
+    assert h.median_saved_pct("hevc", 720, 45000) is None      # other resolution class
+    assert h.median_saved_pct("hevc", 2160, 3000) is None      # other bitrate class
+
+
+def test_history_target_codec_matching(tmp_path):
+    p = _write_history(tmp_path, [
+        _rec(codec="av1_nvenc", saved_pct=80.0), _rec(codec="av1_nvenc", saved_pct=80.0),
+        _rec(codec="av1_nvenc", saved_pct=80.0),
+        _rec(codec="libx265", saved_pct=50.0), _rec(codec="libx265", saved_pct=50.0),
+        _rec(codec="libx265", saved_pct=50.0),
+    ])
+    h = adv.EncodeHistory(p)
+    assert h.median_saved_pct("av1", 2160, 45000) == (80.0, 3)
+    assert h.median_saved_pct("hevc", 2160, 45000) == (50.0, 3)
+
+
+def test_history_corrupt_lines_and_missing_file(tmp_path):
+    p = tmp_path / "encode_history.jsonl"
+    p.write_text('not json\n{"broken": \n' + json.dumps(_rec()) + "\n", encoding="utf-8")
+    assert adv.EncodeHistory(p).median_saved_pct("hevc", 2160, 45000) is None  # 1 < 3
+    missing = adv.EncodeHistory(tmp_path / "nope.jsonl")
+    assert missing.median_saved_pct("hevc", 2160, 45000) is None
+
+
+def test_history_mtime_cache_reloads_on_change(tmp_path):
+    p = _write_history(tmp_path, [_rec(), _rec(), _rec()])
+    h = adv.EncodeHistory(p)
+    assert h.median_saved_pct("hevc", 2160, 45000) is not None
+    import os
+    _write_history(tmp_path, [_rec(saved_pct=10.0)] * 3)
+    os.utime(p, (1, 1))  # force a different mtime either way
+    assert h.median_saved_pct("hevc", 2160, 45000) == (10.0, 3)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_optimization_advisor.py -k history -v`
+Expected: FAIL with "has no attribute 'EncodeHistory'"
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# append to arcade_scanner/core/optimization_advisor.py
+
+# History `codec` holds encoder-profile names (hevc_nvenc, libx265, av1_nvenc…);
+# match the requested target codec by substring.
+_TARGET_SUBSTRINGS = {"hevc": ("hevc", "265"), "av1": ("av1",)}
+
+
+class EncodeHistory:
+    """mtime-cached reader over encode_history.jsonl (best-effort, never raises)."""
+
+    def __init__(self, path: Path = DEFAULT_HISTORY_PATH) -> None:
+        self.path = path
+        self._mtime: float = -1.0
+        self._records: list[dict] = []
+
+    def _load(self) -> list[dict]:
+        try:
+            mtime = self.path.stat().st_mtime
+        except OSError:
+            self._records = []
+            self._mtime = -1.0
+            return self._records
+        if mtime == self._mtime:
+            return self._records
+        records: list[dict] = []
+        try:
+            with open(self.path, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(rec, dict) and rec.get("saved_pct") is not None:
+                        records.append(rec)
+        except OSError:
+            records = []
+        self._records = records
+        self._mtime = mtime
+        return self._records
+
+    def median_saved_pct(self, target_codec: str, height: int, source_kbps: float,
+                         min_samples: int = 3) -> Optional[tuple[float, int]]:
+        """Median real saved_pct for the (target, resolution class, bitrate class) bucket."""
+        substrings = _TARGET_SUBSTRINGS.get(target_codec, (target_codec,))
+        want = (resolution_class(height), bitrate_class(source_kbps))
+        samples: list[float] = []
+        for rec in self._load():
+            codec_str = f"{rec.get('codec', '')}{rec.get('encoder', '')}".lower()
+            if not any(s in codec_str for s in substrings):
+                continue
+            try:
+                key = (resolution_class(int(rec.get("height", 0))),
+                       bitrate_class(float(rec.get("source_kbps", 0))))
+                if key == want:
+                    samples.append(float(rec["saved_pct"]))
+            except (TypeError, ValueError):
+                continue
+        if len(samples) < min_samples:
+            return None
+        return (float(statistics.median(samples)), len(samples))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_optimization_advisor.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+.venv/bin/ruff check arcade_scanner tests
+.venv/bin/mypy arcade_scanner/core/optimization_advisor.py
+git add arcade_scanner/core/optimization_advisor.py tests/test_optimization_advisor.py
+git commit -m "feat(core): encode-history override for savings estimates"
+```
+
+---
+
+### Task 3: Advisor core — build_candidates (ranking + exclusions + summary)
+
+**Files:**
+- Modify: `arcade_scanner/core/optimization_advisor.py` (append)
+- Test: `tests/test_optimization_advisor.py` (append)
+
+**Interfaces:**
+- Consumes: Tasks 1+2 (`estimate_heuristic`, `EncodeHistory`, `CandidateEstimate`); `VideoEntry.optimized_at` (Task 4 adds it — until then `getattr(entry, "optimized_at", 0)` is used, keep that spelling so Task 3 works standalone).
+- Produces: `build_candidates(entries: list[VideoEntry], target_codec: str, history: EncodeHistory, exclude_paths: set[str], limit: int = 100) -> dict` returning `{"summary": {"total_files", "total_estimated_saved_mb", "history_based"}, "results": [dict, ...]}` (results are `CandidateEstimate.__dict__` copies, sorted by `estimated_saved_mb` desc). Summary totals cover ALL candidates, results are capped at `limit`. `MIN_LISTED_SAVED_PCT = 10.0`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/test_optimization_advisor.py
+
+def _empty_history(tmp_path):
+    return adv.EncodeHistory(tmp_path / "none.jsonl")
+
+
+def test_build_candidates_sorted_by_absolute_mb(tmp_path):
+    entries = [
+        _entry(file_path="/lib/small.mp4", size_mb=100.0),            # ~same pct, less MB
+        _entry(file_path="/lib/big.mp4", size_mb=8000.0),
+        _entry(file_path="/lib/lean.mp4", size_mb=5000.0, bitrate_mbps=1.2,
+               width=1280, height=720),                                # < 10% → dropped
+    ]
+    out = adv.build_candidates(entries, "hevc", _empty_history(tmp_path), set())
+    paths = [r["file_path"] for r in out["results"]]
+    assert paths == ["/lib/big.mp4", "/lib/small.mp4"]
+    assert out["results"][0]["estimated_saved_mb"] > out["results"][1]["estimated_saved_mb"]
+
+
+def test_build_candidates_exclusions(tmp_path):
+    entries = [
+        _entry(file_path="/lib/queued.mp4"),
+        _entry(file_path="/lib/done.mp4", optimized_at=1723000000),
+        _entry(file_path="/lib/photo.jpg", media_type="image"),
+        _entry(file_path="/lib/nodata.mp4", bitrate_mbps=0.0),
+        _entry(file_path="/lib/ok.mp4"),
+    ]
+    out = adv.build_candidates(entries, "hevc", _empty_history(tmp_path),
+                               exclude_paths={"/lib/queued.mp4"})
+    assert [r["file_path"] for r in out["results"]] == ["/lib/ok.mp4"]
+
+
+def test_build_candidates_history_beats_heuristic(tmp_path):
+    p = _write_history(tmp_path, [_rec(saved_pct=40.0), _rec(saved_pct=42.0),
+                                  _rec(saved_pct=44.0)])
+    out = adv.build_candidates([_entry()], "hevc", adv.EncodeHistory(p), set())
+    r = out["results"][0]
+    assert r["source"] == "history"
+    assert r["confidence"] == "high"
+    assert r["estimated_saved_pct"] == 42.0
+    assert r["estimated_saved_mb"] == 420.0  # 1000 MB * 42%
+    assert out["summary"]["history_based"] == 1
+
+
+def test_build_candidates_confidence_levels(tmp_path):
+    out = adv.build_candidates(
+        [_entry(file_path="/lib/known.mp4"),
+         _entry(file_path="/lib/odd.mp4", codec="prores")],
+        "hevc", _empty_history(tmp_path), set())
+    by_path = {r["file_path"]: r for r in out["results"]}
+    assert by_path["/lib/known.mp4"]["confidence"] == "medium"
+    assert by_path["/lib/odd.mp4"]["confidence"] == "low"
+    assert all(r["source"] == "heuristic" for r in out["results"])
+
+
+def test_build_candidates_summary_counts_all_but_results_capped(tmp_path):
+    entries = [_entry(file_path=f"/lib/v{i}.mp4") for i in range(5)]
+    out = adv.build_candidates(entries, "hevc", _empty_history(tmp_path), set(), limit=2)
+    assert len(out["results"]) == 2
+    assert out["summary"]["total_files"] == 5
+    assert out["summary"]["total_estimated_saved_mb"] > out["results"][0]["estimated_saved_mb"]
+
+
+def test_build_candidates_reason_mentions_codec_and_resolution(tmp_path):
+    out = adv.build_candidates([_entry()], "hevc", _empty_history(tmp_path), set())
+    reason = out["results"][0]["reason"]
+    assert "h264" in reason.lower()
+    assert "2160" in reason or "4k" in reason.lower()
+```
+
+Note: `_entry(optimized_at=...)` requires `VideoEntry` to tolerate the extra
+field — its `model_config` has `extra="ignore"`, so before Task 4 the value is
+dropped and `getattr(entry, "optimized_at", 0)` returns 0. That makes
+`test_build_candidates_exclusions` FAIL on the `/lib/done.mp4` line until
+Task 4 lands. Mark exactly that test with
+`@pytest.mark.xfail(reason="optimized_at field lands in Task 4", strict=False)`
+and REMOVE the marker in Task 4 (`import pytest` at the top if not present).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_optimization_advisor.py -k build_candidates -v`
+Expected: FAIL with "has no attribute 'build_candidates'"
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# append to arcade_scanner/core/optimization_advisor.py
+
+MIN_LISTED_SAVED_PCT = 10.0
+
+
+def _reason(entry: VideoEntry, saved_pct: float, source: str, samples: int) -> str:
+    codec = (entry.codec or "unknown").upper().replace("H264", "H.264")
+    res = f"{entry.height}p" if (entry.height or 0) > 0 else "?"
+    rate = f"{entry.bitrate_mbps:.1f} Mbit/s"
+    if source == "history":
+        return f"{codec}, {res}, {rate} — {samples} echte Encodes in dieser Klasse"
+    return f"{codec}, {res}, {rate} — deutlich über Referenz"
+
+
+def build_candidates(entries: list[VideoEntry], target_codec: str,
+                     history: EncodeHistory, exclude_paths: set[str],
+                     limit: int = 100) -> dict:
+    """Rank re-encode candidates by absolute expected savings (MB, desc)."""
+    candidates: list[CandidateEstimate] = []
+    for entry in entries:
+        if entry.media_type != "video":
+            continue
+        if getattr(entry, "optimized_at", 0):
+            continue
+        if entry.file_path in exclude_paths:
+            continue
+        heur = estimate_heuristic(entry, target_codec)
+        if heur is None:
+            continue
+        saved_pct, known_pair = heur
+        source = "heuristic"
+        confidence = "medium" if known_pair else "low"
+        samples = 0
+        hist = history.median_saved_pct(
+            target_codec, entry.height or 0, (entry.bitrate_mbps or 0.0) * 1000.0)
+        if hist is not None:
+            saved_pct, samples = hist
+            source, confidence = "history", "high"
+        if saved_pct < MIN_LISTED_SAVED_PCT:
+            continue
+        candidates.append(CandidateEstimate(
+            file_path=entry.file_path,
+            size_mb=entry.size_mb,
+            codec=entry.codec or "unknown",
+            width=entry.width or 0,
+            height=entry.height or 0,
+            bitrate_mbps=entry.bitrate_mbps or 0.0,
+            thumb=entry.thumb or "",
+            estimated_saved_mb=round(entry.size_mb * saved_pct / 100.0, 1),
+            estimated_saved_pct=round(saved_pct, 1),
+            confidence=confidence,
+            source=source,
+            reason=_reason(entry, saved_pct, source, samples),
+        ))
+
+    candidates.sort(key=lambda c: c.estimated_saved_mb, reverse=True)
+    return {
+        "summary": {
+            "total_files": len(candidates),
+            "total_estimated_saved_mb": round(sum(c.estimated_saved_mb for c in candidates), 1),
+            "history_based": sum(1 for c in candidates if c.source == "history"),
+        },
+        "results": [c.__dict__.copy() for c in candidates[:limit]],
+    }
+```
+
+- [ ] **Step 4: Run tests — all pass except the marked xfail**
+
+Run: `.venv/bin/pytest tests/test_optimization_advisor.py -v`
+Expected: PASS, with `test_build_candidates_exclusions` XFAIL (removed in Task 4)
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+.venv/bin/ruff check arcade_scanner tests
+.venv/bin/mypy arcade_scanner/core/optimization_advisor.py
+git add arcade_scanner/core/optimization_advisor.py tests/test_optimization_advisor.py
+git commit -m "feat(core): build_candidates ranking with exclusions and summary"
+```
+
+---
+
+### Task 4: `optimized_at` column end-to-end
+
+**Files:**
+- Modify: `arcade_scanner/models/video_entry.py` (add field after `original_path`)
+- Modify: `arcade_scanner/database/sqlite_store.py` (`_COLUMNS`, `_create_table` migration, `_entry_to_tuple`, `_row_to_api_dict`; new method `get_active_queue_paths`)
+- Modify: `arcade_scanner/scanner/manager.py:239-243` (merge block)
+- Modify: `arcade_scanner/server/routes/files.py:179` (`_handle_mark_optimized`)
+- Test: `tests/test_sqlite_store.py` (append), `tests/test_routes_files.py` (append), `tests/test_optimization_advisor.py` (remove xfail marker)
+
+**Interfaces:**
+- Produces: `VideoEntry.optimized_at: Optional[int] = 0` (unix timestamp, 0 = never); `SQLiteStore.get_active_queue_paths() -> set[str]` (file_paths with queue status pending/downloading/encoding/uploading). Task 5 consumes both.
+
+**CRITICAL:** `upsert` is `INSERT OR REPLACE` over `_COLUMNS` — the column must be in `_COLUMNS`, `_entry_to_tuple`, `_row_to_api_dict` AND be re-copied from `cached_entry` in the scanner merge, or every rescan resets it (same pattern as `favorite`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Follow the existing fixture style in `tests/test_sqlite_store.py` (it builds a store against a tmp dir — reuse its fixture; shown here with a representative `store` fixture name, adapt to the file's actual one):
+
+```python
+# append to tests/test_sqlite_store.py
+
+def test_optimized_at_roundtrip(store):
+    from arcade_scanner.models.video_entry import VideoEntry
+    e = VideoEntry(file_path="/lib/a.mp4", size_mb=10.0, optimized_at=1723000000)
+    store.upsert(e)
+    got = store.get("/lib/a.mp4")
+    assert got is not None
+    assert got.optimized_at == 1723000000
+
+
+def test_optimized_at_defaults_to_zero(store):
+    from arcade_scanner.models.video_entry import VideoEntry
+    store.upsert(VideoEntry(file_path="/lib/b.mp4", size_mb=10.0))
+    got = store.get("/lib/b.mp4")
+    assert got is not None
+    assert got.optimized_at == 0
+
+
+def test_get_active_queue_paths(store):
+    from arcade_scanner.models.video_entry import VideoEntry
+    store.upsert(VideoEntry(file_path="/lib/q.mp4", size_mb=10.0))
+    job_id = store.queue_encode("/lib/q.mp4", size_bytes=1, target_codec="hevc")
+    assert job_id is not None
+    assert store.get_active_queue_paths() == {"/lib/q.mp4"}
+    store.update_job_status(job_id, "done")
+    assert store.get_active_queue_paths() == set()
+
+
+def test_optimized_at_migration_on_existing_db(patch_config, tmp_path):
+    """A pre-existing DB without the column gets it via ALTER TABLE on open."""
+    import sqlite3
+
+    from arcade_scanner.database.sqlite_store import _COLUMNS, SQLiteStore
+    db_file = tmp_path / "media_library.db"
+    legacy_cols = ", ".join(
+        f"{name} {typedef}" for name, typedef in _COLUMNS if name != "optimized_at")
+    conn = sqlite3.connect(db_file)
+    conn.execute(f"CREATE TABLE media ({legacy_cols})")
+    conn.execute("INSERT INTO media (file_path, size_mb) VALUES ('/lib/old.mp4', 5.0)")
+    conn.commit()
+    conn.close()
+
+    s = SQLiteStore()
+    s._ensure_connection()
+    entry = s.get("/lib/old.mp4")
+    assert entry is not None
+    assert entry.optimized_at == 0
+```
+
+```python
+# append to tests/test_routes_files.py, inside class TestMarkOptimized
+# (uses the file's existing FakeHandler / FakeDB / run_route helpers)
+
+    def test_existing_entry_gets_optimized_timestamp(self):
+        entry = VideoEntry(FilePath="/media/a.mp4", Size_MB=10.0, Status="HIGH")
+        db = FakeDB([entry])
+        handler = FakeHandler("/api/mark_optimized?path=/media/a.mp4")
+
+        run_route(handler, fake_db=db)
+
+        assert db.upserted[0].status == "OK"
+        assert db.upserted[0].optimized_at > 0
+        assert handler.status == 204
+
+    def test_new_entry_gets_optimized_timestamp(self):
+        db = FakeDB()
+        handler = FakeHandler("/api/mark_optimized?path=/media/new.mp4")
+
+        with patch("arcade_scanner.server.routes.files.os.path.getsize",
+                   return_value=5 * 1024 * 1024):
+            run_route(handler, fake_db=db)
+
+        assert db.upserted[0].optimized_at > 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_sqlite_store.py -k optimized -v` and `-k active_queue`
+Expected: FAIL (unknown field / missing method)
+
+- [ ] **Step 3: Implement**
+
+`arcade_scanner/models/video_entry.py` — after the `original_path` field:
+
+```python
+    optimized_at: Optional[int] = Field(0, description="Unix timestamp of last successful optimization (0 = never)")
+```
+
+`arcade_scanner/database/sqlite_store.py`:
+
+1. `_COLUMNS`: append `("optimized_at", "INTEGER DEFAULT 0"),` after `("original_path", ...)`.
+2. `_create_table` — after the `original_path` migration block, same pattern:
+
+```python
+        # Migration: optimized_at marks files already processed by the optimizer
+        try:
+            conn.execute("ALTER TABLE media ADD COLUMN optimized_at INTEGER DEFAULT 0")
+        except Exception:
+            pass  # Already exists
+```
+
+3. `_entry_to_tuple` — append `entry.optimized_at or 0,` as the last tuple element (order must match `_COLUMNS`).
+4. `_row_to_api_dict` — add `"optimized_at": row["optimized_at"] or 0,` after the `"OriginalPath"` line.
+5. New method next to `get_queue_status`:
+
+```python
+    def get_active_queue_paths(self) -> set:
+        """file_paths of jobs currently pending or being processed."""
+        conn = self._ensure_connection()
+        with self._write_lock:
+            cursor = conn.execute(
+                "SELECT file_path FROM encoding_queue "
+                "WHERE status IN ('pending', 'downloading', 'encoding', 'uploading')"
+            )
+            return {self._decode_safe_path(row["file_path"]) for row in cursor}
+```
+
+`arcade_scanner/scanner/manager.py` — in the `if cached_entry:` merge block (next to `entry.favorite = cached_entry.favorite`):
+
+```python
+                        entry.optimized_at = cached_entry.optimized_at
+```
+
+`arcade_scanner/server/routes/files.py` `_handle_mark_optimized` — set the timestamp in both branches (existing entry and newly created one), next to the `status = "OK"` assignments:
+
+```python
+        import time as _time
+        now = int(_time.time())
+        entry = db.get(abs_path)
+        if entry:
+            entry.status = "OK"
+            entry.optimized_at = now
+        else:
+            ...
+            entry = VideoEntry(file_path=abs_path, size_mb=size_mb, Status="OK",
+                               optimized_at=now)
+```
+
+(If `time` is already imported at module top, use it directly instead of the local import.)
+
+Also: remove the `@pytest.mark.xfail` marker from
+`test_build_candidates_exclusions` in `tests/test_optimization_advisor.py`.
+
+- [ ] **Step 4: Run the full affected suites**
+
+Run: `.venv/bin/pytest tests/test_sqlite_store.py tests/test_routes_files.py tests/test_optimization_advisor.py tests/test_scanner_manager.py -v`
+Expected: all PASS (including the formerly-xfailed exclusion test), no regressions in scanner/store suites
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+.venv/bin/ruff check arcade_scanner tests
+.venv/bin/mypy arcade_scanner
+git add -A arcade_scanner tests
+git commit -m "feat(db): optimized_at column, rescan-safe, set by mark_optimized"
+```
+
+---
+
+### Task 5: `/api/candidates` route
+
+**Files:**
+- Create: `arcade_scanner/server/routes/candidates.py`
+- Modify: `arcade_scanner/server/api_handler.py` (GET dispatch around line 397; `spa_routes` line 438)
+- Test: `tests/test_routes_candidates.py`
+
+**Interfaces:**
+- Consumes: `build_candidates`, `EncodeHistory`, `DEFAULT_HISTORY_PATH` (Tasks 1–3); `db.get_all()`, `db.get_active_queue_paths()` (Task 4); `user_db.get_user(name).data.vaulted: List[str]` (`arcade_scanner/models/user.py:81`).
+- Produces: `GET /api/candidates?codec=hevc|av1&limit=N` → JSON from `build_candidates`. 401 without session, 400 on invalid codec. `handle_get(handler) -> bool` wired BEFORE `files.handle_get` (files is greedy).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_routes_candidates.py
+"""Route tests for /api/candidates — FakeHandler pattern from test_routes_queue.py."""
+import json
+from unittest.mock import MagicMock, patch
+
+from arcade_scanner.models.video_entry import VideoEntry
+from arcade_scanner.server.routes import candidates
+
+
+class FakeHandler:
+    def __init__(self, path, user="alice"):
+        self.path = path
+        self._user = user
+        self.wfile = MagicMock()
+        self.status = None
+        self.error = None
+        self.headers = {}
+
+    def get_current_user(self):
+        return self._user
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_error(self, code, message=""):
+        self.error = code
+
+    def send_header(self, key, value):
+        pass
+
+    def end_headers(self):
+        pass
+
+    def body(self):
+        raw = b"".join(c.args[0] for c in self.wfile.write.call_args_list)
+        return json.loads(raw)
+
+
+class FakeDB:
+    def __init__(self, entries=(), active=()):
+        self._entries = list(entries)
+        self._active = set(active)
+
+    def get_all(self):
+        return self._entries
+
+    def get_active_queue_paths(self):
+        return self._active
+
+
+class FakeUserDB:
+    def __init__(self, vaulted=()):
+        u = MagicMock()
+        u.data.vaulted = list(vaulted)
+        self._u = u
+
+    def get_user(self, name):
+        return self._u
+
+
+def _entry(path="/lib/a.mp4", **kw):
+    base = dict(file_path=path, size_mb=1000.0, bitrate_mbps=45.0, codec="h264",
+                width=3840, height=2160, frame_rate=30.0, media_type="video")
+    base.update(kw)
+    return VideoEntry(**base)
+
+
+def run(handler, db=None, user_db=None, tmp_path=None):
+    db = db or FakeDB([_entry()])
+    user_db = user_db or FakeUserDB()
+    with patch.object(candidates, "_get_deps", return_value=(db, user_db)):
+        handled = candidates.handle_get(handler)
+    return handled
+
+
+def test_unrelated_path_not_handled():
+    assert run(FakeHandler("/api/other")) is False
+
+
+def test_requires_session():
+    h = FakeHandler("/api/candidates", user=None)
+    assert run(h) is True
+    assert h.error == 401
+
+
+def test_invalid_codec_400():
+    h = FakeHandler("/api/candidates?codec=vp9")
+    assert run(h) is True
+    assert h.error == 400
+
+
+def test_returns_ranked_results():
+    h = FakeHandler("/api/candidates?codec=hevc")
+    db = FakeDB([_entry("/lib/big.mp4", size_mb=8000.0), _entry("/lib/small.mp4", size_mb=100.0)])
+    assert run(h, db=db) is True
+    body = h.body()
+    assert body["summary"]["total_files"] == 2
+    assert [r["file_path"] for r in body["results"]] == ["/lib/big.mp4", "/lib/small.mp4"]
+
+
+def test_excludes_active_queue_and_vaulted():
+    h = FakeHandler("/api/candidates")
+    db = FakeDB([_entry("/lib/q.mp4"), _entry("/lib/v.mp4"), _entry("/lib/ok.mp4")],
+                active={"/lib/q.mp4"})
+    udb = FakeUserDB(vaulted=["/lib/v.mp4"])
+    run(h, db=db, user_db=udb)
+    assert [r["file_path"] for r in h.body()["results"]] == ["/lib/ok.mp4"]
+
+
+def test_limit_param():
+    h = FakeHandler("/api/candidates?limit=1")
+    db = FakeDB([_entry(f"/lib/v{i}.mp4") for i in range(3)])
+    run(h, db=db)
+    body = h.body()
+    assert len(body["results"]) == 1
+    assert body["summary"]["total_files"] == 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_routes_candidates.py -v`
+Expected: FAIL with "No module named ... routes.candidates"
+
+- [ ] **Step 3: Implement the route**
+
+```python
+# arcade_scanner/server/routes/candidates.py
+"""GET /api/candidates — re-encode candidates ranked by expected savings."""
+import os
+from urllib.parse import parse_qs, urlparse
+
+from arcade_scanner.core.optimization_advisor import EncodeHistory, build_candidates
+from arcade_scanner.server.response_helpers import send_json
+
+VALID_CODECS = {"hevc", "av1"}
+
+# Module-level: EncodeHistory caches by mtime, so reuse across requests.
+_history = EncodeHistory()
+
+
+def _get_deps():
+    from arcade_scanner.server.api_handler import db, user_db
+    return db, user_db
+
+
+def handle_get(handler) -> bool:
+    parsed = urlparse(handler.path)
+    if parsed.path != "/api/candidates":
+        return False
+
+    user_name = handler.get_current_user()
+    if not user_name:
+        handler.send_error(401, "Unauthorized")
+        return True
+
+    params = parse_qs(parsed.query)
+    codec = params.get("codec", ["hevc"])[0]
+    if codec not in VALID_CODECS:
+        handler.send_error(400, "Invalid codec (hevc|av1)")
+        return True
+    try:
+        limit = max(1, min(int(params.get("limit", ["100"])[0]), 500))
+    except ValueError:
+        limit = 100
+
+    try:
+        db, user_db = _get_deps()
+        exclude = set(db.get_active_queue_paths())
+        u = user_db.get_user(user_name)
+        if u and u.data.vaulted:
+            exclude.update(os.path.abspath(p) for p in u.data.vaulted)
+        payload = build_candidates(db.get_all(), codec, _history, exclude, limit)
+        send_json(handler, payload)
+    except Exception as e:
+        print(f"❌ Error building candidates: {e}")
+        handler.send_error(500, str(e))
+    return True
+```
+
+`arcade_scanner/server/api_handler.py` — two edits:
+
+1. GET dispatch (line ~397): extend the import and insert BEFORE `files.handle_get`:
+
+```python
+            from .routes import candidates, duplicates, files, queue, settings, tags
+            ...
+            if candidates.handle_get(self):
+                return
+            if files.handle_get(self):
+```
+
+2. `spa_routes` (line ~438): add `"/candidates"` to the list.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_routes_candidates.py tests/test_route_interface.py -v`
+Expected: all PASS (`test_route_interface.py` sanity-checks route modules — if it enumerates them, the new module must conform; check its assertions and follow them)
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+.venv/bin/ruff check arcade_scanner tests
+.venv/bin/mypy arcade_scanner
+git add arcade_scanner/server/routes/candidates.py arcade_scanner/server/api_handler.py tests/test_routes_candidates.py
+git commit -m "feat(web): /api/candidates endpoint with queue/vault exclusion"
+```
+
+---
+
+### Task 6: Frontend — candidates view
+
+**Files:**
+- Create: `arcade_scanner/server/static/candidates.js`
+- Modify: `arcade_scanner/templates/ui_components.py` (nav button after the duplicates entry)
+- Modify: `arcade_scanner/server/static/workspace.js` (wsColors, mode branch, updateURL, loadFromURL)
+- Modify: `arcade_scanner/server/static/filter_engine.js` (early return + ribbon suppression)
+- Modify: `arcade_scanner/templates/dashboard_template.py` (script tag after duplicates.js)
+- Modify: `tests/test_dom_contract.py` (`DYNAMIC_IDS`)
+- Test: existing static suites (`test_js_syntax.py`, `test_dom_contract.py`, `test_js_completeness.py`, `test_js_runtime_patterns.py`, `test_dashboard_template.py`)
+
+**Interfaces:**
+- Consumes: `GET /api/candidates` (Task 5); `POST /api/queue/add` with `{file_path, codec}` (existing); `showToast(msg, type)` (existing global); `videoGrid` container + duplicates-mode display toggling in `workspace.js:89-99`.
+- Produces: global functions used by onclick handlers (must be plain top-level `function` declarations so they land on `window`): `renderCandidatesView()`, `setCandidatesCodec(codec)`, `toggleCandidateSelect(encodedPath)`, `queueCandidate(encodedPath)`, `queueSelectedCandidates()`. Row IDs are dynamic with prefix `cand-`.
+
+- [ ] **Step 1: Write `candidates.js`**
+
+```javascript
+// arcade_scanner/server/static/candidates.js
+/**
+ * Candidates View — ranks the library by expected re-encode savings.
+ * Data: GET /api/candidates (see routes/candidates.py). Queueing reuses
+ * POST /api/queue/add like optimizer.js does.
+ */
+
+let candState = {
+    codec: 'hevc',
+    results: [],
+    summary: null,
+    selected: new Set(),   // file paths
+    loading: false,
+};
+
+function renderCandidatesView() {
+    const grid = document.getElementById('videoGrid');
+    if (!grid) return;
+    grid.innerHTML = '<div class="p-8 text-center text-gray-400">Analysiere Bibliothek…</div>';
+    candState.loading = true;
+
+    fetch(`/api/candidates?codec=${candState.codec}&limit=200`)
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(data => {
+            candState.results = data.results || [];
+            candState.summary = data.summary || null;
+            candState.selected.clear();
+            candState.loading = false;
+            _renderCandidates(grid);
+        })
+        .catch(err => {
+            candState.loading = false;
+            grid.innerHTML = `<div class="p-8 text-center text-red-400">Kandidaten-Analyse fehlgeschlagen: ${err.message}</div>`;
+        });
+}
+
+function _fmtGB(mb) {
+    return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
+}
+
+function _candHeader() {
+    const s = candState.summary || { total_files: 0, total_estimated_saved_mb: 0, history_based: 0 };
+    const codecBtn = (c, label) => `
+        <button onclick="setCandidatesCodec('${c}')"
+                class="px-3 py-1 rounded text-xs font-bold ${candState.codec === c
+                    ? 'bg-arcade-cyan text-black'
+                    : 'bg-white/10 text-gray-300 hover:bg-white/20'}">${label}</button>`;
+    return `
+    <div id="candidatesHeader" class="col-span-full p-4 rounded-xl bg-white/5 mb-2">
+        <div class="flex flex-wrap items-center gap-4">
+            <div>
+                <div class="text-2xl font-bold text-arcade-cyan">~${_fmtGB(s.total_estimated_saved_mb)}</div>
+                <div class="text-xs text-gray-400">geschätzte Ersparnis · ${s.total_files} Kandidaten
+                     · ${s.history_based} mit echter Encode-Historie</div>
+            </div>
+            <div class="flex items-center gap-2 ml-auto">
+                ${codecBtn('hevc', 'HEVC')}${codecBtn('av1', 'AV1')}
+                <button id="candQueueSelectedBtn" onclick="queueSelectedCandidates()"
+                        class="px-3 py-1 rounded text-xs font-bold bg-arcade-cyan/20 text-arcade-cyan hover:bg-arcade-cyan/30">
+                    Auswahl in Queue (${candState.selected.size})
+                </button>
+            </div>
+        </div>
+    </div>`;
+}
+
+function _candRow(r, idx) {
+    const enc = encodeURIComponent(r.file_path);
+    const name = r.file_path.split(/[/\\]/).pop();
+    const checked = candState.selected.has(r.file_path) ? 'checked' : '';
+    const confColors = { high: 'text-green-400', medium: 'text-yellow-400', low: 'text-gray-400' };
+    const confLabel = r.source === 'history' ? 'Historie' : 'Schätzung';
+    const thumb = r.thumb ? `<img src="/thumbnails/${r.thumb}" class="w-24 h-14 object-cover rounded" loading="lazy">`
+                          : '<div class="w-24 h-14 rounded bg-white/10"></div>';
+    return `
+    <div id="cand-${idx}" class="col-span-full flex items-center gap-3 p-2 rounded-lg bg-white/5 hover:bg-white/10">
+        <input type="checkbox" ${checked} onclick="toggleCandidateSelect('${enc}')">
+        <div class="cursor-pointer" onclick="openCinema('${enc}')">${thumb}</div>
+        <div class="min-w-0 flex-1">
+            <div class="truncate text-sm font-medium">${name}</div>
+            <div class="text-xs text-gray-400">${r.codec.toUpperCase()} · ${r.height}p · ${r.bitrate_mbps.toFixed(1)} Mbit/s · ${_fmtGB(r.size_mb)}</div>
+            <div class="text-[11px] text-gray-500">${r.reason}</div>
+        </div>
+        <div class="text-right shrink-0">
+            <div class="text-sm font-bold text-arcade-cyan">−${_fmtGB(r.estimated_saved_mb)}</div>
+            <div class="text-[11px] ${confColors[r.confidence] || ''}">${r.estimated_saved_pct}% · ${confLabel}</div>
+        </div>
+        <button onclick="queueCandidate('${enc}')"
+                class="shrink-0 px-3 py-1.5 rounded text-xs font-bold bg-white/10 hover:bg-arcade-cyan/30">
+            In Queue
+        </button>
+    </div>`;
+}
+
+function _renderCandidates(grid) {
+    if (!candState.results.length) {
+        grid.innerHTML = _candHeader() +
+            '<div class="col-span-full p-8 text-center text-gray-400">Keine Kandidaten — Bibliothek sieht gut optimiert aus. 🎉</div>';
+        return;
+    }
+    grid.innerHTML = _candHeader() + candState.results.map(_candRow).join('');
+}
+
+function setCandidatesCodec(codec) {
+    candState.codec = codec;
+    renderCandidatesView();
+}
+
+function toggleCandidateSelect(encodedPath) {
+    const p = decodeURIComponent(encodedPath);
+    if (candState.selected.has(p)) candState.selected.delete(p);
+    else candState.selected.add(p);
+    const btn = document.getElementById('candQueueSelectedBtn');
+    if (btn) btn.textContent = `Auswahl in Queue (${candState.selected.size})`;
+}
+
+function _queuePaths(paths) {
+    let queued = 0, skipped = 0;
+    const requests = paths.map(p =>
+        fetch('/api/queue/add', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ file_path: p, codec: candState.codec })
+        }).then(r => r.json())
+          .then(d => { if (d.success) queued++; else skipped++; })
+          .catch(() => { skipped++; })
+    );
+    Promise.all(requests).then(() => {
+        if (typeof showToast === 'function') {
+            showToast(`${queued} eingereiht${skipped ? `, ${skipped} übersprungen` : ''}`,
+                      skipped ? 'warning' : 'success');
+        }
+        renderCandidatesView();  // queued files drop out server-side
+    });
+}
+
+function queueCandidate(encodedPath) {
+    _queuePaths([decodeURIComponent(encodedPath)]);
+}
+
+function queueSelectedCandidates() {
+    if (!candState.selected.size) {
+        if (typeof showToast === 'function') showToast('Nichts ausgewählt', 'warning');
+        return;
+    }
+    _queuePaths([...candState.selected]);
+}
+```
+
+(If `openCinema` is not the actual global to open the cinema modal for a path,
+check `cards.js`/`cinema.js` for the function the duplicates view uses for its
+thumbnail preview and call that instead — `tests/test_js_completeness.py` will
+catch an undefined reference.)
+
+- [ ] **Step 2: Wire the templates and workspace**
+
+`arcade_scanner/templates/ui_components.py` — after the duplicates nav button:
+
+```python
+    {nav_btn("m-candidates", "setWorkspaceMode('candidates')", "savings", "Kandidaten", "arcade-gold")}
+```
+
+`arcade_scanner/templates/dashboard_template.py` — after the duplicates.js script tag:
+
+```python
+    <script src="/static/candidates.js?v={int(time.time())}"></script>
+```
+
+`arcade_scanner/server/static/workspace.js`:
+
+1. `wsColors` (line ~66): add `candidates: { accent: '#F4B342', bg: 'rgba(244, 179, 66, 0.05)' }`.
+2. Mode branch (line ~89): widen the special case:
+
+```javascript
+        if (mode === 'duplicates' || mode === 'candidates') {
+            const videoGrid = document.getElementById('videoGrid');
+            const treemapContainer = document.getElementById('treemapContainer');
+            const loadingSentinel = document.getElementById('loadingSentinel');
+            if (videoGrid) videoGrid.style.display = '';
+            if (treemapContainer) treemapContainer.style.display = 'none';
+            if (loadingSentinel) loadingSentinel.style.display = 'none';
+
+            if (mode === 'duplicates') renderDuplicatesView();
+            else renderCandidatesView();
+        } else {
+```
+
+3. `updateURL` (line ~323): add `else if (workspaceMode === 'candidates') path = '/candidates';` next to the duplicates line.
+4. `loadFromURL` (line ~372): add `else if (path === '/candidates') mode = 'candidates';` next to the duplicates line.
+
+`arcade_scanner/server/static/filter_engine.js`:
+
+1. Early return (line ~301): `if (workspaceMode === 'duplicates' || workspaceMode === 'candidates') { return; }`
+2. Ribbon suppression — both places that test `workspaceMode !== 'optimized' && workspaceMode !== 'duplicates'` / `=== 'duplicates'` (lines ~301 and ~328 region): include `'candidates'` the same way.
+
+`tests/test_dom_contract.py` — extend `DYNAMIC_IDS`:
+
+```python
+    # Von candidates.js dynamisch erzeugte IDs:
+    "cand-", "candidatesHeader", "candQueueSelectedBtn",
+```
+
+(If the contract test complains about further IDs, add them to the same set —
+they are all runtime-rendered.)
+
+- [ ] **Step 3: Run the static contract suites**
+
+Run: `.venv/bin/pytest tests/test_js_syntax.py tests/test_dom_contract.py tests/test_js_completeness.py tests/test_js_runtime_patterns.py tests/test_dashboard_template.py -v`
+Expected: all PASS (fix any undefined-global or missing-ID findings they report)
+
+- [ ] **Step 4: Manual smoke test**
+
+Run `./run.sh`, open the dashboard, click "Kandidaten": header with total savings renders, rows listed, codec toggle refetches, "In Queue" shows a toast and the row disappears on refetch, URL is `/candidates` and survives reload. Verify nothing broke in Lobby/Duplicates navigation.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+.venv/bin/ruff check .
+git add arcade_scanner/server/static/candidates.js arcade_scanner/templates/ui_components.py \
+        arcade_scanner/templates/dashboard_template.py arcade_scanner/server/static/workspace.js \
+        arcade_scanner/server/static/filter_engine.js tests/test_dom_contract.py
+git commit -m "feat(web): Kandidaten-Ansicht mit Queue-Anbindung"
+```
+
+---
+
+### Task 7: Changelog + full verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]` section)
+- Modify: `ROADMAP.md` (add the feature under the planned/completed section as appropriate)
+
+- [ ] **Step 1: Update CHANGELOG.md** — add under `## [Unreleased]`:
+
+```markdown
+### Added — Optimizer Candidates View
+- **Kandidaten-Ansicht** (`/candidates`): ranks the library by expected re-encode
+  savings (bitrate-per-resolution heuristic + codec efficiency), refined by real
+  results from `encode_history.jsonl` once a resolution/bitrate class has ≥3
+  encodes. Header shows the total possible savings; rows queue directly into the
+  existing encoding queue (HEVC/AV1 toggle).
+- **`optimized_at` marker**: successful optimizations now stamp the media entry;
+  optimized files no longer appear as candidates (rescan-safe).
+```
+
+- [ ] **Step 2: Full verification**
+
+```bash
+.venv/bin/pytest
+.venv/bin/ruff check .
+.venv/bin/mypy arcade_scanner
+```
+
+Expected: everything green. Fix anything red before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md ROADMAP.md
+git commit -m "docs: changelog & roadmap for the candidates view"
+```
+
+Then finish the branch per `superpowers:finishing-a-development-branch` (PR from the feature branch into `dev`).

--- a/docs/superpowers/specs/2026-08-07-auto-tagging-design.md
+++ b/docs/superpowers/specs/2026-08-07-auto-tagging-design.md
@@ -1,0 +1,137 @@
+# Auto-Tagging Rules — Design
+
+**Date:** 2026-08-07
+**Status:** Approved design, pending implementation plan
+
+## Summary
+
+Rule-based auto-tagging: a rule is a saved Smart-Collection-style query plus a target
+tag. Rules run server-side after every scan (and on demand) and apply their tag to
+matching files. An applied tag becomes a normal user tag: removing it by hand is
+final — the rule never re-applies it (apply-once semantics).
+
+Explicitly out of scope (YAGNI): rule priorities/ordering, multiple tags per rule,
+synchronized tag removal when a file stops matching, TV/iOS client changes (tags
+arrive there via `/api/user/data` as before).
+
+## Data model
+
+- New field on `UserVideoData` (`arcade_scanner/models/user.py`):
+  `auto_tag_rules: List[Dict[str, Any]] = []`, persisted like `smart_collections`
+  in the `users.user_data` JSON blob.
+
+  Rule shape:
+
+  ```json
+  {
+    "id": "uuid",
+    "name": "GoPro-Material",
+    "tag": "gopro",
+    "criteria": { "...": "same schema as smart collection criteria (models/user.py _default_criteria)" },
+    "enabled": true
+  }
+  ```
+
+- New table in the main SQLite DB (`arcade_scanner/database/sqlite_store.py`) for
+  apply-once bookkeeping — kept out of the `user_data` blob so it scales to large
+  libraries:
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS auto_tag_applied (
+      username  TEXT NOT NULL,
+      rule_id   TEXT NOT NULL,
+      file_path TEXT NOT NULL,
+      PRIMARY KEY (username, rule_id, file_path)
+  );
+  ```
+
+  Deleting a rule deletes its rows. Deleting a media entry may leave stale rows;
+  they are harmless and can be pruned by the existing cleanup path later.
+
+## Server-side criteria evaluation
+
+New module `arcade_scanner/core/criteria_eval.py`:
+
+- `matches(entry: VideoEntry, criteria: dict, user_tags: list[str], favorite: bool) -> bool`
+- A faithful Python port of `evaluateCollectionMatch(video, criteria)`
+  (`arcade_scanner/server/static/collections.js`): include/exclude blocks
+  (status, codec, tags, resolution, orientation, media_type, format), `tagLogic`
+  any/all, `favorites`, `date` (any/relative/range), `size` (MB), `duration`
+  (sec), `search` substring.
+- Per-user fields (tags, favorite) come from `UserVideoData`, not from the global
+  `media` row.
+
+**Parity contract test:** shared JSON fixtures of `(video, criteria, expected)`
+triples; one test evaluates them via `node` against `collections.js`, the same
+fixtures run against the Python port. This mirrors the repo's existing JS/HTML
+contract-test approach and prevents the two evaluators from drifting.
+
+## Rule execution
+
+`run_auto_tag_rules(username) -> dict[rule_id, int]` (module `criteria_eval.py` or a
+small `core/auto_tagger.py`):
+
+1. Load the user's enabled rules; skip users without rules.
+2. For each rule: candidates = entries matching the criteria AND not present in
+   `auto_tag_applied` for (username, rule_id).
+3. For each candidate: merge the tag into `user.data.tags[path]` (merge, not
+   replace — do NOT go through `/api/video/tags`, which replaces the whole list;
+   write via `user_store` directly), insert the `auto_tag_applied` row.
+4. If the target tag does not exist in `available_tags`, create it with a default
+   color.
+5. Persist the user once at the end (single `add_user` write), return per-rule
+   counts.
+
+## Triggers
+
+- **Post-scan:** call the runner for all users with enabled rules at both existing
+  scan completion sites: the startup background scan (`arcade_scanner/main.py`,
+  after `run_scan()`) and `/api/rescan` (`arcade_scanner/server/routes/files.py`).
+  Defensive: exceptions are logged and never break the scan or server startup.
+- **Manual:** `POST /api/autotag/run` (session required) runs the logged-in user's
+  rules against the whole library and returns `{rule_id: newly_tagged_count}`.
+
+## API
+
+New route file `arcade_scanner/server/routes/autotag.py`, wired like the existing
+route modules; all endpoints require a session:
+
+- `GET  /api/autotag/rules` — list the user's rules
+- `POST /api/autotag/rules` — create/update/delete/toggle a rule
+  (action-style body, consistent with existing tag routes)
+- `POST /api/autotag/run` — run now, returns per-rule counts
+
+## UI
+
+- **Create — in the Query Builder** (`collections.js`): alongside "save as smart
+  collection", a save mode "Tag automatisch vergeben: ___" that POSTs a rule with
+  the currently built criteria.
+- **Manage — Settings modal**: new "Auto-Tagging" section
+  (`arcade_scanner/templates/components.py`: nav item + `content-autotagging`
+  panel; header map in `static/settings.js`): rule list with enabled toggle,
+  delete, and a "Jetzt ausführen" button showing a result toast.
+- New element IDs and any dynamically created IDs are added to
+  `tests/test_dom_contract.py` (`DYNAMIC_IDS` where applicable).
+
+## Error handling
+
+- Post-scan runner: catch-all with logging; a failing rule skips to the next rule.
+- Run endpoint: standard error responses consistent with existing routes.
+- Unknown/legacy criteria fields are ignored (same lenience as the JS evaluator).
+
+## Testing
+
+- Unit tests for `criteria_eval.py` covering every criteria dimension and
+  include/exclude combinations.
+- JS/Python parity test on shared fixtures (requires `node`, like existing
+  contract tests).
+- Route tests: CRUD + run, session enforcement (mirrors the recent queue-route
+  auth tests).
+- Apply-once semantics: tag applied, removed by user, rule re-run → not re-applied;
+  rule deleted → bookkeeping rows removed.
+- DOM contract tests updated for new IDs.
+
+## CI constraints
+
+CI runs blocking Ruff and blocking mypy: all new code must be type-annotated and
+lint-clean from the start (`pyproject.toml` mypy config with pydantic plugin).

--- a/docs/superpowers/specs/2026-08-07-embedding-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-07-embedding-foundation-design.md
@@ -1,0 +1,135 @@
+# Embedding Foundation (Similarity, Part 1 of 4) — Design
+
+**Date:** 2026-08-07
+**Status:** Approved design, pending implementation plan
+
+## Series context
+
+Part 1 of the similarity/semantic feature series:
+
+1. **Embedding foundation** (this spec) — indexer, storage, `/api/similar`
+2. "Similar videos" strip in cinema mode
+3. Theme view (offline clustering + cluster tagging)
+4. Semantic text search (needs a runtime text encoder; architecture decided then)
+
+Each part gets its own spec → plan → implementation cycle.
+
+## Summary
+
+A standalone GPU indexer computes CLIP-style embeddings for every video (and
+image) in the library and stores them in the main SQLite DB. The server — which
+gains **no new runtime dependency** — serves k-nearest-neighbour queries over the
+stored vectors via a new session-guarded endpoint. Everything runs locally
+(server and indexer share one machine: 32 GB RAM, RTX 4090); privacy model
+unchanged.
+
+Decisions made during brainstorming:
+
+- Runtime: **PyTorch + open_clip**, CUDA (CPU fallback), installed via an
+  optional dependency group — never in the server's runtime deps.
+- Sampling: **12 uniformly spaced frames** per video (5%–95% of duration),
+  per-frame embeddings **and** the normalized mean stored.
+- No pHash sequences (YAGNI): frame embeddings cover re-encode/resolution
+  similarity; exact duplicates remain the duplicate detector's job.
+- Trigger: **manual CLI run** (incremental), optional `--watch --interval N`.
+  No server-triggered indexing in part 1.
+
+## Architecture
+
+Two strictly separated sides, modeled on the optimizer:
+
+- **Indexer** — `scripts/media_indexer.py`, standalone script. Deps via
+  `pip install -e ".[indexer]"` (torch, open_clip_torch). Reads the media list
+  from the main DB, writes embeddings back directly (same machine, no polling
+  protocol).
+- **Server** — reads vectors, computes cosine similarity in pure Python
+  (2K × 512-float brute force ≈ tens of ms; no NumPy). Fully functional when no
+  index exists.
+
+## Data model
+
+Two new tables in the main SQLite DB (`sqlite_store.py` schema setup):
+
+```sql
+CREATE TABLE IF NOT EXISTS embedding_meta (
+    file_path   TEXT PRIMARY KEY,
+    model       TEXT NOT NULL,
+    dim         INTEGER NOT NULL,
+    mtime       REAL NOT NULL,
+    indexed_at  TEXT NOT NULL,
+    mean_vector BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS frame_embeddings (
+    file_path   TEXT NOT NULL,
+    frame_index INTEGER NOT NULL,
+    ts_sec      REAL NOT NULL,
+    vector      BLOB NOT NULL,
+    PRIMARY KEY (file_path, frame_index)
+);
+```
+
+- Vectors: float32 blobs (`struct`-decodable server-side), **L2-normalized on
+  write**, so similarity = dot product.
+- `model` is bookkeeping for staleness: rows written by a different model than
+  the current run are re-indexed.
+- `frame_embeddings` is written in part 1 but not yet queried (enables later
+  excerpt detection).
+
+## Indexer behaviour
+
+- Default model: open_clip **ViT-B-16** (dual encoder — keeps part 4 possible);
+  `--model` to override.
+- Per video: 12 uniform timestamps across 5%–95% of duration; frames extracted
+  via ffmpeg; batched GPU inference; store per-frame vectors + normalized mean.
+- Images (`media_type == "image"`): indexed too, as a single "frame"; same
+  tables — similarity later works for photos as well.
+- Incremental: skip entries whose `embedding_meta` row matches current `mtime`
+  **and** model; delete rows for files no longer in the media table.
+- CLI: one-shot run (default), `--watch --interval N` loop, `--rebuild` to drop
+  and re-index, optimizer-style progress output.
+- Very short videos (duration < ~2 s or fewer decodable frames than requested):
+  index whatever frames are extractable, minimum 1.
+
+## API
+
+New route file `arcade_scanner/server/routes/similar.py`, wired like existing
+route modules; session required:
+
+- `GET /api/similar?path=<file>&limit=12`
+  - Response: `{"status": "ok", "results": [{"file_path": ..., "score": ...}]}`
+    sorted by descending cosine similarity of mean vectors, excluding the query
+    file itself.
+  - Results are filtered to entries the requesting user may see (vault logic
+    consistent with existing routes).
+  - No index at all → HTTP 200 `{"status": "not_indexed"}`.
+  - Query path unknown or not indexed → 404.
+- Mean vectors are lazily loaded into an in-process cache on first request;
+  invalidated via `SQLiteStore.register_on_change` and/or a cheap staleness
+  check, so a fresh indexer run is picked up without server restart.
+
+## Error handling
+
+- Indexer: undecodable files are logged and skipped (run continues); CUDA
+  unavailable → CPU fallback with a warning; DB writes per file are atomic
+  (meta + frames in one transaction).
+- Server: malformed/missing `path` → 400; unknown path → 404; vault-filtered
+  results simply omitted.
+
+## Testing
+
+All CI tests must run **without** the ML stack installed:
+
+- Unit tests: float32 blob encode/decode, normalization, pure-Python kNN with
+  hand-built vectors (known ordering).
+- Route tests: `/api/similar` against fixture rows in the new tables — session
+  enforcement, vault filtering, `not_indexed`, 404, limit.
+- Indexer logic tests with a mocked model: timestamp sampling (5–95%, short
+  videos), incremental skip logic (mtime match, model mismatch), deleted-file
+  cleanup.
+- Schema test: new tables created on fresh and existing DBs.
+
+## CI constraints
+
+Blocking Ruff + mypy: all new code type-annotated and lint-clean. The `[indexer]`
+optional dependency group must not leak into server runtime imports (server
+modules never import torch/open_clip).

--- a/docs/superpowers/specs/2026-08-07-optimizer-candidates-design.md
+++ b/docs/superpowers/specs/2026-08-07-optimizer-candidates-design.md
@@ -1,0 +1,121 @@
+# Optimizer Candidates View — Design
+
+**Date:** 2026-08-07
+**Status:** Approved design, pending implementation plan
+
+## Summary
+
+A dedicated "Top-Kandidaten" view ranking the library by expected optimization
+savings. Scoring combines a bitrate-per-pixel heuristic with real results from
+`encode_history.jsonl` (the estimate improves with every encode the user runs).
+Rows can be queued for encoding directly via the existing encoding queue.
+
+Decisions made during brainstorming:
+
+- Estimation: **two-tier** — heuristic baseline, overridden by the median real
+  `saved_pct` from encode history when a bucket has ≥ 3 samples.
+- UI: **dedicated view** cloned from the duplicates-view pattern (own route,
+  nav button, JS file), with direct queue integration.
+- "Already optimized": new **`optimized_at` column**, written by
+  `/api/mark_optimized` from now on. No backfill for old encodes (YAGNI) —
+  already-HEVC/AV1 files rank low via the codec factor anyway.
+
+Out of scope (YAGNI): probe encodes for display, `_opt.*` backfill, auto-queue
+rules, image optimization.
+
+## Scoring engine (server)
+
+New module `arcade_scanner/core/optimization_advisor.py`. Candidate set:
+`media_type == "video"`, `optimized_at IS NULL`, no active queue job
+(`pending`/`downloading`/`encoding`/`uploading`).
+
+- **Heuristic baseline**: bitrate normalized by pixel count and frame rate,
+  compared against a per-resolution-class reference bitrate for "well
+  compressed"; multiplied by the codec factor from the existing
+  `CODEC_EFFICIENCY` table (`arcade_scanner/core/bitrate_analyzer.py:25`) —
+  its first production consumer.
+- **History override**: bucket = (resolution class × bitrate class), reusing
+  `resolution_class` / `bitrate_class` from `scripts/optimizer_utils.py`. With
+  ≥ 3 history records in the bucket, the median real `saved_pct` replaces the
+  heuristic estimate. Each result is flagged `source: "heuristic" | "history"`.
+- Per-file output: `estimated_saved_mb`, `estimated_saved_pct`, `confidence`,
+  and a short human-readable reason (e.g. "H.264, 4K, 45 Mbit/s — far above
+  reference").
+- Target codec (hevc/av1) is a parameter; it selects the `CODEC_EFFICIENCY`
+  column and the history filter.
+- `encode_history.jsonl` (`~/.arcade-scanner/logs/`) is read lazily and cached
+  with an mtime check; unparseable lines are skipped (matches the existing
+  reader's leniency).
+
+Note: `optimizer_utils.py` lives under `scripts/`; the advisor must reuse the
+bucket helpers without making the server depend on `scripts/` import hacks —
+either move the two small helpers into `arcade_scanner/core/` (optimizer
+imports them from there) or duplicate them with a parity test. Decide in the
+implementation plan; preference: move to core.
+
+## Schema & API
+
+- New column `optimized_at TEXT` (nullable) on the media table, added like
+  previous schema extensions in `sqlite_store.py`. `/api/mark_optimized`
+  (`arcade_scanner/server/routes/files.py`) sets it alongside the existing
+  status reset. The optimizer already calls this endpoint on success — no
+  optimizer change needed.
+- New route file `arcade_scanner/server/routes/candidates.py`, session
+  required:
+  - `GET /api/candidates?codec=hevc&limit=100` →
+    `{"summary": {"total_files": N, "total_estimated_saved_mb": M,
+    "history_based": K}, "results": [...]}`
+  - Sorted by absolute `estimated_saved_mb` descending (large files with
+    moderate percentages beat small files with high ones).
+  - Vault filtering consistent with existing routes; active-queue files
+    excluded.
+  - Invalid `codec` → 400.
+
+## UI — view cloned from the duplicates pattern
+
+Four touch points, same as `/duplicates`:
+
+1. SPA route `/candidates` in `api_handler.py` (`spa_routes`).
+2. Nav button in `arcade_scanner/templates/ui_components.py` (`nav_btn`).
+3. Mode wiring in `static/workspace.js` (wsColors, render branch, URL
+   read/write) + early-return in `filter_engine.js`.
+4. New `static/candidates.js`, registered in
+   `templates/dashboard_template.py` script list; server dispatch like
+   `routes/duplicates.py`.
+
+View layout:
+
+- **Header**: prominent total savings ("~120 GB möglich"), target-codec toggle
+  (hevc/av1), count of history-backed estimates.
+- **Ranked list**: thumbnail, name, codec/resolution/bitrate, estimated
+  savings (MB + %), confidence badge, reason text. Thumbnail click opens the
+  cinema preview (existing pattern).
+- **Actions**: per-row "In Queue" (`queueForRemoteEncode`), multi-select +
+  batch queue (`queueBatchForRemoteEncode` exists in `optimizer.js`); queued
+  rows disappear on refetch.
+
+New element IDs go into `tests/test_dom_contract.py` (and `DYNAMIC_IDS` for
+runtime-created ones).
+
+## Error handling
+
+- Missing/corrupt history file → heuristic-only, no error.
+- Videos with missing bitrate/resolution (ffprobe gaps) are skipped.
+- Queue-add failures surface via the existing toast/alert pattern.
+
+## Testing
+
+- Unit tests: score formula (codec factor, resolution/fps normalization,
+  ordering), history override (fixture JSONL: ≥ 3 samples wins, < 3 falls back,
+  corrupt lines skipped), candidate exclusion rules (`optimized_at`, active
+  queue jobs).
+- Route tests: session enforcement, vault filtering, sorting, `codec`
+  validation, summary numbers.
+- Migration test: `optimized_at` added on fresh and existing DBs;
+  `mark_optimized` sets it.
+- DOM contract tests updated.
+
+## CI constraints
+
+Blocking Ruff + mypy: all new code type-annotated and lint-clean. No new
+runtime dependencies.

--- a/tests/test_dom_contract.py
+++ b/tests/test_dom_contract.py
@@ -33,6 +33,8 @@ DYNAMIC_IDS = {
     "card-", "video-",
     # Toast-Queue (dynamisch per JS):
     "toast-",
+    # Von candidates.js dynamisch erzeugte IDs:
+    "cand-", "candidatesHeader", "candQueueSelectedBtn",
 }
 
 # IDs, die in externen Libraries oder conditionalem HTML sind (kein False-Positive)

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -217,6 +217,36 @@ def test_build_candidates_reason_mentions_codec_and_resolution(tmp_path):
     reason = out["results"][0]["reason"]
     assert "h264" in reason.lower()
     assert "2160" in reason or "4k" in reason.lower()
+    assert "deutlich über referenz" in reason.lower()  # 45 Mbit/s 4K is above the ref
+
+
+def test_build_candidates_reason_below_reference_says_codec_wechsel(tmp_path):
+    # 3.5 Mbit/s @ 1080p is below the ~4 Mbit/s reference -> flat codec-factor gain,
+    # not "far above reference".
+    out = adv.build_candidates(
+        [_entry(bitrate_mbps=3.5, width=1920, height=1080)],
+        "hevc", _empty_history(tmp_path), set())
+    reason = out["results"][0]["reason"]
+    assert "codec-wechsel lohnt" in reason.lower()
+    assert "deutlich über referenz" not in reason.lower()
+
+
+def test_build_candidates_reason_same_codec_says_low_potential(tmp_path):
+    out = adv.build_candidates(
+        [_entry(codec="hevc")], "hevc", _empty_history(tmp_path), set())
+    reason = out["results"][0]["reason"]
+    assert "gleicher codec" in reason.lower()
+
+
+def test_build_candidates_same_codec_skips_history_override(tmp_path):
+    """An already-HEVC file must not inherit the h264-source median for its bucket."""
+    p = _write_history(tmp_path, [_rec(saved_pct=70.0), _rec(saved_pct=70.0),
+                                  _rec(saved_pct=70.0)])
+    out = adv.build_candidates([_entry(codec="hevc")], "hevc", adv.EncodeHistory(p), set())
+    r = out["results"][0]
+    assert r["source"] == "heuristic"
+    assert r["confidence"] == "medium"
+    assert r["estimated_saved_pct"] == 15.0
 
 
 def test_build_candidates_drops_below_min_threshold(tmp_path):

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -3,8 +3,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 from arcade_scanner.core import optimization_advisor as adv
 from arcade_scanner.models.video_entry import VideoEntry
 
@@ -170,7 +168,6 @@ def test_build_candidates_sorted_by_absolute_mb(tmp_path):
     assert out["results"][1]["estimated_saved_mb"] > out["results"][2]["estimated_saved_mb"]
 
 
-@pytest.mark.xfail(reason="optimized_at field lands in Task 4", strict=False)
 def test_build_candidates_exclusions(tmp_path):
     entries = [
         _entry(file_path="/lib/queued.mp4"),

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -3,6 +3,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from arcade_scanner.core import optimization_advisor as adv
 from arcade_scanner.models.video_entry import VideoEntry
 
@@ -144,3 +146,77 @@ def test_history_mtime_cache_reloads_on_change(tmp_path):
     _write_history(tmp_path, [_rec(saved_pct=10.0)] * 3)
     os.utime(p, (1, 1))  # force a different mtime either way
     assert h.median_saved_pct("hevc", 2160, 45000) == (10.0, 3)
+
+
+# --- build_candidates tests -----------------------------------------------
+
+
+def _empty_history(tmp_path):
+    return adv.EncodeHistory(tmp_path / "none.jsonl")
+
+
+def test_build_candidates_sorted_by_absolute_mb(tmp_path):
+    entries = [
+        _entry(file_path="/lib/small.mp4", size_mb=100.0),            # same pct, less MB
+        _entry(file_path="/lib/big.mp4", size_mb=8000.0),
+        _entry(file_path="/lib/lean.mp4", size_mb=5000.0, bitrate_mbps=1.2,
+               width=1280, height=720),                                # included, lower pct
+    ]
+    out = adv.build_candidates(entries, "hevc", _empty_history(tmp_path), set())
+    paths = [r["file_path"] for r in out["results"]]
+    # Sorted by absolute MB savings (desc): big > lean > small
+    assert paths == ["/lib/big.mp4", "/lib/lean.mp4", "/lib/small.mp4"]
+    assert out["results"][0]["estimated_saved_mb"] > out["results"][1]["estimated_saved_mb"]
+    assert out["results"][1]["estimated_saved_mb"] > out["results"][2]["estimated_saved_mb"]
+
+
+@pytest.mark.xfail(reason="optimized_at field lands in Task 4", strict=False)
+def test_build_candidates_exclusions(tmp_path):
+    entries = [
+        _entry(file_path="/lib/queued.mp4"),
+        _entry(file_path="/lib/done.mp4", optimized_at=1723000000),
+        _entry(file_path="/lib/photo.jpg", media_type="image"),
+        _entry(file_path="/lib/nodata.mp4", bitrate_mbps=0.0),
+        _entry(file_path="/lib/ok.mp4"),
+    ]
+    out = adv.build_candidates(entries, "hevc", _empty_history(tmp_path),
+                               exclude_paths={"/lib/queued.mp4"})
+    assert [r["file_path"] for r in out["results"]] == ["/lib/ok.mp4"]
+
+
+def test_build_candidates_history_beats_heuristic(tmp_path):
+    p = _write_history(tmp_path, [_rec(saved_pct=40.0), _rec(saved_pct=42.0),
+                                  _rec(saved_pct=44.0)])
+    out = adv.build_candidates([_entry()], "hevc", adv.EncodeHistory(p), set())
+    r = out["results"][0]
+    assert r["source"] == "history"
+    assert r["confidence"] == "high"
+    assert r["estimated_saved_pct"] == 42.0
+    assert r["estimated_saved_mb"] == 420.0  # 1000 MB * 42%
+    assert out["summary"]["history_based"] == 1
+
+
+def test_build_candidates_confidence_levels(tmp_path):
+    out = adv.build_candidates(
+        [_entry(file_path="/lib/known.mp4"),
+         _entry(file_path="/lib/odd.mp4", codec="prores")],
+        "hevc", _empty_history(tmp_path), set())
+    by_path = {r["file_path"]: r for r in out["results"]}
+    assert by_path["/lib/known.mp4"]["confidence"] == "medium"
+    assert by_path["/lib/odd.mp4"]["confidence"] == "low"
+    assert all(r["source"] == "heuristic" for r in out["results"])
+
+
+def test_build_candidates_summary_counts_all_but_results_capped(tmp_path):
+    entries = [_entry(file_path=f"/lib/v{i}.mp4") for i in range(5)]
+    out = adv.build_candidates(entries, "hevc", _empty_history(tmp_path), set(), limit=2)
+    assert len(out["results"]) == 2
+    assert out["summary"]["total_files"] == 5
+    assert out["summary"]["total_estimated_saved_mb"] > out["results"][0]["estimated_saved_mb"]
+
+
+def test_build_candidates_reason_mentions_codec_and_resolution(tmp_path):
+    out = adv.build_candidates([_entry()], "hevc", _empty_history(tmp_path), set())
+    reason = out["results"][0]["reason"]
+    assert "h264" in reason.lower()
+    assert "2160" in reason or "4k" in reason.lower()

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -1,0 +1,78 @@
+"""Unit tests for the optimization advisor (pure logic, no ffmpeg/fs)."""
+import sys
+from pathlib import Path
+
+from arcade_scanner.core import optimization_advisor as adv
+from arcade_scanner.models.video_entry import VideoEntry
+
+# Add scripts to path for optimizer_utils import
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from optimizer_utils import (  # noqa: E402, I001
+    bitrate_class as ou_bitrate_class,
+    resolution_class as ou_resolution_class,
+)
+
+
+def _entry(**kw) -> VideoEntry:
+    base = dict(file_path="/lib/a.mp4", size_mb=1000.0, bitrate_mbps=45.0,
+                codec="h264", width=3840, height=2160, frame_rate=30.0,
+                media_type="video")
+    base.update(kw)
+    return VideoEntry(**base)
+
+
+def test_bucket_helpers_parity_with_optimizer_utils():
+    for kbps in (0, 1000, 2499, 2500, 7999, 8000, 19999, 20000, 50000):
+        assert adv.bitrate_class(kbps) == ou_bitrate_class(kbps)
+    for h in (0, 480, 576, 577, 720, 800, 801, 1080, 1200, 1201, 1440, 1600, 1601, 2160):
+        assert adv.resolution_class(h) == ou_resolution_class(h)
+
+
+def test_heuristic_high_bitrate_4k_h264_saves_a_lot():
+    result = adv.estimate_heuristic(_entry(), "hevc")
+    assert result is not None
+    saved_pct, known = result
+    assert known is True
+    assert saved_pct > 60  # 45 Mbit/s 4K h264 is far above the ~12 Mbit/s reference
+
+
+def test_heuristic_lean_1080p_h264_saves_moderately():
+    result = adv.estimate_heuristic(
+        _entry(bitrate_mbps=3.5, width=1920, height=1080), "hevc")
+    assert result is not None
+    saved_pct, _ = result
+    assert 20 < saved_pct < 50  # bounded by the codec factor, not the reference
+
+
+def test_heuristic_same_codec_saves_little():
+    fat = adv.estimate_heuristic(_entry(), "hevc")
+    same = adv.estimate_heuristic(_entry(codec="hevc"), "hevc")
+    assert same is not None and fat is not None
+    assert same[0] < fat[0]
+
+
+def test_heuristic_av1_target_beats_hevc_target():
+    h = adv.estimate_heuristic(_entry(), "hevc")
+    a = adv.estimate_heuristic(_entry(), "av1")
+    assert a is not None and h is not None
+    assert a[0] >= h[0]
+
+
+def test_heuristic_unknown_codec_pair_flagged():
+    result = adv.estimate_heuristic(_entry(codec="prores"), "hevc")
+    assert result is not None
+    assert result[1] is False
+
+
+def test_heuristic_missing_data_returns_none():
+    assert adv.estimate_heuristic(_entry(bitrate_mbps=0.0), "hevc") is None
+    assert adv.estimate_heuristic(_entry(height=0), "hevc") is None
+
+
+def test_heuristic_savings_capped():
+    result = adv.estimate_heuristic(_entry(bitrate_mbps=200.0), "hevc")
+    assert result is not None
+    assert result[0] <= 85.0

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -1,4 +1,5 @@
 """Unit tests for the optimization advisor (pure logic, no ffmpeg/fs)."""
+import json
 import sys
 from pathlib import Path
 
@@ -76,3 +77,73 @@ def test_heuristic_savings_capped():
     result = adv.estimate_heuristic(_entry(bitrate_mbps=200.0), "hevc")
     assert result is not None
     assert result[0] <= 85.0
+
+
+# --- EncodeHistory tests --------------------------------------------------
+
+
+def _write_history(tmp_path, records):
+    p = tmp_path / "encode_history.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return p
+
+
+def _rec(**kw):
+    base = dict(ts="2026-08-01T00:00:00", file="x.mp4", encoder="hevc_nvenc",
+                codec="hevc_nvenc", height=2160, source_kbps=45000, q=30,
+                ssim=0.97, saved_pct=70.0)
+    base.update(kw)
+    # If codec is provided but encoder is not, update encoder to match
+    if 'codec' in kw and 'encoder' not in kw:
+        base['encoder'] = kw['codec']
+    return base
+
+
+def test_history_median_with_enough_samples(tmp_path):
+    p = _write_history(tmp_path, [_rec(saved_pct=60.0), _rec(saved_pct=70.0),
+                                  _rec(saved_pct=80.0)])
+    h = adv.EncodeHistory(p)
+    result = h.median_saved_pct("hevc", 2160, 45000)
+    assert result == (70.0, 3)
+
+
+def test_history_too_few_samples_returns_none(tmp_path):
+    p = _write_history(tmp_path, [_rec(), _rec()])
+    assert adv.EncodeHistory(p).median_saved_pct("hevc", 2160, 45000) is None
+
+
+def test_history_bucket_mismatch_returns_none(tmp_path):
+    p = _write_history(tmp_path, [_rec(), _rec(), _rec()])
+    h = adv.EncodeHistory(p)
+    assert h.median_saved_pct("hevc", 720, 45000) is None      # other resolution class
+    assert h.median_saved_pct("hevc", 2160, 3000) is None      # other bitrate class
+
+
+def test_history_target_codec_matching(tmp_path):
+    p = _write_history(tmp_path, [
+        _rec(codec="av1_nvenc", saved_pct=80.0), _rec(codec="av1_nvenc", saved_pct=80.0),
+        _rec(codec="av1_nvenc", saved_pct=80.0),
+        _rec(codec="libx265", saved_pct=50.0), _rec(codec="libx265", saved_pct=50.0),
+        _rec(codec="libx265", saved_pct=50.0),
+    ])
+    h = adv.EncodeHistory(p)
+    assert h.median_saved_pct("av1", 2160, 45000) == (80.0, 3)
+    assert h.median_saved_pct("hevc", 2160, 45000) == (50.0, 3)
+
+
+def test_history_corrupt_lines_and_missing_file(tmp_path):
+    p = tmp_path / "encode_history.jsonl"
+    p.write_text('not json\n{"broken": \n' + json.dumps(_rec()) + "\n", encoding="utf-8")
+    assert adv.EncodeHistory(p).median_saved_pct("hevc", 2160, 45000) is None  # 1 < 3
+    missing = adv.EncodeHistory(tmp_path / "nope.jsonl")
+    assert missing.median_saved_pct("hevc", 2160, 45000) is None
+
+
+def test_history_mtime_cache_reloads_on_change(tmp_path):
+    p = _write_history(tmp_path, [_rec(), _rec(), _rec()])
+    h = adv.EncodeHistory(p)
+    assert h.median_saved_pct("hevc", 2160, 45000) is not None
+    import os
+    _write_history(tmp_path, [_rec(saved_pct=10.0)] * 3)
+    os.utime(p, (1, 1))  # force a different mtime either way
+    assert h.median_saved_pct("hevc", 2160, 45000) == (10.0, 3)

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -220,3 +220,16 @@ def test_build_candidates_reason_mentions_codec_and_resolution(tmp_path):
     reason = out["results"][0]["reason"]
     assert "h264" in reason.lower()
     assert "2160" in reason or "4k" in reason.lower()
+
+
+def test_build_candidates_drops_below_min_threshold(tmp_path):
+    """Verify that candidates with < 10% savings are dropped from both results and summary."""
+    # History with 5% savings (below 10% threshold) for the default bucket (2160/ultra)
+    p = _write_history(tmp_path, [_rec(saved_pct=5.0), _rec(saved_pct=5.0), _rec(saved_pct=5.0)])
+    out = adv.build_candidates([_entry()], "hevc", adv.EncodeHistory(p), set())
+    # Should be completely filtered out from results
+    assert out["results"] == []
+    # Summary should reflect no candidates pass the threshold
+    assert out["summary"]["total_files"] == 0
+    assert out["summary"]["total_estimated_saved_mb"] == 0.0
+    assert out["summary"]["history_based"] == 0

--- a/tests/test_optimization_advisor.py
+++ b/tests/test_optimization_advisor.py
@@ -93,9 +93,6 @@ def _rec(**kw):
                 codec="hevc_nvenc", height=2160, source_kbps=45000, q=30,
                 ssim=0.97, saved_pct=70.0)
     base.update(kw)
-    # If codec is provided but encoder is not, update encoder to match
-    if 'codec' in kw and 'encoder' not in kw:
-        base['encoder'] = kw['codec']
     return base
 
 

--- a/tests/test_route_interface.py
+++ b/tests/test_route_interface.py
@@ -76,3 +76,17 @@ def test_route_handle_get_returns_bool(module_path):
                 f"{module_path}.{fn_name} return annotation must be bool, "
                 f"got {ret!r}"
             )
+
+
+def test_api_handler_re_exports_max_request_size():
+    """
+    Regression test: MAX_REQUEST_SIZE must be re-exported from api_handler.py
+    so that routes/* modules can lazily import it at request time.
+
+    This was broken by commit cf62272 ("style: ruff safe fixes") which removed
+    the unused import, breaking every GET to /api/tags and /api/settings.
+    """
+    from arcade_scanner.server.api_handler import MAX_REQUEST_SIZE
+
+    assert isinstance(MAX_REQUEST_SIZE, int), "MAX_REQUEST_SIZE must be an integer"
+    assert MAX_REQUEST_SIZE > 0, "MAX_REQUEST_SIZE must be positive"

--- a/tests/test_routes_candidates.py
+++ b/tests/test_routes_candidates.py
@@ -1,0 +1,115 @@
+"""Route tests for /api/candidates — FakeHandler pattern from test_routes_queue.py."""
+import json
+from unittest.mock import MagicMock, patch
+
+from arcade_scanner.models.video_entry import VideoEntry
+from arcade_scanner.server.routes import candidates
+
+
+class FakeHandler:
+    def __init__(self, path, user="alice"):
+        self.path = path
+        self._user = user
+        self.wfile = MagicMock()
+        self.status = None
+        self.error = None
+        self.headers = {}
+
+    def get_current_user(self):
+        return self._user
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_error(self, code, message=""):
+        self.error = code
+
+    def send_header(self, key, value):
+        pass
+
+    def end_headers(self):
+        pass
+
+    def body(self):
+        raw = b"".join(c.args[0] for c in self.wfile.write.call_args_list)
+        return json.loads(raw)
+
+
+class FakeDB:
+    def __init__(self, entries=(), active=()):
+        self._entries = list(entries)
+        self._active = set(active)
+
+    def get_all(self):
+        return self._entries
+
+    def get_active_queue_paths(self):
+        return self._active
+
+
+class FakeUserDB:
+    def __init__(self, vaulted=()):
+        u = MagicMock()
+        u.data.vaulted = list(vaulted)
+        self._u = u
+
+    def get_user(self, name):
+        return self._u
+
+
+def _entry(path="/lib/a.mp4", **kw):
+    base = dict(file_path=path, size_mb=1000.0, bitrate_mbps=45.0, codec="h264",
+                width=3840, height=2160, frame_rate=30.0, media_type="video")
+    base.update(kw)
+    return VideoEntry(**base)
+
+
+def run(handler, db=None, user_db=None, tmp_path=None):
+    db = db or FakeDB([_entry()])
+    user_db = user_db or FakeUserDB()
+    with patch.object(candidates, "_get_deps", return_value=(db, user_db)):
+        handled = candidates.handle_get(handler)
+    return handled
+
+
+def test_unrelated_path_not_handled():
+    assert run(FakeHandler("/api/other")) is False
+
+
+def test_requires_session():
+    h = FakeHandler("/api/candidates", user=None)
+    assert run(h) is True
+    assert h.error == 401
+
+
+def test_invalid_codec_400():
+    h = FakeHandler("/api/candidates?codec=vp9")
+    assert run(h) is True
+    assert h.error == 400
+
+
+def test_returns_ranked_results():
+    h = FakeHandler("/api/candidates?codec=hevc")
+    db = FakeDB([_entry("/lib/big.mp4", size_mb=8000.0), _entry("/lib/small.mp4", size_mb=100.0)])
+    assert run(h, db=db) is True
+    body = h.body()
+    assert body["summary"]["total_files"] == 2
+    assert [r["file_path"] for r in body["results"]] == ["/lib/big.mp4", "/lib/small.mp4"]
+
+
+def test_excludes_active_queue_and_vaulted():
+    h = FakeHandler("/api/candidates")
+    db = FakeDB([_entry("/lib/q.mp4"), _entry("/lib/v.mp4"), _entry("/lib/ok.mp4")],
+                active={"/lib/q.mp4"})
+    udb = FakeUserDB(vaulted=["/lib/v.mp4"])
+    run(h, db=db, user_db=udb)
+    assert [r["file_path"] for r in h.body()["results"]] == ["/lib/ok.mp4"]
+
+
+def test_limit_param():
+    h = FakeHandler("/api/candidates?limit=1")
+    db = FakeDB([_entry(f"/lib/v{i}.mp4") for i in range(3)])
+    run(h, db=db)
+    body = h.body()
+    assert len(body["results"]) == 1
+    assert body["summary"]["total_files"] == 3

--- a/tests/test_routes_files.py
+++ b/tests/test_routes_files.py
@@ -278,3 +278,24 @@ class TestMarkOptimized:
         _, db, _, _ = run_route(handler)
         assert db.upserted == []
         assert handler.status == 204
+
+    def test_existing_entry_gets_optimized_timestamp(self):
+        entry = VideoEntry(FilePath="/media/a.mp4", Size_MB=10.0, Status="HIGH")
+        db = FakeDB([entry])
+        handler = FakeHandler("/api/mark_optimized?path=/media/a.mp4")
+
+        run_route(handler, fake_db=db)
+
+        assert db.upserted[0].status == "OK"
+        assert db.upserted[0].optimized_at > 0
+        assert handler.status == 204
+
+    def test_new_entry_gets_optimized_timestamp(self):
+        db = FakeDB()
+        handler = FakeHandler("/api/mark_optimized?path=/media/new.mp4")
+
+        with patch("arcade_scanner.server.routes.files.os.path.getsize",
+                   return_value=5 * 1024 * 1024):
+            run_route(handler, fake_db=db)
+
+        assert db.upserted[0].optimized_at > 0

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -411,3 +411,51 @@ class TestConcurrentReads:
 
         assert errors == [], f"first failure: {errors[0]}"
         assert len(set(seen)) == 1, "threads ended up on different connections"
+
+
+def test_optimized_at_roundtrip(store):
+    from arcade_scanner.models.video_entry import VideoEntry
+    e = VideoEntry(file_path="/lib/a.mp4", size_mb=10.0, optimized_at=1723000000)
+    store.upsert(e)
+    got = store.get("/lib/a.mp4")
+    assert got is not None
+    assert got.optimized_at == 1723000000
+
+
+def test_optimized_at_defaults_to_zero(store):
+    from arcade_scanner.models.video_entry import VideoEntry
+    store.upsert(VideoEntry(file_path="/lib/b.mp4", size_mb=10.0))
+    got = store.get("/lib/b.mp4")
+    assert got is not None
+    assert got.optimized_at == 0
+
+
+def test_get_active_queue_paths(store):
+    from arcade_scanner.models.video_entry import VideoEntry
+    store.upsert(VideoEntry(file_path="/lib/q.mp4", size_mb=10.0))
+    job_id = store.queue_encode("/lib/q.mp4", size_bytes=1, target_codec="hevc")
+    assert job_id is not None
+    assert store.get_active_queue_paths() == {"/lib/q.mp4"}
+    store.update_job_status(job_id, "done")
+    assert store.get_active_queue_paths() == set()
+
+
+def test_optimized_at_migration_on_existing_db(patch_config, tmp_path):
+    """A pre-existing DB without the column gets it via ALTER TABLE on open."""
+    import sqlite3
+
+    from arcade_scanner.database.sqlite_store import _COLUMNS, SQLiteStore
+    db_file = tmp_path / "media_library.db"
+    legacy_cols = ", ".join(
+        f"{name} {typedef}" for name, typedef in _COLUMNS if name != "optimized_at")
+    conn = sqlite3.connect(db_file)
+    conn.execute(f"CREATE TABLE media ({legacy_cols})")
+    conn.execute("INSERT INTO media (file_path, size_mb) VALUES ('/lib/old.mp4', 5.0)")
+    conn.commit()
+    conn.close()
+
+    s = SQLiteStore()
+    s._ensure_connection()
+    entry = s.get("/lib/old.mp4")
+    assert entry is not None
+    assert entry.optimized_at == 0


### PR DESCRIPTION
## Was das ist

Eine neue Ansicht **Kandidaten** (`/candidates`), die die Bibliothek nach erwarteter Re-Encode-Ersparnis sortiert und Dateien direkt in die Encoding-Queue legt.

Spec: `docs/superpowers/specs/2026-08-07-optimizer-candidates-design.md`
Plan: `docs/superpowers/plans/2026-08-07-optimizer-candidates.md`

## Komponenten

- **`core/optimization_advisor.py`** (neu, pure logic): Bitrate-pro-Auflösungs-Heuristik × `CODEC_EFFICIENCY`-Faktor; sobald eine Auflösungs-/Bitrate-Klasse ≥3 echte Encodes in `encode_history.jsonl` hat, ersetzt der Median der realen `saved_pct` die Heuristik (Same-Codec-Guard verhindert, dass bereits-HEVC-Dateien h264-Historie erben). Historie wird als Bucket-Index gecacht (mtime-invalidiert, thread-safe).
- **`optimized_at`-Spalte**: durch Model/Store/Scanner-Merge/`mark_optimized` gefädelt, rescan-sicher (INSERT-OR-REPLACE-Falle), ALTER-TABLE-Migration für Bestands-DBs inkl. Test.
- **`GET /api/candidates`** (Session-pflichtig): Ranking nach absoluter MB-Ersparnis, exkludiert aktive Queue-Jobs und gevaultete Dateien; `codec=hevc|av1`, `limit`.
- **Frontend**: `static/candidates.js` nach dem Duplikate-Muster (Nav-Button, workspace/filter_engine-Wiring, URL `/candidates`), Header mit „bis zu … möglich (Schätzung)", Confidence-Badges (Historie/Schätzung), Einzel- und Batch-Queueing.

## Beifang-Fix (wichtig)

`094a9ea` behebt eine **bestehende dev-Regression**: `cf62272` (ruff-Cleanup) entfernte den `MAX_REQUEST_SIZE`-Reexport aus `api_handler.py`, den `routes/tags.py` und `routes/settings.py` lazy importieren — **`GET /api/tags` und `GET /api/settings` liefern auf dev derzeit 404**. Fix + Regressionstest enthalten.

## Verifikation

- 583 Tests grün, Ruff + mypy sauber (CI-blockierend)
- Browser-Smoke-Test: Login, Rendering mit realer Bibliothek (177 Kandidaten), HEVC/AV1-Toggle-Refetch, Historie-Badges, Cinema-Klick, keine neuen Konsolenfehler
- Multi-Agent-Entwicklung: Review nach jedem Task + finales Whole-Branch-Review (Findings gefixt: Same-Codec-Historie-Override, Begründungstexte, Historien-Scan-Performance)

## Bekannte Follow-ups (nicht blockierend)

- HTML-Escaping für Dateinamen in `candidates.js` **und** `duplicates.js` (gemeinsamer `escapeHtml()`-Helper) — betrifft Namen mit `"`, `&`, `<`
- `routes/candidates.py` nutzt `get_all()` unter Lock; bei sehr großen Bibliotheken (≫10k) auf `get_all_dicts()`-Pfad umstellen

🤖 Generated with [Claude Code](https://claude.com/claude-code)