### PR TITLE
feat: Scan aus der UI stoppen (/api/scan/stop) + Hintergrund-Rescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Scan-Steuerung
+- **Scan stoppen aus der UI** (ROADMAP-Punkt): neuer Stop-Button neben dem
+  Rescan-Button, `GET /api/scan/stop` signalisiert `ScannerManager.stop()`.
+  Teilergebnisse bleiben erhalten (Orphan-Cleanup wird serverseitig
+  übersprungen).
+- **`/api/rescan` läuft im Hintergrund**: antwortet sofort mit 202 statt den
+  Request zu blockieren (Voraussetzung fürs Stoppen), `GET /api/scan/status`
+  zum Pollen; das Frontend lädt nach Abschluss automatisch neu. Doppelte
+  Scans werden mit 409 abgewiesen.
+
 ### Changed — Video Optimizer V2.5
 - **Downscaling**: New `--scale-height H` option scales the encode to H pixels height while keeping the source aspect ratio (width `-2`). Upscaling is refused, the SSIM reference is scaled to match so quality checks stay valid, and the constrained-VBR ladder is adjusted to the target resolution (~pixels^0.75) so a downscale actually converts into savings.
 - **Sample-Clip Pre-Search**: The quality binary search now runs on a ~24s stream-copied probe clip first, then narrows the full-encode search to predicted ±1 — typically 1-2 full passes instead of 3-4 (files ≥ 120s; `--no-presearch` to disable).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,12 +17,10 @@ This document outlines planned features and improvements for the Arcade Media Sc
 
 ### 🟢 User Experience
 - [ ] Customizable grid layout (card size, columns)
-- [ ] **Stop a running scan from the UI.** `ScannerManager.stop()` exists and
-      works — the startup scan runs in a daemon thread (`main.py:100`), so the
-      flag is reachable — but nothing calls it. Needs a `/api/scan/stop`
-      endpoint. Note that `/api/rescan` currently runs the scan synchronously
-      and blocks its request thread, so a scan started that way cannot be
-      stopped until it also moves to a background task.
+- [x] **Stop a running scan from the UI.** (2026-08-08) `/api/scan/stop` +
+      `/api/scan/status` Endpoints, Stop-Button neben dem Rescan-Button;
+      `/api/rescan` läuft dafür jetzt als Hintergrund-Thread (202 + Polling
+      statt blockierendem Request).
 - [x] Keyboard shortcuts for common actions (arrows = navigate in cinema)
 
 ---

--- a/arcade_scanner/server/routes/files.py
+++ b/arcade_scanner/server/routes/files.py
@@ -96,6 +96,16 @@ def handle_get(handler) -> bool:
         _handle_rescan(handler)
         return True
 
+    # /api/scan/status
+    if path == "/api/scan/status":
+        _handle_scan_status(handler)
+        return True
+
+    # /api/scan/stop
+    if path == "/api/scan/stop":
+        _handle_scan_stop(handler)
+        return True
+
     # /api/backup
     if path == "/api/backup":
         _handle_backup(handler)
@@ -644,44 +654,101 @@ def _handle_batch_compress(handler) -> None:
         handler.send_error(500)
 
 
-def _handle_rescan(handler) -> None:
+def _run_rescan_in_background(port: int) -> None:
+    """Scan + auto-tagging + report rebuild — body of the rescan thread."""
     import asyncio
-    import json
 
     from arcade_scanner.scanner import get_scanner_manager
     from arcade_scanner.templates.dashboard_template import generate_html_report
+
+    try:
+        mgr = get_scanner_manager()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(mgr.run_scan())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+        try:
+            # Auto-Tagging-Hook — landet mit PR #34; bis dahin fehlt das Modul
+            from arcade_scanner.core.auto_tagger import run_post_scan_auto_tagging
+            run_post_scan_auto_tagging()
+        except ImportError:
+            pass
+
+        media_cache = _get_media_cache()
+        results = [e.model_dump(by_alias=True) for e in media_cache.get()]
+        media_cache.invalidate()
+        generate_html_report(results, config.report_file, server_port=port)
+        print("✅ Rescan complete.")
+    except Exception as e:
+        print(f"❌ Rescan failed: {e}")
+
+
+def _handle_rescan(handler) -> None:
+    """Start a background rescan (202) — no longer blocks its request thread,
+    which makes /api/scan/stop able to reach a running scan (ROADMAP item)."""
+    import json
+    import threading
+
+    from arcade_scanner.scanner import get_scanner_manager
 
     user_name = handler.get_current_user()
     if not user_name:
         handler.send_error(401, "Unauthorized")
         return
 
