### PR TITLE
fix(dedup): phash-Cache erkennt geänderte Dateien

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Duplikat-Scan: veraltete perceptual Hashes** (`.phash_cache.json`): Der Cache
+  war nur nach Dateipfad indiziert, ohne jede Angabe, aus welchem Dateizustand
+  der Hash stammt. Wurde ein Bild an Ort und Stelle geändert (Neu-Export,
+  Rotation, Rsync über denselben Pfad), lieferte der Cache weiterhin den alten
+  Hash — die Datei landete in einer Duplikatgruppe, die es nicht mehr gab, und
+  genau diese Gruppen bietet die UI zum Löschen an. Cache-Einträge tragen jetzt
+  `mtime_ns` + Dateigröße und werden bei Abweichung neu berechnet (Format v2).
+  Alte v1-Caches werden beim ersten Laden übernommen und mit dem aktuellen
+  Dateizustand gestempelt, statt eine komplette Neuberechnung zu erzwingen.
+  Das Schreiben läuft jetzt über write-then-rename, damit ein Absturz mitten im
+  Speichern nicht den ganzen Cache als kaputtes JSON verwirft.
 - **Duplikat-Scan brach sofort ab** (`'dict' object has no attribute 'file_path'`):
   Der OOM-Fix hatte `_media_cache` von `db.get_all()` auf `db.get_all_dicts()`
   umgestellt — API-Dicts mit UI-Aliasen (`FilePath`) statt `VideoEntry`-Modellen.

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -160,9 +160,13 @@ class DuplicateDetector:
     - Hash bucketing eliminates O(n²) comparisons
     """
 
+    # Bumped whenever the on-disk cache layout changes.
+    HASH_CACHE_VERSION = 2
+
     def __init__(self):
         self._group_counter = 0
-        self._hash_cache: Dict[str, str] = {}  # filepath -> phash hex string
+        # filepath -> (phash hex string, mtime_ns, size_bytes)
+        self._hash_cache: Dict[str, Tuple[str, int, int]] = {}
         self._hash_cache_dirty = False
         self._hash_cache_file = None  # Set lazily
 
@@ -180,16 +184,59 @@ class DuplicateDetector:
             if os.path.exists(self._hash_cache_file):
                 with open(self._hash_cache_file, 'r') as f:
                     raw = json.load(f)
-                    # Validate: only keep entries where file still exists
-                    self._hash_cache = {k: v for k, v in raw.items() if os.path.exists(k)}
-                    purged = len(raw) - len(self._hash_cache)
-                    if purged > 0:
-                        self._hash_cache_dirty = True
-                    print(f"📦 Loaded {len(self._hash_cache)} cached image hashes" +
-                          (f" (purged {purged} orphans)" if purged else ""))
+                self._hash_cache, purged, migrated = self._decode_hash_cache(raw)
+                if purged or migrated:
+                    self._hash_cache_dirty = True
+                notes = []
+                if purged:
+                    notes.append(f"purged {purged} orphans")
+                if migrated:
+                    notes.append(f"migrated {migrated} legacy entries")
+                print(f"📦 Loaded {len(self._hash_cache)} cached image hashes" +
+                      (f" ({', '.join(notes)})" if notes else ""))
         except Exception as e:
             print(f"⚠️ Could not load hash cache: {e}")
             self._hash_cache = {}
+
+    def _decode_hash_cache(self, raw) -> Tuple[Dict[str, Tuple[str, int, int]], int, int]:
+        """Parse an on-disk cache payload into the in-memory form.
+
+        Returns (entries, purged_count, migrated_count). Entries whose file no
+        longer exists are dropped here so the cache does not grow forever.
+
+        Version 1 stored a bare `{path: phash}` map with no way to tell whether
+        the file had changed since, so an edited-in-place image kept serving the
+        old hash — and a wrong hash means a wrong duplicate group, which the UI
+        offers to delete. Those legacy entries are stamped with the file's
+        *current* mtime/size on first load rather than thrown away: re-hashing a
+        six-figure library on upgrade would cost hours, and from that point on
+        every further change is caught.
+        """
+        entries: Dict[str, Tuple[str, int, int]] = {}
+        purged = 0
+        migrated = 0
+
+        if isinstance(raw, dict) and "entries" in raw:
+            items = raw.get("entries") or {}
+        else:
+            items = raw or {}  # Legacy v1: flat {path: hash}
+
+        for path, value in items.items():
+            try:
+                st = os.stat(path)
+            except OSError:
+                purged += 1
+                continue
+
+            if isinstance(value, str):
+                entries[path] = (value, st.st_mtime_ns, st.st_size)
+                migrated += 1
+            elif isinstance(value, (list, tuple)) and len(value) == 3:
+                entries[path] = (str(value[0]), int(value[1]), int(value[2]))
+            else:
+                purged += 1
+
+        return entries, purged, migrated
 
     def _save_hash_cache(self):
         """Persist hash cache to disk."""
@@ -199,20 +246,50 @@ class DuplicateDetector:
         import json
         try:
             os.makedirs(os.path.dirname(self._hash_cache_file), exist_ok=True)
-            with open(self._hash_cache_file, 'w') as f:
-                json.dump(self._hash_cache, f)
+            payload = {
+                "version": self.HASH_CACHE_VERSION,
+                "entries": {p: list(v) for p, v in self._hash_cache.items()},
+            }
+            # Write-then-rename: a crash mid-write would otherwise leave a
+            # truncated JSON file that the next run silently discards whole.
+            tmp_path = f"{self._hash_cache_file}.tmp"
+            with open(tmp_path, 'w') as f:
+                json.dump(payload, f)
+            os.replace(tmp_path, self._hash_cache_file)
             print(f"💾 Saved {len(self._hash_cache)} image hashes to cache")
             self._hash_cache_dirty = False
         except Exception as e:
             print(f"⚠️ Could not save hash cache: {e}")
 
-    def _get_cached_hash(self, filepath: str) -> Optional[str]:
-        """Get a cached phash for a file, or None if not cached."""
-        return self._hash_cache.get(filepath)
+    def _get_cached_hash(self, filepath: str, st: Optional[os.stat_result] = None) -> Optional[str]:
+        """Get a cached phash for a file, or None if absent or stale.
 
