### PR TITLE
feat(dedup): re-encodete Videos werden als Duplikate erkannt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Duplikat-Scan findet re-encodete Videos**: Der bisherige Video-Pass gruppiert
+  nach gerundeter Größe + Dauer + Auflösung. Eine transkodierte Kopie (H.264 →
+  HEVC, 1080p → 720p, anderer CRF) teilt keinen dieser Werte und landete damit
+  nie im selben Bucket — und der visuelle Fallback lief nur *innerhalb* eines
+  Buckets, wo alle Dateien ohnehin schon identische Größe und Auflösung haben.
+  Genau der häufigste echte Duplikat-Fall in einer transkodierten Bibliothek war
+  also unsichtbar. Neuer zweiter Pass: Bucketing nach Dauer (±1,5 s), dann
+  Vergleich perceptueller Hashes von drei Frames bei 25/50/75 % der Laufzeit.
+  Gruppiert wird nur, wenn *alle* Positionen passen — ein gemeinsamer Vorspann
+  reicht nicht, sonst würde eine ganze Serienstaffel zusammenfallen.
+  Gruppen erscheinen als `match_type: "reencode"` mit 75 % Confidence.
+  Frame-Signaturen werden in `.vframe_cache.json` gecacht; gehasht werden nur
+  Videos, die überhaupt einen Dauer-Nachbarn haben. Abschaltbar über
+  `find_all_duplicates(..., detect_reencodes=False)`.
+
 ### Fixed