+    mgr = get_scanner_manager()
+    if mgr.is_scanning:
+        handler.send_error(409, "Scan already in progress")
+        return
+
     print("🔄 Scan requested via API...")
-    try:
-        mgr = get_scanner_manager()
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            new_count = loop.run_until_complete(mgr.run_scan())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
+    port = handler.server.server_address[1]
+    t = threading.Thread(target=_run_rescan_in_background, args=(port,), daemon=True)
+    t.start()
 
-        media_cache = _get_media_cache()
-        port = handler.server.server_address[1]
-        results = [e.model_dump(by_alias=True) for e in media_cache.get()]
-        media_cache.invalidate()
-        generate_html_report(results, config.report_file, server_port=port)
+    handler.send_response(202)
+    handler.send_header("Content-type", "application/json")
+    handler.end_headers()
+    handler.wfile.write(json.dumps({"status": "started"}).encode())
 
-        handler.send_response(200)
-        handler.send_header("Content-type", "application/json")
-        handler.end_headers()
-        handler.wfile.write(json.dumps({"status": "complete", "count": new_count}).encode())
-        print("✅ Rescan complete.")
 
-    except Exception as e:
-        print(f"❌ Rescan failed: {e}")
-        handler.send_error(500, str(e))
+def _handle_scan_status(handler) -> None:
+    import json
+
+    from arcade_scanner.scanner import get_scanner_manager
+
+    if not handler.get_current_user():
+        handler.send_error(401, "Unauthorized")
+        return
+    handler.send_response(200)
+    handler.send_header("Content-type", "application/json")
+    handler.end_headers()
+    handler.wfile.write(json.dumps(
+        {"is_scanning": bool(get_scanner_manager().is_scanning)}).encode())
+
+
+def _handle_scan_stop(handler) -> None:
+    import json
+
+    from arcade_scanner.scanner import get_scanner_manager
+
+    if not handler.get_current_user():
+        handler.send_error(401, "Unauthorized")
+        return
+    mgr = get_scanner_manager()
+    if not mgr.is_scanning:
+        handler.send_error(409, "No scan running")
+        return
+    mgr.stop()
+    print("⏹ Scan stop requested via API.")
+    handler.send_response(200)
+    handler.send_header("Content-type", "application/json")
+    handler.end_headers()
+    handler.wfile.write(json.dumps({"status": "stopping"}).encode())
 
 
 def _handle_backup(handler) -> None:

