### PR TITLE
feat: Embedding-Fundament — Indexer, Vektor-Store, /api/similar (Teil 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Embedding Foundation (Ähnlichkeit Teil 1)
+- **GPU-Indexer** (`scripts/media_indexer.py`): berechnet CLIP-Embeddings
+  (Default ViT-B-16, 12 Frames pro Video, Bilder 1 Frame) und schreibt sie in
+  die Haupt-DB. Inkrementell (mtime/Modell), `--watch`, `--rebuild`; eigene
+  optionale Dependency-Gruppe `pip install -e ".[indexer]"` — der Server
+  selbst bleibt ohne ML-Abhängigkeiten.
+- **`GET /api/similar`**: nächste Nachbarn über die gespeicherten
+  Mean-Vektoren (pures Python, kein NumPy), Session-pflichtig und
+  Vault-gefiltert; Cache invalidiert sich bei Indexer-Läufen selbst.
+
 ### Changed — Video Optimizer V2.5
 - **Downscaling**: New `--scale-height H` option scales the encode to H pixels height while keeping the source aspect ratio (width `-2`). Upscaling is refused, the SSIM reference is scaled to match so quality checks stay valid, and the constrained-VBR ladder is adjusted to the target resolution (~pixels^0.75) so a downscale actually converts into savings.
 - **Sample-Clip Pre-Search**: The quality binary search now runs on a ~24s stream-copied probe clip first, then narrows the full-encode search to predicted ±1 — typically 1-2 full passes instead of 3-4 (files ≥ 120s; `--no-presearch` to disable).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,12 @@ This document outlines planned features and improvements for the Arcade Media Sc
 
 ## Completed Features
 
+### ✅ Embedding Foundation — Ähnlichkeit Teil 1 (2026-08-08)
+- **Vektor-Speicher**: `embedding_meta`/`frame_embeddings` in SQLite, float32-Blobs, L2-normalisiert.
+- **GPU-Indexer**: eigenständiges Skript mit optionalen ML-Deps (`[indexer]`), inkrementell.
+- **`/api/similar`**: Brute-Force-kNN serverseitig ohne neue Runtime-Dependencies.
+- Geplant als Teil 2–4: „Ähnliche Videos"-Leiste im Cinema, Themen-Clustering, semantische Textsuche.
+
 ### ✅ Version 6.8.0 (2026-01-18)
 - **Visual Timeline Scrubber**: Professional timeline with frame-accurate seeking and thumbnail previews.
 - **GIF Export Panel**: Redesigned bottom panel UI with presets and size estimation.

--- a/arcade_scanner/core/similarity.py
+++ b/arcade_scanner/core/similarity.py
@@ -1,0 +1,43 @@
+# arcade_scanner/core/similarity.py
+"""Vector codec + brute-force kNN for the embedding foundation.
+
+Pure stdlib (struct) — the server must not depend on numpy or the ML stack.
+Vectors are L2-normalized at encode time, so similarity is a plain dot
+product. At library scale (a few thousand mean vectors) brute force answers
+in milliseconds.
+"""
+from __future__ import annotations
+
+import math
+import struct
+from typing import Iterable, Sequence
+
+
+def encode_vector(values: Sequence[float]) -> bytes:
+    """L2-normalize and pack as little-endian float32 blob."""
+    norm = math.sqrt(sum(v * v for v in values))
+    if norm > 0:
+        values = [v / norm for v in values]
+    else:
+        values = list(values)
+    return struct.pack(f"<{len(values)}f", *values)
+
+
+def decode_vector(blob: bytes) -> list[float]:
+    """Unpack a little-endian float32 blob."""
+    count = len(blob) // 4
+    return list(struct.unpack(f"<{count}f", blob))
+
+
+def dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def top_k(query: Sequence[float],
+          candidates: Iterable[tuple[str, Sequence[float]]],
+          k: int,
+          exclude: set[str]) -> list[tuple[str, float]]:
+    """Top-k candidates by dot product, descending. `exclude` paths are skipped."""
+    scored = [(path, dot(query, vec)) for path, vec in candidates if path not in exclude]
+    scored.sort(key=lambda item: item[1], reverse=True)
+    return scored[:k]

--- a/arcade_scanner/database/sqlite_store.py
+++ b/arcade_scanner/database/sqlite_store.py
@@ -170,6 +170,90 @@ class SQLiteStore:
         except Exception:
             pass  # Column already exists
 
+        # Embedding storage (similarity part 1) — written by scripts/media_indexer.py,
+        # read by routes/similar.py. Vectors are L2-normalized float32 blobs.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS embedding_meta (
+                file_path   TEXT PRIMARY KEY,
+                model       TEXT NOT NULL,
+                dim         INTEGER NOT NULL,
+                mtime       REAL NOT NULL,
+                indexed_at  TEXT NOT NULL,
+                mean_vector BLOB NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS frame_embeddings (
+                file_path   TEXT NOT NULL,
+                frame_index INTEGER NOT NULL,
+                ts_sec      REAL NOT NULL,
+                vector      BLOB NOT NULL,
+                PRIMARY KEY (file_path, frame_index)
+            )
+        """)
+
+    # ------------------------------------------------------------------
+    # Embedding storage (similarity)
+    # ------------------------------------------------------------------
+
+    def store_embedding(self, file_path: str, model: str, dim: int, mtime: float,
+                        mean_vector: bytes, frames: list[tuple[int, float, bytes]]) -> None:
+        """Write one file's embeddings atomically, replacing any previous rows."""
+        conn = self._ensure_connection()
+        safe_path = self._get_safe_path(file_path)
+        with self._write_lock:
+            conn.execute("BEGIN")
+            try:
+                conn.execute("DELETE FROM frame_embeddings WHERE file_path = ?", (safe_path,))
+                conn.execute(
+                    "INSERT OR REPLACE INTO embedding_meta "
+                    "(file_path, model, dim, mtime, indexed_at, mean_vector) "
+                    "VALUES (?, ?, ?, ?, datetime('now'), ?)",
+                    (safe_path, model, dim, mtime, mean_vector),
+                )
+                conn.executemany(
+                    "INSERT INTO frame_embeddings (file_path, frame_index, ts_sec, vector) "
+                    "VALUES (?, ?, ?, ?)",
+                    [(safe_path, idx, ts, vec) for idx, ts, vec in frames],
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        self._notify_change()
+
+    def get_embedding_state(self) -> dict[str, tuple[float, str]]:
+        """path → (mtime, model) for incremental skip decisions."""
+        conn = self._ensure_connection()
+        with self._write_lock:
+            cursor = conn.execute("SELECT file_path, mtime, model FROM embedding_meta")
+            return {self._decode_safe_path(row["file_path"]): (row["mtime"], row["model"])
+                    for row in cursor}
+
+    def get_mean_vectors(self) -> list[tuple[str, str, bytes]]:
+        """(path, model, mean_vector blob) for every indexed file."""
+        conn = self._ensure_connection()
+        with self._write_lock:
+            cursor = conn.execute("SELECT file_path, model, mean_vector FROM embedding_meta")
+            return [(self._decode_safe_path(row["file_path"]), row["model"], row["mean_vector"])
+                    for row in cursor]
+
+    def delete_embedding(self, file_path: str) -> None:
+        conn = self._ensure_connection()
+        safe_path = self._get_safe_path(file_path)
+        with self._write_lock:
+            conn.execute("DELETE FROM embedding_meta WHERE file_path = ?", (safe_path,))
+            conn.execute("DELETE FROM frame_embeddings WHERE file_path = ?", (safe_path,))
+
+    def prune_embeddings(self, existing_paths: set[str]) -> int:
+        """Drop embeddings for files no longer in the library. Returns count removed."""
+        removed = 0
+        for path in list(self.get_embedding_state()):
+            if path not in existing_paths:
+                self.delete_embedding(path)
+                removed += 1
+        return removed
+
     # ------------------------------------------------------------------
     # Encoding Queue methods
     # ------------------------------------------------------------------

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -394,7 +394,7 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         self._response_started = False
         try:
-            from .routes import duplicates, files, queue, settings, tags
+            from .routes import duplicates, files, queue, settings, similar, tags
             if queue.handle_get(self):
                 return
             if settings.handle_get(self):
@@ -402,6 +402,8 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
             if duplicates.handle_get(self):
                 return
             if tags.handle_get(self):
+                return
+            if similar.handle_get(self):
                 return
             if files.handle_get(self):
                 return

--- a/arcade_scanner/server/routes/similar.py
+++ b/arcade_scanner/server/routes/similar.py
@@ -1,0 +1,89 @@
+# arcade_scanner/server/routes/similar.py
+"""GET /api/similar — nearest neighbours over stored mean embeddings."""
+import os
+import threading
+from typing import Any, Optional
+from urllib.parse import parse_qs, urlparse
+
+from arcade_scanner.core.similarity import decode_vector, top_k
+from arcade_scanner.server.response_helpers import send_json
+
+
+def _get_deps() -> tuple[Any, Any]:
+    from arcade_scanner.server.api_handler import db, user_db
+    return db, user_db
+
+
+class SimilarityCache:
+    """Decoded mean vectors, loaded lazily and invalidated on store changes."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._vectors: Optional[dict[str, list[float]]] = None
+        self._hooked = False
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._vectors = None
+
+    def get(self, media_db: Any) -> dict[str, list[float]]:
+        with self._lock:
+            if not self._hooked:
+                # store_embedding fires _notify_change, so fresh indexer runs
+                # are picked up without a server restart
+                media_db.register_on_change(self.invalidate)
+                self._hooked = True
+            if self._vectors is None:
+                self._vectors = {path: decode_vector(blob)
+                                 for path, _model, blob in media_db.get_mean_vectors()}
+            return self._vectors
+
+
+_cache = SimilarityCache()
+
+
+def handle_get(handler) -> bool:
+    parsed = urlparse(handler.path)
+    if parsed.path != "/api/similar":
+        return False
+
+    user_name = handler.get_current_user()
+    if not user_name:
+        handler.send_error(401, "Unauthorized")
+        return True
+
+    params = parse_qs(parsed.query)
+    query_path = params.get("path", [None])[0]
+    if not query_path:
+        handler.send_error(400, "Missing path parameter")
+        return True
+    query_path = os.path.abspath(query_path)
+    try:
+        limit = max(1, min(int(params.get("limit", ["12"])[0]), 100))
+    except ValueError:
+        limit = 12
+
+    try:
+        media_db, user_db = _get_deps()
+        vectors = _cache.get(media_db)
+        if not vectors:
+            send_json(handler, {"status": "not_indexed"})
+            return True
+        query_vector = vectors.get(query_path)
+        if query_vector is None:
+            handler.send_error(404, "File not indexed")
+            return True
+
+        exclude = {query_path}
+        u = user_db.get_user(user_name)
+        if u and u.data.vaulted:
+            exclude.update(os.path.abspath(p) for p in u.data.vaulted)
+
+        results = top_k(query_vector, vectors.items(), k=limit, exclude=exclude)
+        send_json(handler, {"status": "ok",
+                            "results": [{"file_path": p, "score": round(s, 4)}
+                                        for p, s in results]})
+    except Exception as e:
+        print(f"❌ Error in /api/similar: {e}")
+        handler.send_error(500, str(e))
+    return True

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -55,9 +55,9 @@
 
 **Produces:** importable WITHOUT ml deps. Pure helpers: `sample_timestamps(duration: float, count: int = 12) -> list[float]` (uniform across 5%–95%; duration ≤ 0 → `[0.0]`; short videos → fewer, min 1), `needs_index(path, mtime, model, state: dict) -> bool`. CLI: one-shot default, `--watch --interval N`, `--rebuild`, `--model` (default `ViT-B-16`); frame extraction via ffmpeg subprocess; model inference isolated in `_load_model()`/`_embed_frames()` with lazy torch/open_clip imports and clear install hint on ImportError; per-file errors logged + skipped; deleted files pruned; images single frame.
 
-- [ ] Tests: timestamp math (12 frames, 5%–95% bounds, 1s video → 1 frame), `needs_index` (new / same mtime+model skip / changed mtime / changed model), full `index_library` pass with mocked embed function + fake store recording `store_embedding` calls (no ffmpeg: frame extraction mocked).
-- [ ] Implement; verify module imports clean without torch installed.
-- [ ] pytest/ruff green (scripts/ is outside the mypy target); commit `feat(indexer): standalone GPU media indexer (CLIP embeddings, incremental)`.
+- [x] Tests: timestamp math (12 frames, 5%–95% bounds, 1s video → 1 frame), `needs_index` (new / same mtime+model skip / changed mtime / changed model), full `index_library` pass with mocked embed function + fake store recording `store_embedding` calls (no ffmpeg: frame extraction mocked).
+- [x] Implement; verify module imports clean without torch installed.
+- [x] pytest/ruff green (scripts/ is outside the mypy target); commit `feat(indexer): standalone GPU media indexer (CLIP embeddings, incremental)`.
 
 ### Task 5: `[indexer]` extra + changelog
 

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -63,9 +63,9 @@
 
 **Files:** Modify `pyproject.toml` (optional-dependencies group `indexer = ["torch", "open_clip_torch"]`), `CHANGELOG.md`, `ROADMAP.md`.
 
-- [ ] Add extra; assert server test suite still passes without it installed (it is not installed in this venv — that IS the proof).
-- [ ] CHANGELOG `[Unreleased]` + ROADMAP entry.
-- [ ] Full pytest/ruff/mypy; commit `docs: changelog & roadmap for the embedding foundation`.
+- [x] Add extra; assert server test suite still passes without it installed (it is not installed in this venv — that IS the proof).
+- [x] CHANGELOG `[Unreleased]` + ROADMAP entry.
+- [x] Full pytest/ruff/mypy; commit `docs: changelog & roadmap for the embedding foundation`.
 
 ### Task 6: Push + PR
 

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -69,4 +69,4 @@
 
 ### Task 6: Push + PR
 
-- [ ] `git push -u origin night/embedding-foundation`; PR against `dev` (title per NIGHT-LOOP2.md), body notes the pending 4090 real-run and Parts 2–4.
+- [x] `git push -u origin night/embedding-foundation`; PR against `dev` (title per NIGHT-LOOP2.md), body notes the pending 4090 real-run and Parts 2–4.

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -1,0 +1,72 @@
+# Embedding Foundation Implementation Plan (Similarity Part 1)
+
+> **For agentic workers:** Executed during the 2026-08-08 night run in this worktree. Steps use checkbox (`- [ ]`) syntax as the progress ledger — tick per task, commit alongside the code.
+
+**Goal:** GPU indexer + vector storage + pure-Python kNN + `/api/similar`, exactly as specced in `docs/superpowers/specs/2026-08-07-embedding-foundation-design.md`.
+
+**Architecture:** Indexer (`scripts/media_indexer.py`, optional `[indexer]` deps, lazy torch imports) writes L2-normalized float32 embeddings into two new SQLite tables. The server gains zero dependencies: `core/similarity.py` decodes blobs with `struct` and answers kNN by dot product over an in-memory cache; `routes/similar.py` serves session-guarded, vault-filtered queries.
+
+**Tech Stack:** Python stdlib + pydantic (server); torch + open_clip (indexer only, never imported by server modules); pytest (all tests run WITHOUT the ML stack).
+
+## Global Constraints
+
+- No new server runtime dependencies; no server module imports torch/open_clip.
+- Blocking CI: `.venv/bin/pytest`, `.venv/bin/ruff check .`, `.venv/bin/mypy arcade_scanner` — green before every commit.
+- Vectors: float32 blobs, L2-normalized on write → similarity = dot product.
+- `model` column marks staleness: rows from a different model are re-indexed.
+- Default model `ViT-B-16` (dual encoder, keeps Part 4 possible); 12 uniform frames across 5%–95% of duration; short videos: as many as extractable, min 1; images: 1 frame.
+- API: `GET /api/similar?path=…&limit=12` → `{"status":"ok","results":[{"file_path","score"}]}`; no index → 200 `{"status":"not_indexed"}`; unknown/unindexed path → 404; missing path → 400; session required; vault-filtered.
+
+---
+
+### Task 1: `core/similarity.py` — blob codec + kNN
+
+**Files:** Create `arcade_scanner/core/similarity.py`; Test `tests/test_similarity.py`
+
+**Produces:** `encode_vector(values: Sequence[float]) -> bytes` (L2-normalizes), `decode_vector(blob: bytes) -> list[float]`, `dot(a: list[float], b: list[float]) -> float`, `top_k(query: list[float], candidates: Iterable[tuple[str, list[float]]], k: int, exclude: set[str]) -> list[tuple[str, float]]` (desc by score).
+
+- [ ] Tests: roundtrip codec (float32 precision ~1e-6), normalization (norm 1.0; zero vector stays zero), top_k ordering/limit/exclude.
+- [ ] Implement with `struct.pack(f"<{n}f", ...)`, no numpy.
+- [ ] pytest/ruff/mypy green; commit `feat(core): vector codec and pure-python kNN for similarity`.
+
+### Task 2: SQLite embedding tables + store methods
+
+**Files:** Modify `arcade_scanner/database/sqlite_store.py`; Test `tests/test_sqlite_store.py` (append)
+
+**Produces:** tables `embedding_meta(file_path PK, model, dim, mtime, indexed_at, mean_vector BLOB)`, `frame_embeddings(file_path, frame_index, ts_sec, vector BLOB, PK(file_path, frame_index))`; methods `store_embedding(file_path, model, dim, mtime, mean_vector: bytes, frames: list[tuple[int, float, bytes]]) -> None` (one transaction, replaces old rows), `get_embedding_state() -> dict[str, tuple[float, str]]` (path → (mtime, model)), `get_mean_vectors() -> list[tuple[str, str, bytes]]` ((path, model, blob)), `delete_embedding(file_path) -> None`, `prune_embeddings(existing_paths: set[str]) -> int`.
+
+- [ ] Tests: store/read roundtrip, replace-on-restore semantics (old frame rows gone), state map, prune removes orphans, tables exist on fresh DB.
+- [ ] Implement in `_create_table` + methods next to the auto-tag/queue sections (same `_write_lock`/`_get_safe_path` conventions).
+- [ ] pytest/ruff/mypy green; commit `feat(db): embedding storage tables and access methods`.
+
+### Task 3: `/api/similar` route
+
+**Files:** Create `arcade_scanner/server/routes/similar.py`; Modify `arcade_scanner/server/api_handler.py` (GET dispatch before `files`); Test `tests/test_routes_similar.py`
+
+**Produces:** `handle_get(handler) -> bool`; module-level `SimilarityCache` (mean vectors decoded once, invalidated via `db.register_on_change`); response contract per Global Constraints; vault filtering via requesting user's `data.vaulted` (abspath), query file itself excluded.
+
+- [ ] Tests (FakeHandler pattern from `tests/test_routes_queue.py`, `_get_deps` patched): session 401, missing path 400, empty index → `not_indexed`, unknown path 404, ranked results with limit, vaulted results omitted, query path excluded.
+- [ ] Implement + wire dispatch (GET only).
+- [ ] pytest/ruff/mypy green; commit `feat(web): /api/similar kNN endpoint over stored embeddings`.
+
+### Task 4: `scripts/media_indexer.py`
+
+**Files:** Create `scripts/media_indexer.py`; Test `tests/test_media_indexer.py`
+
+**Produces:** importable WITHOUT ml deps. Pure helpers: `sample_timestamps(duration: float, count: int = 12) -> list[float]` (uniform across 5%–95%; duration ≤ 0 → `[0.0]`; short videos → fewer, min 1), `needs_index(path, mtime, model, state: dict) -> bool`. CLI: one-shot default, `--watch --interval N`, `--rebuild`, `--model` (default `ViT-B-16`); frame extraction via ffmpeg subprocess; model inference isolated in `_load_model()`/`_embed_frames()` with lazy torch/open_clip imports and clear install hint on ImportError; per-file errors logged + skipped; deleted files pruned; images single frame.
+
+- [ ] Tests: timestamp math (12 frames, 5%–95% bounds, 1s video → 1 frame), `needs_index` (new / same mtime+model skip / changed mtime / changed model), full `index_library` pass with mocked embed function + fake store recording `store_embedding` calls (no ffmpeg: frame extraction mocked).
+- [ ] Implement; verify module imports clean without torch installed.
+- [ ] pytest/ruff green (scripts/ is outside the mypy target); commit `feat(indexer): standalone GPU media indexer (CLIP embeddings, incremental)`.
+
+### Task 5: `[indexer]` extra + changelog
+
+**Files:** Modify `pyproject.toml` (optional-dependencies group `indexer = ["torch", "open_clip_torch"]`), `CHANGELOG.md`, `ROADMAP.md`.
+
+- [ ] Add extra; assert server test suite still passes without it installed (it is not installed in this venv — that IS the proof).
+- [ ] CHANGELOG `[Unreleased]` + ROADMAP entry.
+- [ ] Full pytest/ruff/mypy; commit `docs: changelog & roadmap for the embedding foundation`.
+
+### Task 6: Push + PR
+
+- [ ] `git push -u origin night/embedding-foundation`; PR against `dev` (title per NIGHT-LOOP2.md), body notes the pending 4090 real-run and Parts 2–4.

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -45,9 +45,9 @@
 
 **Produces:** `handle_get(handler) -> bool`; module-level `SimilarityCache` (mean vectors decoded once, invalidated via `db.register_on_change`); response contract per Global Constraints; vault filtering via requesting user's `data.vaulted` (abspath), query file itself excluded.
 
-- [ ] Tests (FakeHandler pattern from `tests/test_routes_queue.py`, `_get_deps` patched): session 401, missing path 400, empty index → `not_indexed`, unknown path 404, ranked results with limit, vaulted results omitted, query path excluded.
-- [ ] Implement + wire dispatch (GET only).
-- [ ] pytest/ruff/mypy green; commit `feat(web): /api/similar kNN endpoint over stored embeddings`.
+- [x] Tests (FakeHandler pattern from `tests/test_routes_queue.py`, `_get_deps` patched): session 401, missing path 400, empty index → `not_indexed`, unknown path 404, ranked results with limit, vaulted results omitted, query path excluded.
+- [x] Implement + wire dispatch (GET only).
+- [x] pytest/ruff/mypy green; commit `feat(web): /api/similar kNN endpoint over stored embeddings`.
 
 ### Task 4: `scripts/media_indexer.py`
 

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -35,9 +35,9 @@
 
 **Produces:** tables `embedding_meta(file_path PK, model, dim, mtime, indexed_at, mean_vector BLOB)`, `frame_embeddings(file_path, frame_index, ts_sec, vector BLOB, PK(file_path, frame_index))`; methods `store_embedding(file_path, model, dim, mtime, mean_vector: bytes, frames: list[tuple[int, float, bytes]]) -> None` (one transaction, replaces old rows), `get_embedding_state() -> dict[str, tuple[float, str]]` (path → (mtime, model)), `get_mean_vectors() -> list[tuple[str, str, bytes]]` ((path, model, blob)), `delete_embedding(file_path) -> None`, `prune_embeddings(existing_paths: set[str]) -> int`.
 
-- [ ] Tests: store/read roundtrip, replace-on-restore semantics (old frame rows gone), state map, prune removes orphans, tables exist on fresh DB.
-- [ ] Implement in `_create_table` + methods next to the auto-tag/queue sections (same `_write_lock`/`_get_safe_path` conventions).
-- [ ] pytest/ruff/mypy green; commit `feat(db): embedding storage tables and access methods`.
+- [x] Tests: store/read roundtrip, replace-on-restore semantics (old frame rows gone), state map, prune removes orphans, tables exist on fresh DB.
+- [x] Implement in `_create_table` + methods next to the auto-tag/queue sections (same `_write_lock`/`_get_safe_path` conventions).
+- [x] pytest/ruff/mypy green; commit `feat(db): embedding storage tables and access methods`.
 
 ### Task 3: `/api/similar` route
 

--- a/docs/superpowers/plans/2026-08-08-embedding-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-embedding-foundation.md
@@ -25,9 +25,9 @@
 
 **Produces:** `encode_vector(values: Sequence[float]) -> bytes` (L2-normalizes), `decode_vector(blob: bytes) -> list[float]`, `dot(a: list[float], b: list[float]) -> float`, `top_k(query: list[float], candidates: Iterable[tuple[str, list[float]]], k: int, exclude: set[str]) -> list[tuple[str, float]]` (desc by score).
 
-- [ ] Tests: roundtrip codec (float32 precision ~1e-6), normalization (norm 1.0; zero vector stays zero), top_k ordering/limit/exclude.
-- [ ] Implement with `struct.pack(f"<{n}f", ...)`, no numpy.
-- [ ] pytest/ruff/mypy green; commit `feat(core): vector codec and pure-python kNN for similarity`.
+- [x] Tests: roundtrip codec (float32 precision ~1e-6), normalization (norm 1.0; zero vector stays zero), top_k ordering/limit/exclude.
+- [x] Implement with `struct.pack(f"<{n}f", ...)`, no numpy.
+- [x] pytest/ruff/mypy green; commit `feat(core): vector codec and pure-python kNN for similarity`.
 
 ### Task 2: SQLite embedding tables + store methods
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.0",
 ]
+# GPU embedding indexer (scripts/media_indexer.py) — NEVER a server runtime dep
+indexer = [
+    "torch>=2.0",
+    "open_clip_torch>=2.24",
+]
 
 [project.scripts]
 arcade-scanner = "arcade_scanner.main:run_scanner"

--- a/scripts/media_indexer.py
+++ b/scripts/media_indexer.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""media_indexer.py — standalone GPU embedding indexer (similarity part 1).
+
+Computes CLIP-style embeddings for every video/image in the library and
+stores them in the main SQLite DB (embedding_meta / frame_embeddings).
+Modeled on the optimizer scripts: the server never imports this module and
+never needs the ML stack — install it separately with:
+
+    pip install -e ".[indexer]"
+
+Usage:
+    python3 scripts/media_indexer.py                 # incremental one-shot run
+    python3 scripts/media_indexer.py --rebuild       # drop + reindex everything
+    python3 scripts/media_indexer.py --watch --interval 3600
+    python3 scripts/media_indexer.py --model ViT-B-16
+
+torch/open_clip are imported lazily inside _load_model() so this module
+stays importable (and unit-testable) without them.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from arcade_scanner.core.similarity import encode_vector  # noqa: E402
+
+DEFAULT_MODEL = "ViT-B-16"
+FRAME_COUNT = 12
+SPAN_START = 0.05  # sample across 5%–95% of the duration
+SPAN_END = 0.95
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested without ffmpeg or torch)
+# ---------------------------------------------------------------------------
+
+def sample_timestamps(duration: float, count: int = FRAME_COUNT) -> list[float]:
+    """Uniform timestamps across 5%–95% of the duration.
+
+    Short videos get fewer samples (at most one per whole second), minimum 1.
+    Unknown/zero duration → single frame at 0.
+    """
+    if duration <= 0:
+        return [0.0]
+    usable = min(count, max(1, int(duration)))
+    if usable == 1:
+        return [duration * 0.5]
+    start = duration * SPAN_START
+    end = duration * SPAN_END
+    step = (end - start) / (usable - 1)
+    return [start + i * step for i in range(usable)]
+
+
+def needs_index(path: str, mtime: float, model: str,
+                state: dict[str, tuple[float, str]]) -> bool:
+    """True when the file is new, changed, or was indexed with another model."""
+    entry = state.get(path)
+    if entry is None:
+        return True
+    indexed_mtime, indexed_model = entry
+    return indexed_mtime != mtime or indexed_model != model
+
+
+def mean_of(vectors: list[list[float]]) -> list[float]:
+    dim = len(vectors[0])
+    return [sum(vec[i] for vec in vectors) / len(vectors) for i in range(dim)]
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg frame extraction
+# ---------------------------------------------------------------------------
+
+def extract_frames(path: str, timestamps: list[float]) -> list[bytes]:
+    """One JPEG per timestamp via ffmpeg. Raises on total failure."""
+    frames: list[bytes] = []
+    for ts in timestamps:
+        result = subprocess.run(
+            ["ffmpeg", "-v", "error", "-ss", f"{ts:.3f}", "-i", path,
+             "-frames:v", "1", "-f", "image2pipe", "-vcodec", "mjpeg", "-"],
+            capture_output=True, timeout=60,
+        )
+        if result.returncode == 0 and result.stdout:
+            frames.append(result.stdout)
+    if not frames:
+        raise RuntimeError(f"ffmpeg could not extract any frame from {path}")
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Model (lazy — the only place torch/open_clip are touched)
+# ---------------------------------------------------------------------------
+
+def _load_model(model_name: str):
+    try:
+        import open_clip
+        import torch
+    except ImportError as e:
+        raise SystemExit(
+            f"ML-Stack fehlt ({e}). Installieren mit: pip install -e \".[indexer]\""
+        ) from e
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("⚠️ Keine CUDA-GPU gefunden — CPU-Fallback (deutlich langsamer).")
+    model, _, preprocess = open_clip.create_model_and_transforms(
+        model_name, pretrained="openai" if model_name == "ViT-B-16" else None)
+    model = model.to(device).eval()
+    return model, preprocess, device
+
+
+def make_embed_fn(model_name: str):
+    """Returns embed(jpeg_frames: list[bytes]) -> list[list[float]]."""
+    import io
+
+    from PIL import Image
+
+    model, preprocess, device = _load_model(model_name)
+
+    def embed(jpeg_frames: list[bytes]) -> list[list[float]]:
+        import torch
+        images = [preprocess(Image.open(io.BytesIO(f)).convert("RGB"))
+                  for f in jpeg_frames]
+        batch = torch.stack(images).to(device)
+        with torch.no_grad():
+            features = model.encode_image(batch)
+        return [row.tolist() for row in features.cpu()]
+
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Orchestration (unit-tested with mocked embed/extract functions)
+# ---------------------------------------------------------------------------
+
+def index_library(media_db, model_name: str, embed_fn, extract_fn=extract_frames,
+                  rebuild: bool = False) -> dict[str, int]:
+    """Index all new/changed media. Returns counters for reporting."""
+    entries = media_db.get_all_dicts()
+    existing_paths = {str(e.get("FilePath") or "") for e in entries}
+    pruned = media_db.prune_embeddings(existing_paths)
+
+    state: dict[str, tuple[float, str]] = {} if rebuild else media_db.get_embedding_state()
+    counters = {"indexed": 0, "skipped": 0, "failed": 0, "pruned": pruned}
+
+    for entry in entries:
+        path = str(entry.get("FilePath") or "")
+        if not path:
+            continue
+        mtime = float(entry.get("mtime") or 0)
+        if not needs_index(path, mtime, model_name, state):
+            counters["skipped"] += 1
+            continue
+        try:
+            if entry.get("media_type") == "image":
+                timestamps = [0.0]
+            else:
+                timestamps = sample_timestamps(float(entry.get("Duration_Sec") or 0))
+            frames = extract_fn(path, timestamps)
+            vectors = embed_fn(frames)
+            frame_rows = [(i, timestamps[i] if i < len(timestamps) else 0.0,
+                           encode_vector(vec)) for i, vec in enumerate(vectors)]
+            media_db.store_embedding(
+                path, model_name, len(vectors[0]), mtime,
+                encode_vector(mean_of(vectors)), frame_rows)
+            counters["indexed"] += 1
+            print(f"✅ [{counters['indexed']}] {Path(path).name} ({len(vectors)} frames)")
+        except Exception as e:
+            counters["failed"] += 1
+            print(f"❌ Skipping {Path(path).name}: {e}")
+
+    return counters
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Arcade Scanner Embedding Indexer")
+    parser.add_argument("--model", default=DEFAULT_MODEL,
+                        help=f"open_clip model name (default: {DEFAULT_MODEL})")
+    parser.add_argument("--rebuild", action="store_true",
+                        help="drop skip-state and reindex everything")
+    parser.add_argument("--watch", action="store_true",
+                        help="keep running and re-check periodically")
+    parser.add_argument("--interval", type=int, default=3600,
+                        help="seconds between watch runs (default: 3600)")
+    args = parser.parse_args()
+
+    from arcade_scanner.database import db as media_db
+
+    embed_fn = make_embed_fn(args.model)
+    while True:
+        started = time.time()
+        counters = index_library(media_db, args.model, embed_fn, rebuild=args.rebuild)
+        args.rebuild = False  # only the first watch pass rebuilds
+        print(f"🏁 Indexed {counters['indexed']}, skipped {counters['skipped']}, "
+              f"failed {counters['failed']}, pruned {counters['pruned']} "
+              f"in {time.time() - started:.1f}s")
+        if not args.watch:
+            break
+        time.sleep(max(60, args.interval))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_media_indexer.py
+++ b/tests/test_media_indexer.py
@@ -1,0 +1,131 @@
+# tests/test_media_indexer.py
+"""Indexer logic tests — mocked model + extraction, no ffmpeg, no torch."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.media_indexer import (  # noqa: E402
+    index_library,
+    mean_of,
+    needs_index,
+    sample_timestamps,
+)
+
+
+class TestSampling:
+    def test_twelve_frames_within_span(self):
+        ts = sample_timestamps(600.0)
+        assert len(ts) == 12
+        assert ts[0] == 600.0 * 0.05
+        assert ts[-1] == 600.0 * 0.95
+        assert ts == sorted(ts)
+
+    def test_short_video_gets_fewer_frames(self):
+        assert len(sample_timestamps(3.0)) == 3
+
+    def test_one_second_video_gets_single_middle_frame(self):
+        assert sample_timestamps(1.0) == [0.5]
+
+    def test_zero_duration_single_frame_at_start(self):
+        assert sample_timestamps(0.0) == [0.0]
+
+
+class TestNeedsIndex:
+    def test_new_file(self):
+        assert needs_index("/a", 1.0, "m", {}) is True
+
+    def test_unchanged_is_skipped(self):
+        assert needs_index("/a", 1.0, "m", {"/a": (1.0, "m")}) is False
+
+    def test_changed_mtime_reindexes(self):
+        assert needs_index("/a", 2.0, "m", {"/a": (1.0, "m")}) is True
+
+    def test_changed_model_reindexes(self):
+        assert needs_index("/a", 1.0, "ViT-L-14", {"/a": (1.0, "ViT-B-16")}) is True
+
+
+def test_mean_of_vectors():
+    assert mean_of([[1.0, 0.0], [0.0, 1.0]]) == [0.5, 0.5]
+
+
+class FakeStore:
+    def __init__(self, entries, state=None):
+        self._entries = entries
+        self._state = state or {}
+        self.stored = []
+        self.pruned_with = None
+
+    def get_all_dicts(self):
+        return self._entries
+
+    def get_embedding_state(self):
+        return dict(self._state)
+
+    def prune_embeddings(self, existing):
+        self.pruned_with = set(existing)
+        return 0
+
+    def store_embedding(self, path, model, dim, mtime, mean_vector, frames):
+        self.stored.append({"path": path, "model": model, "dim": dim,
+                            "mtime": mtime, "frames": len(frames)})
+
+
+def _entry(path="/lib/a.mp4", **kw):
+    base = {"FilePath": path, "Duration_Sec": 600.0, "media_type": "video", "mtime": 100}
+    base.update(kw)
+    return base
+
+
+def _fake_extract(path, timestamps):
+    return [b"jpeg"] * len(timestamps)
+
+
+def _fake_embed(frames):
+    return [[1.0, 0.0] for _ in frames]
+
+
+def test_index_library_indexes_new_and_skips_indexed():
+    store = FakeStore(
+        [_entry(), _entry("/lib/done.mp4")],
+        state={"/lib/done.mp4": (100.0, "ViT-B-16")},
+    )
+    counters = index_library(store, "ViT-B-16", _fake_embed, extract_fn=_fake_extract)
+    assert counters == {"indexed": 1, "skipped": 1, "failed": 0, "pruned": 0}
+    assert store.stored[0]["path"] == "/lib/a.mp4"
+    assert store.stored[0]["frames"] == 12
+    assert store.stored[0]["dim"] == 2
+    assert store.pruned_with == {"/lib/a.mp4", "/lib/done.mp4"}
+
+
+def test_index_library_rebuild_ignores_state():
+    store = FakeStore([_entry()], state={"/lib/a.mp4": (100.0, "ViT-B-16")})
+    counters = index_library(store, "ViT-B-16", _fake_embed,
+                             extract_fn=_fake_extract, rebuild=True)
+    assert counters["indexed"] == 1
+
+
+def test_index_library_image_gets_single_frame():
+    store = FakeStore([_entry("/lib/pic.jpg", media_type="image", Duration_Sec=0)])
+    index_library(store, "ViT-B-16", _fake_embed, extract_fn=_fake_extract)
+    assert store.stored[0]["frames"] == 1
+
+
+def test_index_library_failure_skips_file_and_continues():
+    def broken_extract(path, timestamps):
+        if "bad" in path:
+            raise RuntimeError("decode error")
+        return _fake_extract(path, timestamps)
+
+    store = FakeStore([_entry("/lib/bad.mp4"), _entry("/lib/good.mp4")])
+    counters = index_library(store, "ViT-B-16", _fake_embed, extract_fn=broken_extract)
+    assert counters["failed"] == 1
+    assert counters["indexed"] == 1
+    assert [s["path"] for s in store.stored] == ["/lib/good.mp4"]
+
+
+def test_module_imports_without_ml_stack():
+    # This suite runs in a venv WITHOUT torch/open_clip — importing the module
+    # (already done above) and its pure helpers must not require them.
+    assert "torch" not in sys.modules
+    assert "open_clip" not in sys.modules

--- a/tests/test_routes_similar.py
+++ b/tests/test_routes_similar.py
@@ -1,0 +1,141 @@
+# tests/test_routes_similar.py
+"""Route tests for /api/similar — FakeHandler pattern from test_routes_queue.py."""
+import json
+from unittest.mock import MagicMock, patch
+
+from arcade_scanner.core.similarity import encode_vector
+from arcade_scanner.server.routes import similar
+
+
+class FakeHandler:
+    def __init__(self, path, user="alice"):
+        self.path = path
+        self._user = user
+        self.wfile = MagicMock()
+        self.status = None
+        self.error = None
+        self.headers = {}
+
+    def get_current_user(self):
+        return self._user
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_error(self, code, message=""):
+        self.error = code
+
+    def send_header(self, key, value):
+        pass
+
+    def end_headers(self):
+        pass
+
+    def body(self):
+        raw = b"".join(c.args[0] for c in self.wfile.write.call_args_list)
+        return json.loads(raw)
+
+
+class FakeMediaDB:
+    def __init__(self, vectors=()):
+        # vectors: list of (path, raw_values)
+        self._vectors = [(p, "m", encode_vector(v)) for p, v in vectors]
+        self.callbacks = []
+
+    def get_mean_vectors(self):
+        return list(self._vectors)
+
+    def register_on_change(self, cb):
+        self.callbacks.append(cb)
+
+
+def _user_db(vaulted=()):
+    user_db = MagicMock()
+    u = MagicMock()
+    u.data.vaulted = list(vaulted)
+    user_db.get_user.return_value = u
+    return user_db
+
+
+def run(handler, media_db=None, user_db=None):
+    media_db = media_db if media_db is not None else FakeMediaDB()
+    user_db = user_db or _user_db()
+    similar._cache.invalidate()
+    similar._cache._hooked = False
+    with patch.object(similar, "_get_deps", return_value=(media_db, user_db)):
+        handled = similar.handle_get(handler)
+    return handled
+
+
+def test_unrelated_path_not_handled():
+    assert run(FakeHandler("/api/other")) is False
+
+
+def test_requires_session():
+    h = FakeHandler("/api/similar?path=/lib/a.mp4", user=None)
+    assert run(h) is True
+    assert h.error == 401
+
+
+def test_missing_path_is_400():
+    h = FakeHandler("/api/similar")
+    assert run(h) is True
+    assert h.error == 400
+
+
+def test_empty_index_reports_not_indexed():
+    h = FakeHandler("/api/similar?path=/lib/a.mp4")
+    assert run(h, FakeMediaDB()) is True
+    assert h.body() == {"status": "not_indexed"}
+
+
+def test_unknown_path_is_404():
+    h = FakeHandler("/api/similar?path=/lib/missing.mp4")
+    db = FakeMediaDB([("/lib/a.mp4", [1.0, 0.0])])
+    assert run(h, db) is True
+    assert h.error == 404
+
+
+def test_ranked_results_exclude_query_and_respect_limit():
+    db = FakeMediaDB([
+        ("/lib/query.mp4", [1.0, 0.0]),
+        ("/lib/close.mp4", [0.9, 0.1]),
+        ("/lib/mid.mp4", [0.5, 0.5]),
+        ("/lib/far.mp4", [0.0, 1.0]),
+    ])
+    h = FakeHandler("/api/similar?path=/lib/query.mp4&limit=2")
+    assert run(h, db) is True
+    body = h.body()
+    assert body["status"] == "ok"
+    paths = [r["file_path"] for r in body["results"]]
+    assert paths == ["/lib/close.mp4", "/lib/mid.mp4"]
+    assert "/lib/query.mp4" not in paths
+    assert body["results"][0]["score"] >= body["results"][1]["score"]
+
+
+def test_vaulted_results_omitted():
+    db = FakeMediaDB([
+        ("/lib/query.mp4", [1.0, 0.0]),
+        ("/lib/secret.mp4", [1.0, 0.0]),
+        ("/lib/ok.mp4", [0.5, 0.5]),
+    ])
+    h = FakeHandler("/api/similar?path=/lib/query.mp4")
+    assert run(h, db, _user_db(vaulted=["/lib/secret.mp4"])) is True
+    paths = [r["file_path"] for r in h.body()["results"]]
+    assert paths == ["/lib/ok.mp4"]
+
+
+def test_cache_invalidated_via_on_change_hook():
+    db = FakeMediaDB([("/lib/query.mp4", [1.0, 0.0]), ("/lib/a.mp4", [0.9, 0.1])])
+    h = FakeHandler("/api/similar?path=/lib/query.mp4")
+    run(h, db)
+    assert db.callbacks, "cache must register an on_change hook"
+    # simulate an indexer write: new vector appears after invalidation
+    db._vectors.append(("/lib/new.mp4", "m", encode_vector([0.95, 0.05])))
+    for cb in db.callbacks:
+        cb()
+    h2 = FakeHandler("/api/similar?path=/lib/query.mp4")
+    with patch.object(similar, "_get_deps", return_value=(db, _user_db())):
+        similar.handle_get(h2)
+    paths = [r["file_path"] for r in h2.body()["results"]]
+    assert "/lib/new.mp4" in paths

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,0 +1,62 @@
+# tests/test_similarity.py
+"""Unit tests for the vector codec and pure-Python kNN (no numpy, no ML stack)."""
+import math
+
+from arcade_scanner.core.similarity import decode_vector, dot, encode_vector, top_k
+
+
+def test_roundtrip_preserves_direction():
+    blob = encode_vector([3.0, 4.0])
+    values = decode_vector(blob)
+    assert len(values) == 2
+    # encode normalizes: (3,4) → (0.6, 0.8)
+    assert math.isclose(values[0], 0.6, abs_tol=1e-6)
+    assert math.isclose(values[1], 0.8, abs_tol=1e-6)
+
+
+def test_encoded_vector_is_unit_length():
+    values = decode_vector(encode_vector([1.0, 2.0, 3.0, 4.0]))
+    norm = math.sqrt(sum(v * v for v in values))
+    assert math.isclose(norm, 1.0, abs_tol=1e-6)
+
+
+def test_zero_vector_stays_zero():
+    values = decode_vector(encode_vector([0.0, 0.0, 0.0]))
+    assert values == [0.0, 0.0, 0.0]
+
+
+def test_blob_is_float32_layout():
+    blob = encode_vector([1.0, 0.0])
+    assert len(blob) == 8  # 2 × 4 bytes
+
+
+def test_dot_of_normalized_vectors_is_cosine():
+    a = decode_vector(encode_vector([1.0, 0.0]))
+    b = decode_vector(encode_vector([1.0, 1.0]))
+    assert math.isclose(dot(a, b), math.cos(math.pi / 4), abs_tol=1e-6)
+
+
+def test_top_k_orders_and_limits():
+    query = decode_vector(encode_vector([1.0, 0.0]))
+    candidates = [
+        ("/lib/same.mp4", decode_vector(encode_vector([1.0, 0.0]))),
+        ("/lib/close.mp4", decode_vector(encode_vector([0.9, 0.1]))),
+        ("/lib/far.mp4", decode_vector(encode_vector([0.0, 1.0]))),
+    ]
+    results = top_k(query, candidates, k=2, exclude=set())
+    assert [p for p, _ in results] == ["/lib/same.mp4", "/lib/close.mp4"]
+    assert results[0][1] >= results[1][1]
+
+
+def test_top_k_excludes_paths():
+    query = decode_vector(encode_vector([1.0, 0.0]))
+    candidates = [
+        ("/lib/query.mp4", query),
+        ("/lib/other.mp4", decode_vector(encode_vector([0.5, 0.5]))),
+    ]
+    results = top_k(query, candidates, k=5, exclude={"/lib/query.mp4"})
+    assert [p for p, _ in results] == ["/lib/other.mp4"]
+
+
+def test_top_k_empty_candidates():
+    assert top_k([1.0], [], k=3, exclude=set()) == []

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -411,3 +411,53 @@ class TestConcurrentReads:
 
         assert errors == [], f"first failure: {errors[0]}"
         assert len(set(seen)) == 1, "threads ended up on different connections"
+
+
+# ---------------------------------------------------------------------------
+# Embedding storage (similarity part 1)
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingStorage:
+    def test_tables_exist(self, store):
+        rows = store._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('embedding_meta', 'frame_embeddings')").fetchall()
+        assert len(rows) == 2
+
+    def test_store_and_read_roundtrip(self, store):
+        store.store_embedding("/lib/a.mp4", "ViT-B-16", 2, 111.0, b"MEAN",
+                              [(0, 1.5, b"F0"), (1, 3.0, b"F1")])
+        state = store.get_embedding_state()
+        assert state == {"/lib/a.mp4": (111.0, "ViT-B-16")}
+        vectors = store.get_mean_vectors()
+        assert vectors == [("/lib/a.mp4", "ViT-B-16", b"MEAN")]
+        frames = store._conn.execute(
+            "SELECT frame_index, ts_sec, vector FROM frame_embeddings "
+            "WHERE file_path = ? ORDER BY frame_index", ("/lib/a.mp4",)).fetchall()
+        assert [(r["frame_index"], r["ts_sec"], r["vector"]) for r in frames] == [
+            (0, 1.5, b"F0"), (1, 3.0, b"F1")]
+
+    def test_restore_replaces_old_rows(self, store):
+        store.store_embedding("/lib/a.mp4", "ViT-B-16", 2, 111.0, b"OLD",
+                              [(0, 1.0, b"X"), (1, 2.0, b"Y"), (2, 3.0, b"Z")])
+        store.store_embedding("/lib/a.mp4", "ViT-L-14", 2, 222.0, b"NEW", [(0, 1.0, b"N")])
+        assert store.get_embedding_state() == {"/lib/a.mp4": (222.0, "ViT-L-14")}
+        assert store.get_mean_vectors() == [("/lib/a.mp4", "ViT-L-14", b"NEW")]
+        count = store._conn.execute(
+            "SELECT COUNT(*) FROM frame_embeddings WHERE file_path = ?",
+            ("/lib/a.mp4",)).fetchone()[0]
+        assert count == 1
+
+    def test_delete_embedding(self, store):
+        store.store_embedding("/lib/a.mp4", "m", 1, 1.0, b"V", [(0, 0.0, b"F")])
+        store.delete_embedding("/lib/a.mp4")
+        assert store.get_embedding_state() == {}
+        count = store._conn.execute("SELECT COUNT(*) FROM frame_embeddings").fetchone()[0]
+        assert count == 0
+
+    def test_prune_removes_orphans(self, store):
+        store.store_embedding("/lib/keep.mp4", "m", 1, 1.0, b"V", [])
+        store.store_embedding("/lib/gone.mp4", "m", 1, 1.0, b"V", [])
+        removed = store.prune_embeddings({"/lib/keep.mp4"})
+        assert removed == 1
+        assert list(store.get_embedding_state()) == ["/lib/keep.mp4"]


### PR DESCRIPTION
## Was das ist

Teil 1 der Ähnlichkeits-/Semantik-Serie (Spec: `docs/superpowers/specs/2026-08-07-embedding-foundation-design.md`, Plan mit abgehakten Tasks: `docs/superpowers/plans/2026-08-08-embedding-foundation.md`). Nachtlauf 2, Phase B.

- **`core/similarity.py`**: Float32-Blob-Codec (struct, kein NumPy), L2-Normalisierung beim Encoden, Brute-Force-kNN per Skalarprodukt.
- **SQLite**: `embedding_meta` (Mean-Vektor + mtime/Modell-Buchhaltung) und `frame_embeddings` (12 Einzel-Frames für spätere Ausschnitt-Erkennung); Schreiben pro Datei atomar, Prune für gelöschte Dateien.
- **`GET /api/similar?path=…&limit=12`**: Session-pflichtig, Vault-gefiltert, `not_indexed`-Antwort ohne Index, 404 für unindizierte Pfade; Mean-Vektor-Cache invalidiert sich über `register_on_change` bei Indexer-Läufen selbst.
- **`scripts/media_indexer.py`**: eigenständiger GPU-Indexer nach Optimizer-Vorbild — torch/open_clip nur lazy (`pip install -e ".[indexer]"`), Default ViT-B-16, 12 gleichverteilte Frames (5–95 %), Bilder 1 Frame, inkrementell über mtime+Modell, `--watch/--interval/--rebuild/--model`, Fehlerdateien werden geloggt und übersprungen.

## Verifikation

580 Tests, ruff, mypy — alles grün, **ohne** installierten ML-Stack (das beweist zugleich, dass kein Server-Modul torch braucht). Indexer-Logik (Sampling, Skip, Fehlerpfad) mit gemocktem Modell getestet.

## Offen / bewusst nicht enthalten

- **GPU-Echtlauf steht aus**: bitte einmal auf dem 4090-PC `pip install -e ".[indexer]"` und `python3 scripts/media_indexer.py` laufen lassen (erster Lauf lädt das Modell herunter). Danach liefert `/api/similar` echte Nachbarn.
- Teil 2–4 folgen als eigene Projekte: „Ähnliche Videos"-Leiste im Cinema, Themen-Clustering, semantische Textsuche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)