+- **Duplikat-Scan empfahl bei Re-Encodes die falsche Datei zum Behalten**:
+  `_calculate_video_quality_score` vergibt +20 Punkte für moderne Codecs. Beim
+  Abwägen zwischen byte-identischen Kopien ist das richtig, in einer
+  Re-Encode-Gruppe genau falsch: die HEVC-Datei ist dort das verkleinerte
+  Derivat des H.264-Originals. Der Codec-Bonus entfällt jetzt für
+  `reencode`-Gruppen; Auflösung und Bitrate entscheiden.
+- **Duplikat-Scan ließ temporäre Frame-Dateien liegen**: Schlug der
+  ffmpeg-Aufruf in `_get_video_frame_hash` fehl oder lief in den Timeout, blieb
+  die per `NamedTemporaryFile(delete=False)` angelegte Datei in `/tmp` zurück —
+  über einen langen Scan mit vielen kaputten Dateien summiert sich das. Cleanup
+  läuft jetzt im `finally`.
 - **Duplikat-Scan: veraltete perceptual Hashes** (`.phash_cache.json`): Der Cache
   war nur nach Dateipfad indiziert, ohne jede Angabe, aus welchem Dateizustand
   der Hash stammt. Wurde ein Bild an Ort und Stelle geändert (Neu-Export,

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -148,63 +148,66 @@ class _BandedHashIndex:
         return found
 
 
-class DuplicateDetector:
+class _StatValidatedHashCache:
+    """Disk-backed `path -> hash` cache that notices when a file changes.
+
+    Each entry carries the mtime and size the hash was computed from, so a file
+    replaced in place (re-export, rotation, rsync over the same path) is
+    re-hashed instead of silently keeping a hash that no longer describes it.
+
+    The stored value is opaque to this class — the image pass keeps a single
+    phash there, the video pass keeps a joined multi-frame signature.
     """
-    Detects duplicate media files using various strategies.
 
-    Videos: Exact match on size + duration + resolution
-    Images: Perceptual hash (if imagehash available) or exact size + resolution
+    # Bumped whenever the on-disk layout changes.
+    VERSION = 2
 
-    Performance:
-    - Perceptual hashes are cached to disk across scans
-    - Hash bucketing eliminates O(n²) comparisons
-    """
+    def __init__(self, filename: str, label: str):
+        self._filename = filename
+        self._label = label
+        self._entries: Dict[str, Tuple[str, int, int]] = {}
+        self.dirty = False
+        self.path: Optional[str] = None  # Resolved lazily on first load
 
-    # Bumped whenever the on-disk cache layout changes.
-    HASH_CACHE_VERSION = 2
+    def __len__(self) -> int:
+        return len(self._entries)
 
-    def __init__(self):
-        self._group_counter = 0
-        # filepath -> (phash hex string, mtime_ns, size_bytes)
-        self._hash_cache: Dict[str, Tuple[str, int, int]] = {}
-        self._hash_cache_dirty = False
-        self._hash_cache_file = None  # Set lazily
-
-    def _ensure_hash_cache(self):
-        """Load hash cache from disk on first use."""
-        if self._hash_cache_file is not None:
-            return  # Already loaded
+    def load(self) -> None:
+        """Load from disk on first use; a no-op once `path` is set."""
+        if self.path is not None:
+            return
 
         import json
 
         from ..config import config
 
-        self._hash_cache_file = os.path.join(config.hidden_data_dir, ".phash_cache.json")
+        self.path = os.path.join(config.hidden_data_dir, self._filename)
         try:
-            if os.path.exists(self._hash_cache_file):
-                with open(self._hash_cache_file, 'r') as f:
+            if os.path.exists(self.path):
+                with open(self.path, 'r') as f:
                     raw = json.load(f)
-                self._hash_cache, purged, migrated = self._decode_hash_cache(raw)
+                self._entries, purged, migrated = self.decode(raw)
                 if purged or migrated:
-                    self._hash_cache_dirty = True
+                    self.dirty = True
                 notes = []
                 if purged:
                     notes.append(f"purged {purged} orphans")
                 if migrated:
                     notes.append(f"migrated {migrated} legacy entries")
-                print(f"📦 Loaded {len(self._hash_cache)} cached image hashes" +
+                print(f"📦 Loaded {len(self._entries)} cached {self._label}" +
                       (f" ({', '.join(notes)})" if notes else ""))
         except Exception as e:
-            print(f"⚠️ Could not load hash cache: {e}")
-            self._hash_cache = {}
+            print(f"⚠️ Could not load {self._label} cache: {e}")
+            self._entries = {}
 
-    def _decode_hash_cache(self, raw) -> Tuple[Dict[str, Tuple[str, int, int]], int, int]:
-        """Parse an on-disk cache payload into the in-memory form.
+    @staticmethod
+    def decode(raw) -> Tuple[Dict[str, Tuple[str, int, int]], int, int]:
+        """Parse an on-disk payload into the in-memory form.
 
         Returns (entries, purged_count, migrated_count). Entries whose file no
         longer exists are dropped here so the cache does not grow forever.
 
-        Version 1 stored a bare `{path: phash}` map with no way to tell whether
+        Version 1 stored a bare `{path: hash}` map with no way to tell whether
         the file had changed since, so an edited-in-place image kept serving the
         old hash — and a wrong hash means a wrong duplicate group, which the UI
         offers to delete. Those legacy entries are stamped with the file's
@@ -238,36 +241,36 @@ class DuplicateDetector:
 
         return entries, purged, migrated
 
-    def _save_hash_cache(self):
-        """Persist hash cache to disk."""
-        if not self._hash_cache_dirty or not self._hash_cache_file:
+    def save(self) -> None:
+        """Persist to disk, unless nothing changed."""
+        if not self.dirty or not self.path:
             return
 
         import json
         try:
-            os.makedirs(os.path.dirname(self._hash_cache_file), exist_ok=True)
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
             payload = {
-                "version": self.HASH_CACHE_VERSION,
-                "entries": {p: list(v) for p, v in self._hash_cache.items()},
+                "version": self.VERSION,
+                "entries": {p: list(v) for p, v in self._entries.items()},
             }
             # Write-then-rename: a crash mid-write would otherwise leave a
             # truncated JSON file that the next run silently discards whole.
-            tmp_path = f"{self._hash_cache_file}.tmp"
+            tmp_path = f"{self.path}.tmp"
             with open(tmp_path, 'w') as f:
                 json.dump(payload, f)
-            os.replace(tmp_path, self._hash_cache_file)
-            print(f"💾 Saved {len(self._hash_cache)} image hashes to cache")
-            self._hash_cache_dirty = False
+            os.replace(tmp_path, self.path)
+            print(f"💾 Saved {len(self._entries)} {self._label} to cache")
+            self.dirty = False
         except Exception as e:
-            print(f"⚠️ Could not save hash cache: {e}")
+            print(f"⚠️ Could not save {self._label} cache: {e}")
 
-    def _get_cached_hash(self, filepath: str, st: Optional[os.stat_result] = None) -> Optional[str]:
-        """Get a cached phash for a file, or None if absent or stale.
+    def get(self, filepath: str, st: Optional[os.stat_result] = None) -> Optional[str]:
+        """Cached hash for a file, or None if absent or stale.
 
         `st` is the caller's already-taken stat of the file; the hash is only
         reused when mtime and size still match what was hashed.
         """
-        entry = self._hash_cache.get(filepath)
+        entry = self._entries.get(filepath)
         if entry is None:
             return None
 
@@ -282,21 +285,81 @@ class DuplicateDetector:
             return None
         return hash_str
 
-    def _set_cached_hash(self, filepath: str, hash_str: str, st: Optional[os.stat_result] = None):
-        """Store a phash together with the file identity it was computed from."""
+    def set(self, filepath: str, hash_str: str, st: Optional[os.stat_result] = None) -> None:
+        """Store a hash together with the file identity it was computed from."""
         if st is None:
             try:
                 st = os.stat(filepath)
             except OSError:
                 return
-        self._hash_cache[filepath] = (hash_str, st.st_mtime_ns, st.st_size)
-        self._hash_cache_dirty = True
+        self._entries[filepath] = (hash_str, st.st_mtime_ns, st.st_size)
+        self.dirty = True
+
+
+class _UnionFind:
+    """Disjoint-set over integer indices, for order-independent clustering."""
+
+    __slots__ = ("_parent",)
+
+    def __init__(self, n: int):
+        self._parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        root = x
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[x] != root:  # Path compression
+            self._parent[x], x = root, self._parent[x]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self._parent[max(ra, rb)] = min(ra, rb)
+
+    def clusters(self) -> List[List[int]]:
+        """Members grouped by root, each cluster and the whole list sorted."""
+        buckets: Dict[int, List[int]] = defaultdict(list)
+        for i in range(len(self._parent)):
+            buckets[self.find(i)].append(i)
+        return [sorted(members) for _, members in sorted(buckets.items())]
+
+
+class DuplicateDetector:
+    """
+    Detects duplicate media files using various strategies.
+
+    Videos: Exact match on size + duration + resolution, plus a second pass that
+            catches re-encodes (same content, different size/codec/resolution)
+    Images: Perceptual hash (if imagehash available) or exact size + resolution
+
+    Performance:
+    - Perceptual hashes are cached to disk across scans
+    - Hash bucketing eliminates O(n²) comparisons
+    """
+
+    # Frame positions sampled for the re-encode pass, as fractions of duration.
+    # Spread out on purpose: a single early frame is often a black frame or a
+    # studio logo, which matches across completely unrelated videos.
+    REENCODE_FRAME_POSITIONS = (0.25, 0.5, 0.75)
+    # How far two durations may drift and still be considered the same content.
+    # Re-encodes land within a frame or two; container padding adds a bit more.
+    REENCODE_DURATION_TOLERANCE_SEC = 1.5
+    # Max per-frame Hamming distance. Every sampled position must be within it.
+    REENCODE_FRAME_THRESHOLD = 8
+
+    def __init__(self):
+        self._group_counter = 0
+        self._image_hashes = _StatValidatedHashCache(".phash_cache.json", "image hashes")
+        self._video_hashes = _StatValidatedHashCache(
+            ".vframe_cache.json", "video frame signatures"
+        )
 
     def _generate_group_id(self) -> str:
         self._group_counter += 1
         return f"dup_{self._group_counter:04d}"
 
-    def find_all_duplicates(self, entries: List, progress_callback=None, batch_size: int = 5000, batch_offset: int = 0) -> Tuple[List[DuplicateGroup], bool]:
+    def find_all_duplicates(self, entries: List, progress_callback=None, batch_size: int = 5000, batch_offset: int = 0, detect_reencodes: bool = True) -> Tuple[List[DuplicateGroup], bool]:
         """
         Find duplicates in the media library with batching support.
 
@@ -305,6 +368,9 @@ class DuplicateDetector:
             progress_callback: Optional callable(str, float) to report status and progress (0-100)
             batch_size: Max number of images to process per batch (default 5000)
             batch_offset: Starting offset for image processing (for pagination)
+            detect_reencodes: Also look for re-encoded copies of the same video
+                (different size/codec, same content). Costs ffmpeg frame
+                extractions on first run; cached afterwards.
 
         Returns:
             Tuple of (List of DuplicateGroup objects, has_more: bool indicating if more batches available)
@@ -330,6 +396,15 @@ class DuplicateDetector:
 
         video_groups = self._find_video_duplicates(videos, progress_callback)
         groups.extend(video_groups)
+
+        # Second video pass: copies that were re-encoded, so no metadata matches
+        if detect_reencodes:
+            already_grouped = {f.path for g in video_groups for f in g.files}
+            groups.extend(
+                self._find_reencoded_video_duplicates(
+                    videos, already_grouped, progress_callback
+                )
+            )
 
         # Find image duplicates (batched)
         if progress_callback:
@@ -458,6 +533,7 @@ class DuplicateDetector:
         if not IMAGEHASH_AVAILABLE:
             return None
 
+        temp_path = None
         try:
             # Create temp file for extracted frame
             with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp:
@@ -486,16 +562,18 @@ class DuplicateDetector:
                 phash = imagehash.phash(img)
                 hash_str = str(phash)
 
-            # Cleanup
-            try:
-                os.remove(temp_path)
-            except Exception:
-                pass
-
             return hash_str
 
         except Exception:
             return None
+        finally:
+            # Always clean up: on an ffmpeg failure or timeout the old code left
+            # the (empty) temp file behind, filling /tmp over a long scan.
+            if temp_path:
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass
 
     def _verify_by_visual_hash(self, files: List, threshold: int = 8) -> List[List]:
         """
@@ -546,12 +624,167 @@ class DuplicateDetector:
 
         return groups
 
-    def _create_video_group(self, videos: List) -> DuplicateGroup:
+    # -- Re-encode detection --------------------------------------------------
+    #
+    # The exact pass above buckets videos by rounded size + duration +
+    # resolution. A re-encoded copy (H.264 -> HEVC, 1080p -> 720p, different
+    # CRF) shares none of those, so it never reaches the same bucket -- and the
+    # visual-hash fallback only ever runs *inside* one bucket, where files
+    # already have identical size and resolution and there is nothing left for
+    # it to find. Re-encodes, the single most common kind of real duplicate in
+    # a transcoded library, were therefore invisible.
+    #
+    # What does survive re-encoding is the picture itself and, to within about
+    # a frame, the duration. So: bucket by duration, then compare perceptual
+    # hashes of frames sampled at the same *relative* positions.
+
+    def _video_frame_signature(self, video) -> Optional[str]:
+        """Perceptual hashes of several frames of one video, ':'-joined.
+
+        Cached on disk keyed by path + mtime + size, because each miss costs one
+        ffmpeg invocation per sampled position.
+        """
+        path = getattr(video, 'file_path', '')
+        try:
+            st = os.stat(path)
+        except OSError:
+            return None
+
+        cached = self._video_hashes.get(path, st)
+        if cached:
+            return cached
+
+        duration = getattr(video, 'duration_sec', 0) or 0
+        if duration <= 0:
+            return None
+
+        hashes = []
+        for fraction in self.REENCODE_FRAME_POSITIONS:
+            hash_str = self._get_video_frame_hash(path, duration * fraction)
+            if not hash_str:
+                return None  # A partial signature would compare unequal lengths
+            hashes.append(hash_str)
+
+        signature = ":".join(hashes)
+        self._video_hashes.set(path, signature, st)
+        return signature
+
+    @staticmethod
+    def _signatures_match(sig_a: str, sig_b: str, threshold: int) -> bool:
+        """True when *every* sampled frame is within the Hamming threshold.
+
+        Requiring all positions rather than a majority is what keeps episodes of
+        the same series apart: they share an intro, not a whole runtime.
+        """
+        frames_a = sig_a.split(":")
+        frames_b = sig_b.split(":")
+        if len(frames_a) != len(frames_b):
+            return False
+        try:
+            return all(
+                _hamming(int(a, 16), int(b, 16)) <= threshold
+                for a, b in zip(frames_a, frames_b)
+            )
+        except ValueError:
+            return False
+
+    def _duration_candidate_pairs(self, videos: List) -> List[Tuple[int, int]]:
+        """Index pairs whose durations are close enough to be the same content.
+
+        Sweeps the duration-sorted list, so this is O(n log n) plus the pairs
+        actually emitted -- not an all-pairs comparison.
+        """
+        order = sorted(
+            range(len(videos)),
+            key=lambda i: (getattr(videos[i], 'duration_sec', 0) or 0, videos[i].file_path),
+        )
+        tolerance = self.REENCODE_DURATION_TOLERANCE_SEC
+
+        pairs = []
+        for a in range(len(order)):
+            dur_a = getattr(videos[order[a]], 'duration_sec', 0) or 0
+            if dur_a <= 0:
+                continue
+            for b in range(a + 1, len(order)):
+                dur_b = getattr(videos[order[b]], 'duration_sec', 0) or 0
+                if dur_b - dur_a > tolerance:
+                    break  # Sorted: everything further out is further away
+                pairs.append((order[a], order[b]))
+        return pairs
+
+    def _find_reencoded_video_duplicates(
+        self, videos: List, skip_paths: Set[str], progress_callback=None
+    ) -> List[DuplicateGroup]:
+        """Group videos that hold the same content at different encodings."""
+        if not IMAGEHASH_AVAILABLE:
+            return []
+
+        candidates = [
+            v for v in videos
+            if v.file_path not in skip_paths and (getattr(v, 'duration_sec', 0) or 0) > 0
+        ]
+        if len(candidates) < 2:
+            return []
+
+        pairs = self._duration_candidate_pairs(candidates)
+        if not pairs:
+            return []
+
+        # Only videos that actually have a duration neighbour get hashed; a file
+        # with a unique runtime can have no re-encode twin, so paying for three
+        # ffmpeg seeks on it would be pure waste.
+        needed = sorted({i for pair in pairs for i in pair})
+        self._video_hashes.load()
+
+        signatures: Dict[int, str] = {}
+        for done, idx in enumerate(needed):
+            if progress_callback and done % 25 == 0:
+                pct = 55 + (done / len(needed)) * 20  # 55-75% range
+                progress_callback(
+                    f"Checking video {done}/{len(needed)} for re-encoded copies", pct
+                )
+            signature = self._video_frame_signature(candidates[idx])
+            if signature:
+                signatures[idx] = signature
+        self._video_hashes.save()
+
+        # Union-Find: whether A and B end up together must not depend on the
+        # order the pairs happen to be visited in.
+        uf = _UnionFind(len(candidates))
+        for i, j in pairs:
+            sig_i, sig_j = signatures.get(i), signatures.get(j)
+            if sig_i and sig_j and self._signatures_match(
+                sig_i, sig_j, self.REENCODE_FRAME_THRESHOLD
+            ):
+                uf.union(i, j)
+
+        groups = []
+        for members in uf.clusters():
+            if len(members) > 1:
+                groups.append(
+                    self._create_video_group(
+                        [candidates[i] for i in members],
+                        match_type="reencode",
+                        confidence=0.75,
+                    )
+                )
+        return groups
+
+    def _create_video_group(
+        self, videos: List, match_type: str = "exact", confidence: float = 0.95
+    ) -> DuplicateGroup:
         """Create a DuplicateGroup from a list of matching videos."""
         dup_files = []
 
+        # Within a re-encode group the codec says nothing about which copy is
+        # the source — the HEVC file is usually the *lossy* derivative of the
+        # H.264 original, so its +20 codec bonus would recommend keeping exactly
+        # the copy the user wants to drop. Resolution and bitrate still do carry
+        # that signal, so only the codec term is dropped.
+        codec_bonus = match_type != "reencode"
+
         for v in videos:
-            quality_score = self._calculate_video_quality_score(v)
+            quality_score = self._calculate_video_quality_score(v, codec_bonus=codec_bonus)
             dup_file = DuplicateFile(
                 path=v.file_path,
                 size_mb=v.size_mb,
@@ -576,18 +809,22 @@ class DuplicateDetector:
 
         return DuplicateGroup(
             group_id=self._generate_group_id(),
-            match_type="exact",
+            match_type=match_type,
             media_type="video",
-            confidence=0.95,
+            confidence=confidence,
             files=dup_files,
             recommended_keep=dup_files[0].path if dup_files else "",
             potential_savings_mb=round(savings, 2),
         )
 
-    def _calculate_video_quality_score(self, video) -> float:
+    def _calculate_video_quality_score(self, video, codec_bonus: bool = True) -> float:
         """
         Calculate a quality score for a video.
         Higher score = better quality = should keep.
+
+        `codec_bonus` rewards modern codecs — right when picking between
+        byte-identical copies, wrong when picking between re-encodes, where the
+        efficient codec marks the lossy derivative rather than the source.
         """
         score = 0.0
 
@@ -609,7 +846,7 @@ class DuplicateDetector:
             score += 5
 
         # Codec contribution (0-20 points)
-        codec = getattr(video, 'codec', '').lower()
+        codec = getattr(video, 'codec', '').lower() if codec_bonus else ''
         if 'hevc' in codec or 'h265' in codec or 'x265' in codec:
             score += 20  # Modern efficient codec
         elif 'h264' in codec or 'avc' in codec or 'x264' in codec:
@@ -664,7 +901,7 @@ class DuplicateDetector:
         import gc
 
         # Load hash cache from disk
-        self._ensure_hash_cache()
+        self._image_hashes.load()
 
         # Phase 1: Compute/retrieve hashes with progress tracking
         hash_data: List[Tuple[str, 'imagehash.ImageHash', Any]] = []
@@ -685,7 +922,7 @@ class DuplicateDetector:
                 continue
 
             # Check cache first
-            cached_hash_str = self._get_cached_hash(path, st)
+            cached_hash_str = self._image_hashes.get(path, st)
             if cached_hash_str:
                 try:
                     phash = imagehash.hex_to_hash(cached_hash_str)
@@ -702,7 +939,7 @@ class DuplicateDetector:
                     phash = imagehash.phash(hash_img)
                     hash_str = str(phash)
                     hash_data.append((hash_str, phash, img))
-                    self._set_cached_hash(path, hash_str, st)
+                    self._image_hashes.set(path, hash_str, st)
                     cache_misses += 1
             except Exception:
                 continue
@@ -712,7 +949,7 @@ class DuplicateDetector:
                 gc.collect()
 
         # Save updated cache to disk
-        self._save_hash_cache()
+        self._image_hashes.save()
 
         if progress_callback:
             progress_callback(f"Hashed {len(hash_data)} images ({cache_hits} cached, {cache_misses} new)", 92)

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -5,15 +5,19 @@ These pin down the near-miss image matching behaviour of
 dirs; no real media library or arcade_data/ is touched.
 
 The detector is driven through its hash cache rather than through real images:
-`_ensure_hash_cache` returns early once `_hash_cache_file` is set, and
-`_save_hash_cache` returns early while the cache is not dirty, so a
-pre-populated `_hash_cache` lets a test choose exact phash values.
+`_StatValidatedHashCache.load()` returns early once `path` is set, and `save()`
+returns early while the cache is not dirty, so a pre-populated cache lets a test
+choose exact phash values without decoding anything.
 """
 import os
 
 import pytest
 
-from arcade_scanner.core.duplicate_detector import IMAGEHASH_AVAILABLE, DuplicateDetector
+from arcade_scanner.core.duplicate_detector import (
+    IMAGEHASH_AVAILABLE,
+    DuplicateDetector,
+    _StatValidatedHashCache,
+)
 
 pytestmark = pytest.mark.skipif(
     not IMAGEHASH_AVAILABLE, reason="imagehash/Pillow not installed"
@@ -40,16 +44,16 @@ def make_detector(tmp_path, hashes):
     detector = DuplicateDetector()
     # Point the cache at a tmp file so _ensure_hash_cache short-circuits and
     # nothing is ever read from or written to the real arcade_data/ dir.
-    detector._hash_cache_file = str(tmp_path / ".phash_cache.json")
+    detector._image_hashes.path = str(tmp_path / ".phash_cache.json")
 
     images = []
     for i, hash_str in enumerate(hashes):
         path = tmp_path / f"img_{i:03d}.jpg"
         path.write_bytes(b"\xff\xd8\xff\xd9")  # not a real JPEG; never decoded
-        detector._set_cached_hash(str(path), hash_str)
+        detector._image_hashes.set(str(path), hash_str)
         images.append(FakeImage(str(path)))
 
-    detector._hash_cache_dirty = False  # keep _save_hash_cache a no-op
+    detector._image_hashes.dirty = False  # keep save() a no-op
     return detector, images
 
 
@@ -201,7 +205,7 @@ def test_missing_files_are_skipped(tmp_path):
 def test_cached_hash_is_reused_while_file_is_unchanged(tmp_path):
     detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
 
-    assert detector._get_cached_hash(images[0].file_path) == "f0f0f0f0f0f0f0f0"
+    assert detector._image_hashes.get(images[0].file_path) == "f0f0f0f0f0f0f0f0"
 
 
 def test_cached_hash_is_dropped_when_file_content_changes(tmp_path):
@@ -217,7 +221,7 @@ def test_cached_hash_is_dropped_when_file_content_changes(tmp_path):
     with open(path, "wb") as f:
         f.write(b"\xff\xd8completely different bytes\xff\xd9")
 
-    assert detector._get_cached_hash(path) is None
+    assert detector._image_hashes.get(path) is None
 
 
 def test_cached_hash_is_dropped_when_only_mtime_changes(tmp_path):
@@ -228,7 +232,7 @@ def test_cached_hash_is_dropped_when_only_mtime_changes(tmp_path):
     st = os.stat(path)
     os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
 
-    assert detector._get_cached_hash(path) is None
+    assert detector._image_hashes.get(path) is None
 
 
 def test_changed_file_is_regrouped_by_its_new_hash(tmp_path):
@@ -241,7 +245,7 @@ def test_changed_file_is_regrouped_by_its_new_hash(tmp_path):
     path = images[1].file_path
     with open(path, "wb") as f:
         f.write(b"\xff\xd8other\xff\xd9")
-    detector._set_cached_hash(path, "0f0f0f0f0f0f0f0f")
+    detector._image_hashes.set(path, "0f0f0f0f0f0f0f0f")
 
     groups = detector._find_image_duplicates_by_hash(images, threshold=5)
 
@@ -254,7 +258,7 @@ def test_legacy_flat_cache_is_migrated_and_stamped(tmp_path):
     path = tmp_path / "legacy.jpg"
     path.write_bytes(b"\xff\xd8\xff\xd9")
 
-    entries, purged, migrated = detector._decode_hash_cache(
+    entries, purged, migrated = _StatValidatedHashCache.decode(
         {str(path): "f0f0f0f0f0f0f0f0"}
     )
 
@@ -269,7 +273,7 @@ def test_decode_purges_orphans_and_malformed_entries(tmp_path):
     present.write_bytes(b"\xff\xd8\xff\xd9")
     st = os.stat(present)
 
-    entries, purged, migrated = detector._decode_hash_cache({
+    entries, purged, migrated = _StatValidatedHashCache.decode({
         "version": 2,
         "entries": {
             str(present): ["f0f0f0f0f0f0f0f0", st.st_mtime_ns, st.st_size],
@@ -285,15 +289,16 @@ def test_decode_purges_orphans_and_malformed_entries(tmp_path):
 
 def test_cache_roundtrips_through_disk(tmp_path):
     detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
-    detector._hash_cache_dirty = True
-    detector._save_hash_cache()
+    detector._image_hashes.dirty = True
+    detector._image_hashes.save()
 
-    reloaded = DuplicateDetector()
-    reloaded._hash_cache_file = detector._hash_cache_file
     import json
-    with open(detector._hash_cache_file) as f:
+    with open(detector._image_hashes.path) as f:
         raw = json.load(f)
-    reloaded._hash_cache, _, _ = reloaded._decode_hash_cache(raw)
 
-    assert raw["version"] == DuplicateDetector.HASH_CACHE_VERSION
-    assert reloaded._get_cached_hash(images[0].file_path) == "f0f0f0f0f0f0f0f0"
+    reloaded = _StatValidatedHashCache(".phash_cache.json", "image hashes")
+    reloaded.path = detector._image_hashes.path
+    reloaded._entries, _, _ = _StatValidatedHashCache.decode(raw)
+
+    assert raw["version"] == _StatValidatedHashCache.VERSION
+    assert reloaded.get(images[0].file_path) == "f0f0f0f0f0f0f0f0"

--- a/tests/test_duplicate_reencodes.py
+++ b/tests/test_duplicate_reencodes.py
@@ -1,0 +1,317 @@
+"""Tests for the re-encoded-video pass in `DuplicateDetector`.
+
+The exact-match pass buckets videos by rounded size + duration + resolution, so
+a re-encoded copy — same content, different codec/CRF/resolution — never shares
+a bucket with its original. This module covers the second pass that catches
+them: duration bucketing plus multi-frame perceptual hashes.
+
+No ffmpeg runs here. Frame signatures are pre-seeded into the detector's video
+hash cache, which `_video_frame_signature` consults before shelling out; the
+cache is stat-validated, so the tmp files it points at have to actually exist.
+"""
+import os
+
+import pytest
+
+from arcade_scanner.core.duplicate_detector import (
+    IMAGEHASH_AVAILABLE,
+    DuplicateDetector,
+    _UnionFind,
+)
+
+pytestmark = pytest.mark.skipif(
+    not IMAGEHASH_AVAILABLE, reason="imagehash/Pillow not installed"
+)
+
+
+class FakeVideo:
+    """Minimal stand-in for a scanned video entry."""
+
+    def __init__(self, file_path, duration_sec, size_mb=100.0,
+                 width=1920, height=1080, codec="h264", bitrate_mbps=8.0):
+        self.file_path = file_path
+        self.duration_sec = duration_sec
+        self.size_mb = size_mb
+        self.width = width
+        self.height = height
+        self.codec = codec
+        self.bitrate_mbps = bitrate_mbps
+        self.media_type = "video"
+        self.thumb = ""
+
+
+def make_detector(tmp_path, specs):
+    """Build a detector plus videos from (duration, signature, **kwargs) specs.
+
+    `signature` is a ':'-joined list of hex frame hashes, or None to model a
+    video whose frames could not be extracted.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    detector = DuplicateDetector()
+    # Point both caches at tmp so nothing touches the real arcade_data/ dir.
+    detector._image_hashes.path = str(tmp_path / ".phash_cache.json")
+    detector._video_hashes.path = str(tmp_path / ".vframe_cache.json")
+
+    videos = []
+    for i, spec in enumerate(specs):
+        duration, signature = spec[0], spec[1]
+        kwargs = spec[2] if len(spec) > 2 else {}
+        path = tmp_path / f"vid_{i:03d}.mp4"
+        path.write_bytes(b"\x00" * (16 + i))  # never decoded
+        if signature:
+            detector._video_hashes.set(str(path), signature)
+        videos.append(FakeVideo(str(path), duration, **kwargs))
+
+    detector._video_hashes.dirty = False  # keep save() a no-op
+    return detector, videos
+
+
+def grouped(groups):
+    """Set of frozensets of basenames, one per duplicate group."""
+    return {frozenset(os.path.basename(f.path) for f in g.files) for g in groups}
+
+
+SIG_A = "0000000000000000:1111111111111111:2222222222222222"
+SIG_A_NEAR = "0000000000000001:1111111111111111:2222222222222222"  # 1 bit off
+SIG_B = "ffffffffffffffff:eeeeeeeeeeeeeeee:dddddddddddddddd"
+
+
+# --- the gap this pass exists to close ---------------------------------------
+
+
+def test_reencode_with_different_size_and_codec_is_found(tmp_path):
+    """The case the exact pass structurally cannot see.
+
+    Same film, transcoded: half the size, HEVC instead of H.264, 720p instead of
+    1080p. Nothing in the exact signature (size + duration + resolution) matches,
+    so before this pass the pair was simply invisible.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (3600.0, SIG_A, {"size_mb": 4000.0, "codec": "h264", "width": 1920, "height": 1080}),
+        (3600.2, SIG_A_NEAR, {"size_mb": 1200.0, "codec": "hevc", "width": 1280, "height": 720}),
+    ])
+
+    exact = detector._find_video_duplicates(videos)
+    assert exact == [], "precondition: the exact pass must not find this pair"
+
+    groups = detector._find_reencoded_video_duplicates(videos, set())
+
+    assert grouped(groups) == {frozenset({"vid_000.mp4", "vid_001.mp4"})}
+    assert groups[0].match_type == "reencode"
+    assert groups[0].confidence < 0.95, "a frame match is weaker evidence than bytes"
+
+
+def test_savings_and_keep_are_reported_for_reencode_groups(tmp_path):
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A, {"size_mb": 1000.0, "bitrate_mbps": 12.0}),
+        (600.0, SIG_A_NEAR, {"size_mb": 400.0, "bitrate_mbps": 4.0}),
+    ])
+
+    group = detector._find_reencoded_video_duplicates(videos, set())[0]
+
+    assert os.path.basename(group.recommended_keep) == "vid_000.mp4"  # higher bitrate
+    assert group.potential_savings_mb == pytest.approx(400.0)
+
+
+def test_codec_bonus_does_not_recommend_keeping_the_lossy_copy(tmp_path):
+    """The HEVC member of a re-encode group is the derivative, not the source.
+
+    `_calculate_video_quality_score` hands modern codecs +20, which is right
+    when choosing between byte-identical copies and wrong here: it would
+    recommend keeping the shrunken transcode over the original it came from.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A, {"codec": "h264", "width": 1920, "height": 1080,
+                        "bitrate_mbps": 8.0, "size_mb": 600.0}),
+        (600.0, SIG_A_NEAR, {"codec": "hevc", "width": 1920, "height": 1080,
+                             "bitrate_mbps": 2.0, "size_mb": 150.0}),
+    ])
+
+    group = detector._find_reencoded_video_duplicates(videos, set())[0]
+
+    assert os.path.basename(group.recommended_keep) == "vid_000.mp4"
+
+
+def test_codec_bonus_still_applies_to_exact_groups(tmp_path):
+    """Only the re-encode path drops the codec term."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, None, {"codec": "hevc", "bitrate_mbps": 1.0}),
+    ])
+
+    with_bonus = detector._calculate_video_quality_score(videos[0])
+    without = detector._calculate_video_quality_score(videos[0], codec_bonus=False)
+
+    assert with_bonus > without
+
+
+# --- precision ---------------------------------------------------------------
+
+
+def test_same_duration_different_content_is_not_grouped(tmp_path):
+    """Two 22-minute episodes are not duplicates of each other."""
+    detector, videos = make_detector(tmp_path, [
+        (1320.0, SIG_A),
+        (1320.0, SIG_B),
+    ])
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+def test_one_matching_frame_is_not_enough(tmp_path):
+    """A shared intro must not group a whole series together.
+
+    Frame 1 matches exactly; the later positions do not. Requiring *every*
+    sampled position is what separates "same intro" from "same film".
+    """
+    shared_intro = "0000000000000000:aaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbb"
+    detector, videos = make_detector(tmp_path, [
+        (1320.0, SIG_A),
+        (1320.0, shared_intro),
+    ])
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+def test_durations_beyond_tolerance_are_not_compared(tmp_path):
+    """Identical frames but a 30s runtime gap — a trailer, not the film."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (630.0, SIG_A),
+    ])
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+# --- bookkeeping -------------------------------------------------------------
+
+
+def test_files_already_grouped_exactly_are_skipped(tmp_path):
+    """No file may appear in two groups; the exact pass wins."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.0, SIG_A),
+    ])
+
+    groups = detector._find_reencoded_video_duplicates(
+        videos, {videos[0].file_path}
+    )
+
+    assert groups == []
+
+
+def test_videos_without_a_signature_are_ignored(tmp_path):
+    """A video whose frames could not be extracted is dropped, not guessed at."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.0, None),
+    ])
+    # Duration 0 also means "no seek position to sample", so nothing is written.
+    detector._video_hashes.set(videos[1].file_path, "")
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+def test_transitive_reencodes_form_one_group(tmp_path):
+    """Three encodes of the same source belong in a single group, not three."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.5, SIG_A_NEAR),
+        (601.0, SIG_A),
+    ])
+
+    groups = detector._find_reencoded_video_duplicates(videos, set())
+
+    assert grouped(groups) == {
+        frozenset({"vid_000.mp4", "vid_001.mp4", "vid_002.mp4"})
+    }
+
+
+def test_grouping_is_independent_of_input_order(tmp_path):
+    """Whether A and B land together must not depend on iteration order."""
+    specs = [
+        (600.0, SIG_A),
+        (600.4, SIG_A_NEAR),
+        (600.8, SIG_A),
+        (1320.0, SIG_B),
+    ]
+    detector_a, videos_a = make_detector(tmp_path / "a", specs)
+    detector_b, videos_b = make_detector(tmp_path / "b", list(reversed(specs)))
+
+    groups_a = detector_a._find_reencoded_video_duplicates(videos_a, set())
+    groups_b = detector_b._find_reencoded_video_duplicates(videos_b, set())
+
+    def by_index(groups):
+        return {
+            frozenset(os.path.basename(f.path) for f in g.files) for g in groups
+        }
+
+    # Same three-member cluster either way, just under mirrored filenames.
+    assert len(by_index(groups_a)) == len(by_index(groups_b)) == 1
+    assert {len(g) for g in by_index(groups_a)} == {3}
+    assert {len(g) for g in by_index(groups_b)} == {3}
+
+
+def test_frame_hashing_is_skipped_for_unique_durations(tmp_path, monkeypatch):
+    """Videos with no duration neighbour never reach ffmpeg.
+
+    Each signature costs three ffmpeg seeks, so hashing a file that provably
+    cannot have a twin is pure waste on a large library.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.2, SIG_A_NEAR),
+        (9999.0, None),  # unique runtime
+    ])
+
+    hashed = []
+    original = detector._video_frame_signature
+
+    def spy(video):
+        hashed.append(os.path.basename(video.file_path))
+        return original(video)
+
+    monkeypatch.setattr(detector, "_video_frame_signature", spy)
+    detector._find_reencoded_video_duplicates(videos, set())
+
+    assert "vid_002.mp4" not in hashed
+
+
+def test_detect_reencodes_flag_disables_the_pass(tmp_path, monkeypatch):
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.2, SIG_A_NEAR),
+    ])
+
+    called = []
+    monkeypatch.setattr(
+        detector,
+        "_find_reencoded_video_duplicates",
+        lambda *a, **kw: called.append(1) or [],
+    )
+
+    detector.find_all_duplicates(videos, detect_reencodes=False)
+    assert called == []
+
+    detector.find_all_duplicates(videos, detect_reencodes=True)
+    assert called == [1]
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def test_signature_length_mismatch_never_matches():
+    two_frames = "0000000000000000:1111111111111111"
+    assert not DuplicateDetector._signatures_match(SIG_A, two_frames, threshold=64)
+
+
+def test_malformed_signature_never_matches():
+    assert not DuplicateDetector._signatures_match(SIG_A, "zz:zz:zz", threshold=64)
+
+
+def test_union_find_clusters_are_sorted_and_complete():
+    uf = _UnionFind(6)
+    uf.union(4, 1)
+    uf.union(1, 0)
+    uf.union(3, 5)
+
+    assert uf.clusters() == [[0, 1, 4], [2], [3, 5]]