--- a/arcade_scanner/server/static/settings.js
+++ b/arcade_scanner/server/static/settings.js
@@ -556,26 +556,60 @@ async function revealInFinder(path) {
  */
 function rescanLibrary() {
     const btn = document.getElementById('refreshBtn');
+    const stopBtn = document.getElementById('stopScanBtn');
     const originalContent = btn.innerHTML;
 
-    btn.innerHTML = '<span class="material-icons spin">sync</span> SCANNEN...';
+    btn.innerHTML = '<span class="material-icons spin">sync</span>';
     btn.style.pointerEvents = 'none';
-    document.body.style.opacity = '0.5';
+    if (stopBtn) stopBtn.classList.remove('hidden');
 
+    const restore = () => {
+        btn.innerHTML = originalContent;
+        btn.style.pointerEvents = 'auto';
+        if (stopBtn) stopBtn.classList.add('hidden');
+    };
+
+    // /api/rescan antwortet 202 und scannt im Hintergrund — Fortschritt pollen,
+    // damit /api/scan/stop den laufenden Scan erreichen kann.
     fetch('/api/rescan')
         .then(response => {
-            if (response.ok) return response.json();
-            throw new Error('Scan failed');
+            if (response.status === 409) throw new Error('Scan läuft bereits');
+            if (!response.ok) throw new Error('Scan failed');
+            return response.json();
         })
         .then(() => {
-            location.reload();
+            const poll = setInterval(() => {
+                fetch('/api/scan/status')
+                    .then(r => r.json())
+                    .then(status => {
+                        if (!status.is_scanning) {
+                            clearInterval(poll);
+                            location.reload();
+                        }
+                    })
+                    .catch(() => { clearInterval(poll); restore(); });
+            }, 2000);
         })
         .catch(e => {
             console.error(e);
-            alert('Scan error: ' + e.message);
-            btn.innerHTML = originalContent;
-            btn.style.pointerEvents = 'auto';
-            document.body.style.opacity = '1';
+            if (typeof showToast === 'function') showToast(e.message, 'error');
+            restore();
+        });
+}
+
+/**
+ * Stop a running library scan (partial results are kept; orphan cleanup is
+ * skipped server-side to protect existing entries).
+ */
+function stopScan() {
+    fetch('/api/scan/stop')
+        .then(r => {
+            if (r.status === 409) throw new Error('Kein Scan aktiv');
+            if (!r.ok) throw new Error('Stop fehlgeschlagen');
+            if (typeof showToast === 'function') showToast('Scan wird gestoppt…', 'info');
+        })
+        .catch(e => {
+            if (typeof showToast === 'function') showToast(e.message, 'warning');
         });
 }
 
@@ -838,6 +872,7 @@ window.revealInFinder = revealInFinder;
 
 // Rescan
 window.rescanLibrary = rescanLibrary;
+window.stopScan = stopScan;
 
 // Saved views
 window.renderSavedViews = renderSavedViews;

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -2223,6 +2223,9 @@ FILTER_BAR_COMPONENT = """
         <button id="refreshBtn" onclick="rescanLibrary()" class="bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white p-2 rounded-full transition-colors flex items-center justify-center flex-shrink-0" title="Rescan Library">
             <span class="material-icons text-[18px]">refresh</span>
         </button>
+        <button id="stopScanBtn" onclick="stopScan()" class="hidden bg-red-500/10 hover:bg-red-500/20 text-red-400 hover:text-red-300 p-2 rounded-full transition-colors flex items-center justify-center flex-shrink-0" title="Scan stoppen">
+            <span class="material-icons text-[18px]">stop</span>
+        </button>
     </div>
 </div>
 

--- a/tests/test_routes_files.py
+++ b/tests/test_routes_files.py
@@ -91,6 +91,7 @@ def _stub_scanner_manager():
         return 0
 
     manager.run_scan = no_scan
+    manager.is_scanning = False  # MagicMock default is truthy → 409-Guard griffe
     return manager
 
 
@@ -112,6 +113,7 @@ def run_route(handler, fake_db=None, path_allowed=True, exists=True):
                return_value=exists), \
          patch("arcade_scanner.scanner.get_scanner_manager",
                return_value=_stub_scanner_manager()), \
+         patch("arcade_scanner.server.routes.files._run_rescan_in_background"), \
          patch("arcade_scanner.templates.dashboard_template.generate_html_report"), \
          patch("arcade_scanner.server.routes.files.subprocess.run") as run:
         handled = files.handle_get(handler)
@@ -134,6 +136,8 @@ ROUTES = [
     "/batch_favorite?paths=/media/a.mp4",
     "/batch_compress?paths=/media/a.mp4",
     "/api/rescan",
+    "/api/scan/status",
+    "/api/scan/stop",
     "/api/backup",
 ]
 
@@ -278,3 +282,74 @@ class TestMarkOptimized:
         _, db, _, _ = run_route(handler)
         assert db.upserted == []
         assert handler.status == 204
+
+
+# ---------------------------------------------------------------------------
+# /api/rescan (background) + /api/scan/status + /api/scan/stop
+# ---------------------------------------------------------------------------
+
+def run_scan_route(handler, is_scanning=False):
+    """Like run_route, but with a controllable scanner manager."""
+    manager = _stub_scanner_manager()
+    manager.is_scanning = is_scanning
+    with patch("arcade_scanner.scanner.get_scanner_manager", return_value=manager), \
+         patch("arcade_scanner.server.routes.files._run_rescan_in_background") as bg:
+        handled = files.handle_get(handler)
+    return handled, manager, bg
+
+
+class TestScanControl:
+    def test_rescan_starts_background_and_returns_202(self):
+        handler = FakeHandler("/api/rescan")
+        handled, _, bg = run_scan_route(handler)
+        assert handled is True
+        assert handler.status == 202
+        assert handler.body == {"status": "started"}
+        bg.assert_called_once()
+
+    def test_rescan_conflicts_while_scanning(self):
+        handler = FakeHandler("/api/rescan")
+        handled, _, bg = run_scan_route(handler, is_scanning=True)
+        assert handled is True
+        assert handler.error == 409
+        bg.assert_not_called()
+
+    def test_rescan_requires_session(self):
+        handler = FakeHandler("/api/rescan", user=None)
+        handled, _, bg = run_scan_route(handler)
+        assert handled is True
+        assert handler.error == 401
+        bg.assert_not_called()
+
+    def test_status_reports_scanning_flag(self):
+        handler = FakeHandler("/api/scan/status")
+        handled, _, _ = run_scan_route(handler, is_scanning=True)
+        assert handled is True
+        assert handler.body == {"is_scanning": True}
+
+    def test_status_requires_session(self):
+        handler = FakeHandler("/api/scan/status", user=None)
+        handled, *_ = run_scan_route(handler)
+        assert handled is True
+        assert handler.error == 401
+
+    def test_stop_signals_running_scan(self):
+        handler = FakeHandler("/api/scan/stop")
+        handled, manager, _ = run_scan_route(handler, is_scanning=True)
+        assert handled is True
+        assert handler.body == {"status": "stopping"}
+        manager.stop.assert_called_once()
+
+    def test_stop_without_scan_conflicts(self):
+        handler = FakeHandler("/api/scan/stop")
+        handled, manager, _ = run_scan_route(handler)
+        assert handled is True
+        assert handler.error == 409
+        manager.stop.assert_not_called()
+
+    def test_stop_requires_session(self):
+        handler = FakeHandler("/api/scan/stop", user=None)
+        handled, manager, _ = run_scan_route(handler)
+        assert handled is True
+        assert handler.error == 401
+        manager.stop.assert_not_called()


### PR DESCRIPTION
## Was das ist

Der offene ROADMAP-Punkt **„Stop a running scan from the UI"** (Nachtlauf 2, Phase C).

- **`GET /api/rescan`** blockiert nicht mehr: startet den Scan als Daemon-Thread und antwortet sofort `202 {"status":"started"}`; laufender Scan → `409`. (Genau die Voraussetzung, die die ROADMAP-Notiz beschrieb — vorher war ein per API gestarteter Scan nicht stoppbar.)
- **`GET /api/scan/status`** → `{"is_scanning": bool}` zum Pollen.
- **`GET /api/scan/stop`** → signalisiert `ScannerManager.stop()` (`409`, wenn kein Scan läuft). Teilergebnisse bleiben erhalten — der Scanner überspringt beim Abbruch bewusst das Orphan-Cleanup (bestehendes Verhalten, `manager.py`).
- **UI**: Stop-Button (rot) neben dem Rescan-Button, sichtbar nur während eines Scans; `rescanLibrary()` pollt den Status und lädt nach Abschluss neu, statt auf die (jetzt sofortige) Antwort zu warten.
- Der Auto-Tagging-Post-Scan-Hook im Hintergrund-Body ist import-tolerant (`try/except ImportError`), damit dieser PR unabhängig von PR #34 mergebar ist — nach dem Merge von #34 greift er automatisch.

## Verifikation

557 Tests grün (8 neue für rescan-202/409, status, stop inkl. Session-Pflicht; Test-Harness verhindert echte Scan-Threads), ruff + mypy sauber, JS-Contract-Suiten grün. Alle GET-Endpoints Session-pflichtig.

Hinweis: bewusst GET statt POST für stop/rescan — folgt der bestehenden `/api/rescan`-Konvention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)