-    def _set_cached_hash(self, filepath: str, hash_str: str):
-        """Store a phash in the cache."""
-        self._hash_cache[filepath] = hash_str
+        `st` is the caller's already-taken stat of the file; the hash is only
+        reused when mtime and size still match what was hashed.
+        """
+        entry = self._hash_cache.get(filepath)
+        if entry is None:
+            return None
+
+        hash_str, mtime_ns, size = entry
+        if st is None:
+            try:
+                st = os.stat(filepath)
+            except OSError:
+                return None
+
+        if st.st_mtime_ns != mtime_ns or st.st_size != size:
+            return None
+        return hash_str
+
+    def _set_cached_hash(self, filepath: str, hash_str: str, st: Optional[os.stat_result] = None):
+        """Store a phash together with the file identity it was computed from."""
+        if st is None:
+            try:
+                st = os.stat(filepath)
+            except OSError:
+                return
+        self._hash_cache[filepath] = (hash_str, st.st_mtime_ns, st.st_size)
         self._hash_cache_dirty = True
 
     def _generate_group_id(self) -> str:
@@ -601,11 +678,14 @@ class DuplicateDetector:
                 progress_callback(f"Hashing image {idx}/{total_images} (cache: {cache_hits} hits)", pct)
 
             path = img.file_path
-            if not os.path.exists(path):
+            # One stat serves both the existence check and cache validation.
+            try:
+                st = os.stat(path)
+            except OSError:
                 continue
 
             # Check cache first
-            cached_hash_str = self._get_cached_hash(path)
+            cached_hash_str = self._get_cached_hash(path, st)
             if cached_hash_str:
                 try:
                     phash = imagehash.hex_to_hash(cached_hash_str)
@@ -622,7 +702,7 @@ class DuplicateDetector:
                     phash = imagehash.phash(hash_img)
                     hash_str = str(phash)
                     hash_data.append((hash_str, phash, img))
-                    self._set_cached_hash(path, hash_str)
+                    self._set_cached_hash(path, hash_str, st)
                     cache_misses += 1
             except Exception:
                 continue

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -46,9 +46,10 @@ def make_detector(tmp_path, hashes):
     for i, hash_str in enumerate(hashes):
         path = tmp_path / f"img_{i:03d}.jpg"
         path.write_bytes(b"\xff\xd8\xff\xd9")  # not a real JPEG; never decoded
-        detector._hash_cache[str(path)] = hash_str
+        detector._set_cached_hash(str(path), hash_str)
         images.append(FakeImage(str(path)))
 
+    detector._hash_cache_dirty = False  # keep _save_hash_cache a no-op
     return detector, images
 
 
@@ -192,3 +193,107 @@ def test_missing_files_are_skipped(tmp_path):
     groups = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert groups == []
+
+
+# --- hash cache identity -----------------------------------------------------
+
+
+def test_cached_hash_is_reused_while_file_is_unchanged(tmp_path):
+    detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
+
+    assert detector._get_cached_hash(images[0].file_path) == "f0f0f0f0f0f0f0f0"
+
+
+def test_cached_hash_is_dropped_when_file_content_changes(tmp_path):
+    """An edited-in-place image must not keep serving its old hash.
+
+    A stale hash puts the file in the wrong duplicate group, and the UI offers
+    to delete members of that group — so this is a data-loss path, not just a
+    stale-cache annoyance.
+    """
+    detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
+    path = images[0].file_path
+
+    with open(path, "wb") as f:
+        f.write(b"\xff\xd8completely different bytes\xff\xd9")
+
+    assert detector._get_cached_hash(path) is None
+
+
+def test_cached_hash_is_dropped_when_only_mtime_changes(tmp_path):
+    """Same size, new mtime — still a re-hash, since the bytes may differ."""
+    detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
+    path = images[0].file_path
+
+    st = os.stat(path)
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+    assert detector._get_cached_hash(path) is None
+
+
+def test_changed_file_is_regrouped_by_its_new_hash(tmp_path):
+    """End to end: a changed file drops out of the group its old hash implied."""
+    detector, images = make_detector(
+        tmp_path, ["f0f0f0f0f0f0f0f0", "f0f0f0f0f0f0f0f0"]
+    )
+    # Rewrite one file, then pin its new content to a distant hash — as a real
+    # re-hash of the changed bytes would.
+    path = images[1].file_path
+    with open(path, "wb") as f:
+        f.write(b"\xff\xd8other\xff\xd9")
+    detector._set_cached_hash(path, "0f0f0f0f0f0f0f0f")
+
+    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+
+    assert groups == []
+
+
+def test_legacy_flat_cache_is_migrated_and_stamped(tmp_path):
+    """v1 caches ({path: hash}) keep working instead of forcing a full re-hash."""
+    detector = DuplicateDetector()
+    path = tmp_path / "legacy.jpg"
+    path.write_bytes(b"\xff\xd8\xff\xd9")
+
+    entries, purged, migrated = detector._decode_hash_cache(
+        {str(path): "f0f0f0f0f0f0f0f0"}
+    )
+
+    st = os.stat(path)
+    assert entries == {str(path): ("f0f0f0f0f0f0f0f0", st.st_mtime_ns, st.st_size)}
+    assert (purged, migrated) == (0, 1)
+
+
+def test_decode_purges_orphans_and_malformed_entries(tmp_path):
+    detector = DuplicateDetector()
+    present = tmp_path / "present.jpg"
+    present.write_bytes(b"\xff\xd8\xff\xd9")
+    st = os.stat(present)
+
+    entries, purged, migrated = detector._decode_hash_cache({
+        "version": 2,
+        "entries": {
+            str(present): ["f0f0f0f0f0f0f0f0", st.st_mtime_ns, st.st_size],
+            str(tmp_path / "gone.jpg"): ["aaaaaaaaaaaaaaaa", 1, 2],
+            str(present) + ".bad": None,
+        },
+    })
+
+    assert list(entries) == [str(present)]
+    assert purged == 2
+    assert migrated == 0
+
+
+def test_cache_roundtrips_through_disk(tmp_path):
+    detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
+    detector._hash_cache_dirty = True
+    detector._save_hash_cache()
+
+    reloaded = DuplicateDetector()
+    reloaded._hash_cache_file = detector._hash_cache_file
+    import json
+    with open(detector._hash_cache_file) as f:
+        raw = json.load(f)
+    reloaded._hash_cache, _, _ = reloaded._decode_hash_cache(raw)
+
+    assert raw["version"] == DuplicateDetector.HASH_CACHE_VERSION
+    assert reloaded._get_cached_hash(images[0].file_path) == "f0f0f0f0f0f0f0f0"


### PR DESCRIPTION
## Problem

`.phash_cache.json` war allein nach Dateipfad indiziert:

```json
{"/media/fotos/a.jpg": "f0f0f0f0f0f0f0f0"}
```

Nichts daran sagt, aus welchem Dateizustand der Hash stammt. Wird ein Bild an derselben Stelle ersetzt — Neu-Export, Rotation, `rsync` über den gleichen Pfad — liefert der Cache weiterhin den alten Hash. Die Datei landet dann in einer Duplikatgruppe, die zu ihrem aktuellen Inhalt nicht mehr passt.

Das ist deshalb kein reiner Cache-Schluckauf: die Duplikat-Ansicht bietet genau diese Gruppen zum Löschen an (`POST /api/duplicates/delete`). Ein falscher Hash kann also dazu führen, dass die falsche Datei als "redundant" vorgeschlagen wird.

## Änderung

- Cache-Einträge sind jetzt `(hash, mtime_ns, size)`. Weicht eines ab, wird neu gehasht.
- Die Hash-Schleife nutzt ein einziges `os.stat()` für Existenz-Check *und* Cache-Validierung — kein zusätzlicher Syscall gegenüber vorher (`os.path.exists`).
- Format v2 mit expliziter `version`. Alte v1-Caches (flaches `{pfad: hash}`) werden beim ersten Laden übernommen und mit dem aktuellen Dateizustand gestempelt, statt verworfen: eine sechsstellige Bibliothek beim Upgrade komplett neu zu hashen kostet Stunden. Ab diesem Punkt greift die Prüfung dann für jede weitere Änderung.
- Speichern über write-then-rename. Bisher hinterließ ein Absturz mitten im `json.dump` eine abgeschnittene JSON-Datei, die der nächste Lauf still komplett verwirft.

## Tests

7 neue Tests in `tests/test_duplicate_detector.py` — geänderter Inhalt, nur geänderte mtime, End-to-End-Regruppierung, v1-Migration, Orphan-/Malformed-Purge, Disk-Roundtrip.

`707 passed, 1 xfailed` — volle Suite grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)