### PR DESCRIPTION
> Stacked auf #37 — Base ist `fix/dup-phash-cache-invalidation`. Nach dem Merge von #37 stelle ich die Base auf `dev` um (oder #37 zuerst mergen, dann rebaset das hier sauber).

## Problem

Der Video-Pass gruppiert nach gerundeter Größe + Dauer + Auflösung:

```python
signature = f"v:{size_mb}:{duration}:{width}x{height}"
```

Eine transkodierte Kopie — H.264 → HEVC, 1080p → 720p, anderer CRF — teilt **keinen** dieser Werte mit ihrem Original und landet nie im selben Bucket.

Der visuelle Fallback (`_verify_by_visual_hash`), der genau dafür gedacht war, läuft nur *innerhalb* eines Buckets. Dort haben alle Dateien schon identische Größe, Dauer und Auflösung — er hatte also nie eine Chance, den Fall zu sehen, für den er geschrieben wurde. Der häufigste echte Duplikat-Fall in einer transkodierten Bibliothek war damit strukturell unsichtbar.

## Ansatz

Was ein Re-Encode überlebt: das Bild selbst, und — bis auf ein, zwei Frames — die Laufzeit.

1. **Dauer-Bucketing** (±1,5 s) per Sweep über die nach Dauer sortierte Liste. O(n log n) plus tatsächlich emittierte Paare, kein all-pairs.
2. **Multi-Frame-phash** bei 25/50/75 % der Laufzeit. Bewusst gespreizt: ein einzelner früher Frame ist oft schwarz oder ein Studio-Logo und matcht dann quer durch die Bibliothek.
3. **Alle** Positionen müssen innerhalb der Hamming-Schwelle liegen. Das ist der Unterschied zwischen "gleicher Vorspann" und "gleicher Film" — sonst fällt eine komplette Serienstaffel in eine Gruppe.
4. **Union-Find** statt greedy: ob A und B zusammen landen, darf nicht davon abhängen, in welcher Reihenfolge die Paare besucht werden.

Gruppen erscheinen als `match_type: "reencode"`, Confidence 0.75 — ein Frame-Match ist schwächere Evidenz als übereinstimmende Bytes. Die UI rendert `match_type`/`confidence` generisch, es braucht also keine Frontend-Änderung.

### Kosten

Jede Signatur kostet drei ffmpeg-Seeks. Deshalb:
- gehasht wird **nur**, was mindestens einen Dauer-Nachbarn hat (eine Datei mit einzigartiger Laufzeit kann keinen Re-Encode-Zwilling haben),
- Signaturen werden stat-validiert in `.vframe_cache.json` gecacht (gleiches Format wie der Bild-Cache aus #37, gemeinsame Klasse `_StatValidatedHashCache`),
- abschaltbar über `find_all_duplicates(..., detect_reencodes=False)`.

## Zwei Funde aus dem Ende-zu-Ende-Lauf

Gegen echte ffmpeg-Dateien getestet (testsrc 20 s → x264 CRF 18, davon x265 CRF 34 @ 320x240, plus ein unbeteiligtes mandelbrot-Video). Paar wird gefunden, das Fremdvideo nicht. Dabei kam heraus:

- **Der Codec-Bonus empfahl die falsche Datei zum Behalten.** `_calculate_video_quality_score` gibt HEVC +20. Zwischen byte-identischen Kopien ist das richtig; in einer Re-Encode-Gruppe ist die HEVC-Datei aber das verkleinerte Derivat des Originals. Der Bonus entfällt für `reencode`-Gruppen, Auflösung und Bitrate entscheiden.
- **`_get_video_frame_hash` ließ Temp-Dateien liegen**, wenn ffmpeg fehlschlug oder in den Timeout lief (`NamedTemporaryFile(delete=False)`, `os.remove` nur im Erfolgspfad). Cleanup jetzt im `finally`.

## Tests

16 neue Tests in `tests/test_duplicate_reencodes.py` — inkl. der Präzisionsfälle (gleiche Dauer/anderer Inhalt, geteilter Vorspann, Dauer außerhalb der Toleranz), Reihenfolge-Unabhängigkeit, transitive Gruppen, "keine ffmpeg-Kosten für einzigartige Laufzeiten" und der Keep-Empfehlung.

`723 passed, 1 xfailed` — volle Suite grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)