### PR TITLE
refactor(dedup): redundanten visuellen Fallback im Video-Pass entfernt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project will be documented in this file.
   `find_all_duplicates(..., detect_reencodes=False)`.
 
 ### Fixed
+- **Bild-Duplikate fielen aus dem Ergebnis, wenn eine Gruppe ihren Partner
+  zuerst beanspruchte**: Der Near-Miss-Pass war greedy — wer einmal in einer
+  Gruppe steckte, war für alle weiteren Vergleiche verbraucht. Bei A~B und A~C,
+  aber B!~C, verschwand je nach Reihenfolge B oder C komplett aus dem Ergebnis
+  und wurde als eindeutig gemeldet. Welches von beiden, hing an der
+  Iterationsreihenfolge, dieselbe Bibliothek konnte also unterschiedliche
+  Antworten liefern. Clustering läuft jetzt über Union-Find: jedes Paar
+  innerhalb der Schwelle landet garantiert in derselben Gruppe. Preis dafür ist
+  transitives Ketten (A~B, B~C ergibt eine Gruppe, auch wenn A!~C) — bei
+  Schwelle 5 über 64 Bit braucht das einen echten Verlauf fast identischer
+  Bilder, und die zusammen zu zeigen ist ohnehin die erwartete Antwort.
 - **Duplikat-Scan fand keine Duplikate über Batch-Grenzen hinweg**: Die
   Bild-Batches waren echte Slices (`all_images[offset:offset+size]`), und
   verglichen wurde nur *innerhalb* eines Slices. Zwei Kopien desselben Fotos auf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ All notable changes to this project will be documented in this file.
   Videos, die überhaupt einen Dauer-Nachbarn haben. Abschaltbar über
   `find_all_duplicates(..., detect_reencodes=False)`.
 
+### Changed
+- **Bild-Hashing läuft parallel**: Das Dekodieren der Bilder ist die gesamte
+  Kosten des ersten Duplikat-Scans, und PIL wie numpy geben dabei den GIL frei.
+  Cache-Misses laufen jetzt über einen Thread-Pool (Threads = Kernzahl,
+  gedeckelt bei 8). Gemessen auf 4 Kernen: 300 Bilder à 1600×1200 in 2,0 s statt
+  6,2 s (3,0×), bei identischer Gruppierung. Nebenbei entfällt pro Bild ein
+  `imagehash.hex_to_hash` — das Objekt wurde durch beide Vergleichsphasen
+  gereicht, aber nie gelesen (verglichen wird auf `int(hash, 16)`).
+
 ### Fixed
 - **Bild-Duplikate fielen aus dem Ergebnis, wenn eine Gruppe ihren Partner
   zuerst beanspruchte**: Der Near-Miss-Pass war greedy — wer einmal in einer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ All notable changes to this project will be documented in this file.
   `find_all_duplicates(..., detect_reencodes=False)`.
 
 ### Fixed
+- **Duplikat-Scan fand keine Duplikate über Batch-Grenzen hinweg**: Die
+  Bild-Batches waren echte Slices (`all_images[offset:offset+size]`), und
+  verglichen wurde nur *innerhalb* eines Slices. Zwei Kopien desselben Fotos auf
+  gegenüberliegenden Seiten einer Grenze — Eintrag 4999 und 5001 — wurden damit
+  in keinem einzigen Batch je miteinander verglichen. Zusätzlich überschrieb
+  jeder Lauf den Gruppen-Cache mit seinem eigenen Slice-Ergebnis, Batch 2 warf
+  also alles weg, was Batch 1 gefunden hatte. Das Limit begrenzt jetzt nur noch,
+  wie viele *neue* Hashes ein Lauf berechnet; verglichen wird immer über die
+  gesamte Bibliothek. Jeder Lauf liefert damit ein vollständiges Ergebnis, das
+  mit jedem weiteren Batch wächst.
+- **Nicht dekodierbare Bilder wurden bei jedem Scan neu versucht**: Fehlschläge
+  hinterließen keine Spur im Cache. Mit dem neuen Batch-Modell hätte das zu
+  einem endlosen "weitere Batches verfügbar" geführt. Sie werden jetzt markiert
+  (stat-validiert wie jeder andere Eintrag, eine reparierte Datei wird also
+  wieder versucht).
 - **Duplikat-Scan empfahl bei Re-Encodes die falsche Datei zum Behalten**:
   `_calculate_video_quality_score` vergibt +20 Punkte für moderne Codecs. Beim
   Abwägen zwischen byte-identischen Kopien ist das richtig, in einer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to this project will be documented in this file.
   `find_all_duplicates(..., detect_reencodes=False)`.
 
 ### Changed
+- **Redundanten visuellen Fallback im Video-Pass entfernt**:
+  `_verify_by_content_sample` startete für Dateien, die es nicht über Bytes
+  matchen konnte, eine eigene Ein-Frame-Prüfung. Diese Dateien sind genau die,
+  die der Exact-Pass ungruppiert lässt — und die übernimmt jetzt der
+  Re-Encode-Pass, mit drei Frames statt einem und mit Cache. Der Inline-Weg
+  konnte also nur schwächer wiederholen, was ohnehin passiert (~50 Zeilen weg).
 - **Bild-Hashing läuft parallel**: Das Dekodieren der Bilder ist die gesamte
   Kosten des ersten Duplikat-Scans, und PIL wie numpy geben dabei den GIL frei.
   Cache-Misses laufen jetzt über einen Thread-Pool (Threads = Kernzahl,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Duplikat-Scan findet re-encodete Videos**: Der bisherige Video-Pass gruppiert
+  nach gerundeter Größe + Dauer + Auflösung. Eine transkodierte Kopie (H.264 →
+  HEVC, 1080p → 720p, anderer CRF) teilt keinen dieser Werte und landete damit
+  nie im selben Bucket — und der visuelle Fallback lief nur *innerhalb* eines
+  Buckets, wo alle Dateien ohnehin schon identische Größe und Auflösung haben.
+  Genau der häufigste echte Duplikat-Fall in einer transkodierten Bibliothek war
+  also unsichtbar. Neuer zweiter Pass: Bucketing nach Dauer (±1,5 s), dann
+  Vergleich perceptueller Hashes von drei Frames bei 25/50/75 % der Laufzeit.
+  Gruppiert wird nur, wenn *alle* Positionen passen — ein gemeinsamer Vorspann
+  reicht nicht, sonst würde eine ganze Serienstaffel zusammenfallen.
+  Gruppen erscheinen als `match_type: "reencode"` mit 75 % Confidence.
+  Frame-Signaturen werden in `.vframe_cache.json` gecacht; gehasht werden nur
+  Videos, die überhaupt einen Dauer-Nachbarn haben. Abschaltbar über
+  `find_all_duplicates(..., detect_reencodes=False)`.
+
 ### Fixed
+- **Duplikat-Scan empfahl bei Re-Encodes die falsche Datei zum Behalten**:
+  `_calculate_video_quality_score` vergibt +20 Punkte für moderne Codecs. Beim
+  Abwägen zwischen byte-identischen Kopien ist das richtig, in einer
+  Re-Encode-Gruppe genau falsch: die HEVC-Datei ist dort das verkleinerte
+  Derivat des H.264-Originals. Der Codec-Bonus entfällt jetzt für
+  `reencode`-Gruppen; Auflösung und Bitrate entscheiden.
+- **Duplikat-Scan ließ temporäre Frame-Dateien liegen**: Schlug der
+  ffmpeg-Aufruf in `_get_video_frame_hash` fehl oder lief in den Timeout, blieb
+  die per `NamedTemporaryFile(delete=False)` angelegte Datei in `/tmp` zurück —
+  über einen langen Scan mit vielen kaputten Dateien summiert sich das. Cleanup
+  läuft jetzt im `finally`.
 - **Duplikat-Scan: veraltete perceptual Hashes** (`.phash_cache.json`): Der Cache
   war nur nach Dateipfad indiziert, ohne jede Angabe, aus welchem Dateizustand
   der Hash stammt. Wurde ein Bild an Ort und Stelle geändert (Neu-Export,

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -551,33 +551,24 @@ class DuplicateDetector:
     def _verify_by_content_sample(self, files: List) -> List[List]:
         """
         Verify potential duplicates by comparing content samples.
-        Falls back to visual hash for re-encoded videos.
-        Returns groups of files that have matching content.
+        Returns groups of files whose sampled bytes match.
+
+        Files that fail this check are simply not grouped here. They are not
+        lost: `_find_reencoded_video_duplicates` picks up everything the exact
+        pass left ungrouped and compares it by picture instead of by bytes.
+        That subsumes the single-frame fallback this method used to run inline
+        (`_verify_by_visual_hash`), which only ever saw files that already had
+        matching size, duration and resolution, sampled one frame instead of
+        three, and cached nothing between scans.
         """
-        # Calculate content hashes
         hash_map: Dict[str, List] = defaultdict(list)
-        unmatched = []
 
         for f in files:
-            path = f.file_path
-            content_hash = self._get_content_sample_hash(path)
+            content_hash = self._get_content_sample_hash(f.file_path)
             if content_hash:
                 hash_map[content_hash].append(f)
 
-        # Collect exact match groups
-        result_groups = [group for group in hash_map.values() if len(group) > 1]
-
-        # Collect files that didn't match by content hash
-        for group in hash_map.values():
-            if len(group) == 1:
-                unmatched.append(group[0])
-
-        # If we have unmatched files and imagehash is available, try visual matching
-        if len(unmatched) >= 2 and IMAGEHASH_AVAILABLE:
-            visual_groups = self._verify_by_visual_hash(unmatched)
-            result_groups.extend(visual_groups)
-
-        return result_groups
+        return [group for group in hash_map.values() if len(group) > 1]
 
     def _get_video_frame_hash(self, video_path: str, position_sec: float = 2.0) -> Optional[str]:
         """
@@ -632,64 +623,13 @@ class DuplicateDetector:
                 except OSError:
                     pass
 
-    def _verify_by_visual_hash(self, files: List, threshold: int = 8) -> List[List]:
-        """
-        Group files by visual similarity using frame extraction + perceptual hash.
-        Threshold: max hash difference to consider as duplicate (0=exact, higher=more lenient)
-        """
-        # Get visual hashes for all files
-        hash_data: List[Tuple[Any, Any]] = []  # (file, phash_obj)
-
-        for f in files:
-            path = f.file_path
-            duration = getattr(f, 'duration_sec', 0) if hasattr(f, 'duration_sec') else 0
-
-            # Sample frame from middle of video (or 2s in if short)
-            sample_pos = min(duration / 2, 2.0) if duration > 0 else 2.0
-
-            hash_str = self._get_video_frame_hash(path, sample_pos)
-            if hash_str:
-                try:
-                    phash_obj = imagehash.hex_to_hash(hash_str)
-                    hash_data.append((f, phash_obj))
-                except Exception:
-                    pass
-
-        # Group by similar hashes
-        used = set()
-        groups = []
-
-        for i, (file_a, hash_a) in enumerate(hash_data):
-            if i in used:
-                continue
-
-            similar = [file_a]
-            used.add(i)
-
-            for j, (file_b, hash_b) in enumerate(hash_data):
-                if j in used:
-                    continue
-
-                # Compare hashes
-                diff = hash_a - hash_b
-                if diff <= threshold:
-                    similar.append(file_b)
-                    used.add(j)
-
-            if len(similar) > 1:
-                groups.append(similar)
-
-        return groups
-
     # -- Re-encode detection --------------------------------------------------
     #
     # The exact pass above buckets videos by rounded size + duration +
     # resolution. A re-encoded copy (H.264 -> HEVC, 1080p -> 720p, different
-    # CRF) shares none of those, so it never reaches the same bucket -- and the
-    # visual-hash fallback only ever runs *inside* one bucket, where files
-    # already have identical size and resolution and there is nothing left for
-    # it to find. Re-encodes, the single most common kind of real duplicate in
-    # a transcoded library, were therefore invisible.
+    # CRF) shares none of those, so it never reaches the same bucket.
+    # Re-encodes, the single most common kind of real duplicate in a transcoded
+    # library, were therefore invisible.
     #
     # What does survive re-encoding is the picture itself and, to within about
     # a frame, the duration. So: bucket by duration, then compare perceptual

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -5,6 +5,7 @@ Finds duplicate videos and images in the media library.
 import hashlib
 import os
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -73,6 +74,14 @@ class DuplicateGroup:
             "recommended_keep": self.recommended_keep,
             "potential_savings_mb": self.potential_savings_mb,
         }
+
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _is_hex(value: str) -> bool:
+    """Cheap check that a cached string is a parseable hash."""
+    return bool(value) and all(c in _HEX_DIGITS for c in value)
 
 
 def _popcount(value: int) -> int:
@@ -357,6 +366,35 @@ class DuplicateDetector:
         self._video_hashes = _StatValidatedHashCache(
             ".vframe_cache.json", "video frame signatures"
         )
+
+    @staticmethod
+    def _hash_worker_count(pending: int) -> int:
+        """Threads for the image hashing pool.
+
+        Decoding is CPU-bound but runs mostly outside the GIL, so the useful
+        ceiling is core count — measured throughput on a 4-core box peaks at 4
+        threads and drifts back down past it. Capped at 8 so a large server does
+        not spawn a pool that only adds contention and memory.
+        """
+        return max(1, min(pending, os.cpu_count() or 1, 8))
+
+    @staticmethod
+    def _phash_file(path: str) -> Optional[str]:
+        """Perceptual hash of one image file, or None if it cannot be decoded.
+
+        Runs on pool threads: it touches no detector state, so the only shared
+        thing is the file system.
+        """
+        try:
+            with Image.open(path) as pil_img:
+                hash_img = (
+                    pil_img.convert('RGB')
+                    if pil_img.mode not in ('RGB', 'L')
+                    else pil_img
+                )
+                return str(imagehash.phash(hash_img))
+        except Exception:
+            return None
 
     def _generate_group_id(self) -> str:
         self._group_counter += 1
@@ -943,19 +981,17 @@ class DuplicateDetector:
         # Load hash cache from disk
         self._image_hashes.load()
 
-        # Phase 1: Compute/retrieve hashes with progress tracking
-        hash_data: List[Tuple[str, 'imagehash.ImageHash', Any]] = []
+        # Phase 1a: resolve every image against the cache. Cheap and sequential
+        # — one stat and one dict lookup each — and it decides which files
+        # actually have to be decoded.
+        hashes_by_path: Dict[str, str] = {}
+        pending: List[Tuple[Any, os.stat_result]] = []
         total_images = len(images)
         cache_hits = 0
-        cache_misses = 0
         deferred = 0
         budget = total_images if hash_budget is None else max(hash_budget, 0)
 
-        for idx, img in enumerate(images):
-            if progress_callback and idx % 200 == 0:
-                pct = 80 + (idx / total_images) * 10  # 80-90% range
-                progress_callback(f"Hashing image {idx}/{total_images} (cache: {cache_hits} hits)", pct)
-
+        for img in images:
             path = img.file_path
             # One stat serves both the existence check and cache validation.
             try:
@@ -963,7 +999,6 @@ class DuplicateDetector:
             except OSError:
                 continue
 
-            # Check cache first
             cached_hash_str = self._image_hashes.get(path, st)
             if cached_hash_str == self.UNHASHABLE:
                 # Known-undecodable, and unchanged since we found that out.
@@ -971,36 +1006,66 @@ class DuplicateDetector:
                 # run, burning the budget and leaving `deferred` permanently
                 # above zero — an endless "more batches available".
                 continue
-            if cached_hash_str:
-                try:
-                    phash = imagehash.hex_to_hash(cached_hash_str)
-                    hash_data.append((cached_hash_str, phash, img))
-                    cache_hits += 1
-                    continue
-                except Exception:
-                    pass  # Invalid cache entry, recompute
+            # A corrupt entry is treated as a miss and recomputed. Validating
+            # the hex here rather than parsing it keeps cache hits cheap; the
+            # comparison phases read `int(hash_str, 16)`, so garbage would raise
+            # there instead of quietly costing one image its match.
+            if cached_hash_str and _is_hex(cached_hash_str):
+                hashes_by_path[path] = cached_hash_str
+                cache_hits += 1
+                continue
 
             if budget <= 0:
                 deferred += 1
                 continue
             budget -= 1
+            pending.append((img, st))
 
-            # Cache miss — compute hash
-            try:
-                with Image.open(path) as pil_img:
-                    hash_img = pil_img.convert('RGB') if pil_img.mode not in ('RGB', 'L') else pil_img
-                    phash = imagehash.phash(hash_img)
-                    hash_str = str(phash)
-                    hash_data.append((hash_str, phash, img))
-                    self._image_hashes.set(path, hash_str, st)
-                    cache_misses += 1
-            except Exception:
-                self._image_hashes.set(path, self.UNHASHABLE, st)
-                continue
+        # Phase 1b: decode and hash the misses across a thread pool. Decoding is
+        # the whole cost here, and PIL and numpy both drop the GIL while they
+        # work, so this scales with cores: measured 3.1x on 4 cores at 1600x1200
+        # (5.9s -> 1.9s for 300 images), with byte-identical hashes.
+        cache_misses = 0
+        if pending:
+            workers = self._hash_worker_count(len(pending))
+            # Chunked so progress keeps moving and the periodic GC that large
+            # libraries rely on still happens between chunks rather than never.
+            chunk_size = max(workers * 8, 100)
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                for start in range(0, len(pending), chunk_size):
+                    chunk = pending[start:start + chunk_size]
+                    if progress_callback:
+                        pct = 80 + (start / len(pending)) * 10  # 80-90% range
+                        progress_callback(
+                            f"Hashing image {start}/{len(pending)} "
+                            f"({cache_hits} from cache, {workers} threads)",
+                            pct,
+                        )
 
-            # Periodic GC for large libraries
-            if cache_misses % 500 == 0 and cache_misses > 0:
-                gc.collect()
+                    for (img, st), hash_str in zip(
+                        chunk, pool.map(self._phash_file, (i.file_path for i, _ in chunk))
+                    ):
+                        if hash_str:
+                            hashes_by_path[img.file_path] = hash_str
+                            self._image_hashes.set(img.file_path, hash_str, st)
+                            cache_misses += 1
+                        else:
+                            self._image_hashes.set(img.file_path, self.UNHASHABLE, st)
+
+                    gc.collect()
+
+        # Phase 1c: assemble in input order, so the result never depends on how
+        # the pool happened to interleave.
+        #
+        # Only the hex string is carried. The old code also built an
+        # `imagehash.ImageHash` per image here and threaded it through both
+        # grouping phases, where nothing ever read it -- comparison runs on
+        # `int(hash_str, 16)`. Each of those cost a numpy array construction.
+        hash_data: List[Tuple[str, Any]] = [
+            (hashes_by_path[img.file_path], img)
+            for img in images
+            if img.file_path in hashes_by_path
+        ]
 
         # Save updated cache to disk
         self._image_hashes.save()
@@ -1014,16 +1079,15 @@ class DuplicateDetector:
 
         # Phase 2: Group by exact hash (O(n) — covers most true duplicates)
         exact_buckets: Dict[str, List] = defaultdict(list)
-        for hash_str, phash, img in hash_data:
-            exact_buckets[hash_str].append((phash, img))
+        for hash_str, img in hash_data:
+            exact_buckets[hash_str].append(img)
 
         groups = []
         used_paths = set()
 
         # Exact matches — identical hashes
-        for hash_str, bucket in exact_buckets.items():
-            if len(bucket) > 1:
-                imgs = [img for _, img in bucket]
+        for hash_str, imgs in exact_buckets.items():
+            if len(imgs) > 1:
                 group = self._create_image_group(imgs, match_type="hash")
                 groups.append(group)
                 for img in imgs:
@@ -1037,7 +1101,7 @@ class DuplicateDetector:
         # and were never compared. Banding indexes every part of the hash, so
         # recall no longer depends on *where* the images differ.
         remaining = [
-            (h, p, img) for h, p, img in hash_data if img.file_path not in used_paths
+            (h, img) for h, img in hash_data if img.file_path not in used_paths
         ] if threshold > 0 else []
 
         if remaining:
@@ -1047,7 +1111,7 @@ class DuplicateDetector:
             # A hex phash is 4 bits per character (16 chars = the usual 64 bits).
             index = _BandedHashIndex(bits=len(remaining[0][0]) * 4, threshold=threshold)
             values = []
-            for idx, (hash_str, phash, img) in enumerate(remaining):
+            for idx, (hash_str, img) in enumerate(remaining):
                 value = int(hash_str, 16)
                 values.append(value)
                 index.add(idx, value)
@@ -1078,7 +1142,7 @@ class DuplicateDetector:
             for members in uf.clusters():
                 if len(members) > 1:
                     group = self._create_image_group(
-                        [remaining[i][2] for i in members], match_type="hash"
+                        [remaining[i][1] for i in members], match_type="hash"
                     )
                     groups.append(group)
 

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -1052,25 +1052,34 @@ class DuplicateDetector:
                 values.append(value)
                 index.add(idx, value)
 
-            used_remaining = set()
-            for i, (h_i, p_i, img_i) in enumerate(remaining):
-                if i in used_remaining:
-                    continue
-
-                similar = [img_i]
-                used_remaining.add(i)
-
+            # Union-Find rather than the greedy "claim and move on" pass this
+            # replaces. Greedy consumed a match into the first group that
+            # reached it, so a third image near *that* one but not near the
+            # group's anchor was left ungrouped and reported as unique: with
+            # A~B and A~C but B!~C, whichever of B/C lost the race simply
+            # vanished from the results. Which one lost depended on iteration
+            # order, so the same library could yield different answers.
+            #
+            # The trade-off is that near-duplicates now chain transitively (A~B,
+            # B~C puts A and C in one group even if A!~C). At threshold 5 over
+            # 64 bits that needs a genuine gradient of near-identical images,
+            # and grouping those together is the answer a user expects anyway —
+            # unlike silently dropping one.
+            uf = _UnionFind(len(remaining))
+            for i in range(len(remaining)):
                 # Sorted for deterministic grouping across runs.
                 for j in sorted(index.candidates(values[i])):
-                    if j == i or j in used_remaining:
-                        continue
+                    if j <= i:
+                        continue  # Each pair once; union is symmetric
                     # Banding only narrows the field; the real distance decides.
                     if _hamming(values[i], values[j]) <= threshold:
-                        similar.append(remaining[j][2])
-                        used_remaining.add(j)
+                        uf.union(i, j)
 
-                if len(similar) > 1:
-                    group = self._create_image_group(similar, match_type="hash")
+            for members in uf.clusters():
+                if len(members) > 1:
+                    group = self._create_image_group(
+                        [remaining[i][2] for i in members], match_type="hash"
+                    )
                     groups.append(group)
 
         return groups, deferred

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -347,6 +347,9 @@ class DuplicateDetector:
     REENCODE_DURATION_TOLERANCE_SEC = 1.5
     # Max per-frame Hamming distance. Every sampled position must be within it.
     REENCODE_FRAME_THRESHOLD = 8
+    # Cache marker for a file that could not be decoded, so it is not retried
+    # on every scan. Not a valid hex hash, so it can never match a real one.
+    UNHASHABLE = "!"
 
     def __init__(self):
         self._group_counter = 0
@@ -366,27 +369,38 @@ class DuplicateDetector:
         Args:
             entries: List of VideoEntry objects from the database
             progress_callback: Optional callable(str, float) to report status and progress (0-100)
-            batch_size: Max number of images to process per batch (default 5000)
-            batch_offset: Starting offset for image processing (for pagination)
+            batch_size: Max number of images to *hash* per run (default 5000).
+                Comparison always covers the whole library — see below.
+            batch_offset: Legacy pagination cursor. Kept so existing callers and
+                the frontend's "scan next batch" button keep working; it no
+                longer slices the input, since batch progress is now tracked by
+                what the hash cache already holds.
             detect_reencodes: Also look for re-encoded copies of the same video
                 (different size/codec, same content). Costs ffmpeg frame
                 extractions on first run; cached afterwards.
 
         Returns:
             Tuple of (List of DuplicateGroup objects, has_more: bool indicating if more batches available)
+
+        Batching note: this used to slice the image list
+        (`all_images[offset:offset + size]`) and compare only within the slice.
+        Two copies of the same photo that happened to land on opposite sides of
+        a boundary — entries 4999 and 5001 — were therefore never compared to
+        each other, in any batch, ever. Worse, each run overwrote the group
+        cache with its own slice's results, so finishing batch 2 discarded
+        everything batch 1 had found.
+
+        Now the cap applies only to how many *new* hashes are computed per run.
+        Comparison always runs over every image whose hash is already known, so
+        each run returns a complete, global result that grows as more of the
+        library gets hashed.
         """
         # Separate by media type
         videos = [e for e in entries if getattr(e, 'media_type', 'video') == 'video']
-        all_images = [e for e in entries if getattr(e, 'media_type', 'video') == 'image']
-
-        # Apply batching to images (videos are usually fewer and faster to process)
-        total_images = len(all_images)
-        images = all_images[batch_offset:batch_offset + batch_size]
-        has_more = (batch_offset + batch_size) < total_images
+        images = [e for e in entries if getattr(e, 'media_type', 'video') == 'image']
 
         if progress_callback:
-            batch_info = f" (batch {batch_offset//batch_size + 1}, images {batch_offset+1}-{min(batch_offset+batch_size, total_images)} of {total_images})"
-            progress_callback(f"Starting duplicate scan{batch_info}", 5)
+            progress_callback(f"Starting duplicate scan ({len(images)} images)", 5)
 
         groups = []
 
@@ -406,15 +420,20 @@ class DuplicateDetector:
                 )
             )
 
-        # Find image duplicates (batched)
+        # Find image duplicates (hashing capped per run, comparison global)
         if progress_callback:
             progress_callback(f"Scanning image metadata ({len(images)} images)...", 80)
 
-        image_groups = self._find_image_duplicates(images, progress_callback)
+        image_groups, deferred = self._find_image_duplicates(
+            images, progress_callback, hash_budget=batch_size
+        )
         groups.extend(image_groups)
+        has_more = deferred > 0
 
         if progress_callback:
-            status = "Scan complete" + (" - more batches available" if has_more else "")
+            status = "Scan complete" + (
+                f" - {deferred} images still to hash" if has_more else ""
+            )
             progress_callback(status, 100)
 
         return groups, has_more
@@ -856,15 +875,22 @@ class DuplicateDetector:
 
         return round(score, 2)
 
-    def _find_image_duplicates(self, images: List, progress_callback=None) -> List[DuplicateGroup]:
+    def _find_image_duplicates(
+        self, images: List, progress_callback=None, hash_budget: Optional[int] = None
+    ) -> Tuple[List[DuplicateGroup], int]:
         """
         Find duplicate images.
         Uses perceptual hash if available, otherwise falls back to exact match.
+
+        Returns (groups, deferred) where `deferred` counts images left unhashed
+        because the budget ran out. The exact-match fallback needs no hashing,
+        so it always defers nothing.
         """
         if IMAGEHASH_AVAILABLE:
-            return self._find_image_duplicates_by_hash(images, progress_callback=progress_callback)
-        else:
-            return self._find_image_duplicates_by_exact(images)
+            return self._find_image_duplicates_by_hash(
+                images, progress_callback=progress_callback, hash_budget=hash_budget
+            )
+        return self._find_image_duplicates_by_exact(images), 0
 
     def _find_image_duplicates_by_exact(self, images: List) -> List[DuplicateGroup]:
         """Find duplicate images by exact size + resolution match."""
@@ -889,14 +915,28 @@ class DuplicateDetector:
 
         return groups
 
-    def _find_image_duplicates_by_hash(self, images: List, threshold: int = 5, progress_callback=None) -> List[DuplicateGroup]:
+    def _find_image_duplicates_by_hash(
+        self,
+        images: List,
+        threshold: int = 5,
+        progress_callback=None,
+        hash_budget: Optional[int] = None,
+    ) -> Tuple[List[DuplicateGroup], int]:
         """
         Find duplicate images using perceptual hash.
         Images with hash difference <= threshold are considered duplicates.
 
+        `hash_budget` caps how many *new* hashes this run computes; images past
+        it keep their place in the library and are simply not compared yet.
+        Comparison itself always covers every image with a known hash, so a
+        budget bounds one run's cost without ever splitting the search space.
+
+        Returns (groups, deferred_count).
+
         Performance optimizations:
         - Hash caching: reuses previously computed hashes from disk
-        - Hash bucketing: groups by exact hash first (O(n)), then near-miss via prefix buckets
+        - Hash bucketing: groups by exact hash first (O(n)), then near-miss via
+          a banded candidate index
         """
         import gc
 
@@ -908,6 +948,8 @@ class DuplicateDetector:
         total_images = len(images)
         cache_hits = 0
         cache_misses = 0
+        deferred = 0
+        budget = total_images if hash_budget is None else max(hash_budget, 0)
 
         for idx, img in enumerate(images):
             if progress_callback and idx % 200 == 0:
@@ -923,6 +965,12 @@ class DuplicateDetector:
 
             # Check cache first
             cached_hash_str = self._image_hashes.get(path, st)
+            if cached_hash_str == self.UNHASHABLE:
+                # Known-undecodable, and unchanged since we found that out.
+                # Without this the same broken files would be retried on every
+                # run, burning the budget and leaving `deferred` permanently
+                # above zero — an endless "more batches available".
+                continue
             if cached_hash_str:
                 try:
                     phash = imagehash.hex_to_hash(cached_hash_str)
@@ -931,6 +979,11 @@ class DuplicateDetector:
                     continue
                 except Exception:
                     pass  # Invalid cache entry, recompute
+
+            if budget <= 0:
+                deferred += 1
+                continue
+            budget -= 1
 
             # Cache miss — compute hash
             try:
@@ -942,6 +995,7 @@ class DuplicateDetector:
                     self._image_hashes.set(path, hash_str, st)
                     cache_misses += 1
             except Exception:
+                self._image_hashes.set(path, self.UNHASHABLE, st)
                 continue
 
             # Periodic GC for large libraries
@@ -952,7 +1006,11 @@ class DuplicateDetector:
         self._image_hashes.save()
 
         if progress_callback:
-            progress_callback(f"Hashed {len(hash_data)} images ({cache_hits} cached, {cache_misses} new)", 92)
+            progress_callback(
+                f"Hashed {len(hash_data)} images ({cache_hits} cached, {cache_misses} new"
+                + (f", {deferred} deferred" if deferred else "") + ")",
+                92,
+            )
 
         # Phase 2: Group by exact hash (O(n) — covers most true duplicates)
         exact_buckets: Dict[str, List] = defaultdict(list)
@@ -1015,7 +1073,7 @@ class DuplicateDetector:
                     group = self._create_image_group(similar, match_type="hash")
                     groups.append(group)
 
-        return groups
+        return groups, deferred
 
     def _create_image_group(self, images: List, match_type: str) -> DuplicateGroup:
         """Create a DuplicateGroup from a list of matching images."""

--- a/arcade_scanner/core/duplicate_detector.py
+++ b/arcade_scanner/core/duplicate_detector.py
@@ -148,63 +148,66 @@ class _BandedHashIndex:
         return found
 
 
-class DuplicateDetector:
+class _StatValidatedHashCache:
+    """Disk-backed `path -> hash` cache that notices when a file changes.
+
+    Each entry carries the mtime and size the hash was computed from, so a file
+    replaced in place (re-export, rotation, rsync over the same path) is
+    re-hashed instead of silently keeping a hash that no longer describes it.
+
+    The stored value is opaque to this class — the image pass keeps a single
+    phash there, the video pass keeps a joined multi-frame signature.
     """
-    Detects duplicate media files using various strategies.
 
-    Videos: Exact match on size + duration + resolution
-    Images: Perceptual hash (if imagehash available) or exact size + resolution
+    # Bumped whenever the on-disk layout changes.
+    VERSION = 2
 
-    Performance:
-    - Perceptual hashes are cached to disk across scans
-    - Hash bucketing eliminates O(n²) comparisons
-    """
+    def __init__(self, filename: str, label: str):
+        self._filename = filename
+        self._label = label
+        self._entries: Dict[str, Tuple[str, int, int]] = {}
+        self.dirty = False
+        self.path: Optional[str] = None  # Resolved lazily on first load
 
-    # Bumped whenever the on-disk cache layout changes.
-    HASH_CACHE_VERSION = 2
+    def __len__(self) -> int:
+        return len(self._entries)
 
-    def __init__(self):
-        self._group_counter = 0
-        # filepath -> (phash hex string, mtime_ns, size_bytes)
-        self._hash_cache: Dict[str, Tuple[str, int, int]] = {}
-        self._hash_cache_dirty = False
-        self._hash_cache_file = None  # Set lazily
-
-    def _ensure_hash_cache(self):
-        """Load hash cache from disk on first use."""
-        if self._hash_cache_file is not None:
-            return  # Already loaded
+    def load(self) -> None:
+        """Load from disk on first use; a no-op once `path` is set."""
+        if self.path is not None:
+            return
 
         import json
 
         from ..config import config
 
-        self._hash_cache_file = os.path.join(config.hidden_data_dir, ".phash_cache.json")
+        self.path = os.path.join(config.hidden_data_dir, self._filename)
         try:
-            if os.path.exists(self._hash_cache_file):
-                with open(self._hash_cache_file, 'r') as f:
+            if os.path.exists(self.path):
+                with open(self.path, 'r') as f:
                     raw = json.load(f)
-                self._hash_cache, purged, migrated = self._decode_hash_cache(raw)
+                self._entries, purged, migrated = self.decode(raw)
                 if purged or migrated:
-                    self._hash_cache_dirty = True
+                    self.dirty = True
                 notes = []
                 if purged:
                     notes.append(f"purged {purged} orphans")
                 if migrated:
                     notes.append(f"migrated {migrated} legacy entries")
-                print(f"📦 Loaded {len(self._hash_cache)} cached image hashes" +
+                print(f"📦 Loaded {len(self._entries)} cached {self._label}" +
                       (f" ({', '.join(notes)})" if notes else ""))
         except Exception as e:
-            print(f"⚠️ Could not load hash cache: {e}")
-            self._hash_cache = {}
+            print(f"⚠️ Could not load {self._label} cache: {e}")
+            self._entries = {}
 
-    def _decode_hash_cache(self, raw) -> Tuple[Dict[str, Tuple[str, int, int]], int, int]:
-        """Parse an on-disk cache payload into the in-memory form.
+    @staticmethod
+    def decode(raw) -> Tuple[Dict[str, Tuple[str, int, int]], int, int]:
+        """Parse an on-disk payload into the in-memory form.
 
         Returns (entries, purged_count, migrated_count). Entries whose file no
         longer exists are dropped here so the cache does not grow forever.
 
-        Version 1 stored a bare `{path: phash}` map with no way to tell whether
+        Version 1 stored a bare `{path: hash}` map with no way to tell whether
         the file had changed since, so an edited-in-place image kept serving the
         old hash — and a wrong hash means a wrong duplicate group, which the UI
         offers to delete. Those legacy entries are stamped with the file's
@@ -238,36 +241,36 @@ class DuplicateDetector:
 
         return entries, purged, migrated
 
-    def _save_hash_cache(self):
-        """Persist hash cache to disk."""
-        if not self._hash_cache_dirty or not self._hash_cache_file:
+    def save(self) -> None:
+        """Persist to disk, unless nothing changed."""
+        if not self.dirty or not self.path:
             return
 
         import json
         try:
-            os.makedirs(os.path.dirname(self._hash_cache_file), exist_ok=True)
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
             payload = {
-                "version": self.HASH_CACHE_VERSION,
-                "entries": {p: list(v) for p, v in self._hash_cache.items()},
+                "version": self.VERSION,
+                "entries": {p: list(v) for p, v in self._entries.items()},
             }
             # Write-then-rename: a crash mid-write would otherwise leave a
             # truncated JSON file that the next run silently discards whole.
-            tmp_path = f"{self._hash_cache_file}.tmp"
+            tmp_path = f"{self.path}.tmp"
             with open(tmp_path, 'w') as f:
                 json.dump(payload, f)
-            os.replace(tmp_path, self._hash_cache_file)
-            print(f"💾 Saved {len(self._hash_cache)} image hashes to cache")
-            self._hash_cache_dirty = False
+            os.replace(tmp_path, self.path)
+            print(f"💾 Saved {len(self._entries)} {self._label} to cache")
+            self.dirty = False
         except Exception as e:
-            print(f"⚠️ Could not save hash cache: {e}")
+            print(f"⚠️ Could not save {self._label} cache: {e}")
 
-    def _get_cached_hash(self, filepath: str, st: Optional[os.stat_result] = None) -> Optional[str]:
-        """Get a cached phash for a file, or None if absent or stale.
+    def get(self, filepath: str, st: Optional[os.stat_result] = None) -> Optional[str]:
+        """Cached hash for a file, or None if absent or stale.
 
         `st` is the caller's already-taken stat of the file; the hash is only
         reused when mtime and size still match what was hashed.
         """
-        entry = self._hash_cache.get(filepath)
+        entry = self._entries.get(filepath)
         if entry is None:
             return None
 
@@ -282,21 +285,81 @@ class DuplicateDetector:
             return None
         return hash_str
 
-    def _set_cached_hash(self, filepath: str, hash_str: str, st: Optional[os.stat_result] = None):
-        """Store a phash together with the file identity it was computed from."""
+    def set(self, filepath: str, hash_str: str, st: Optional[os.stat_result] = None) -> None:
+        """Store a hash together with the file identity it was computed from."""
         if st is None:
             try:
                 st = os.stat(filepath)
             except OSError:
                 return
-        self._hash_cache[filepath] = (hash_str, st.st_mtime_ns, st.st_size)
-        self._hash_cache_dirty = True
+        self._entries[filepath] = (hash_str, st.st_mtime_ns, st.st_size)
+        self.dirty = True
+
+
+class _UnionFind:
+    """Disjoint-set over integer indices, for order-independent clustering."""
+
+    __slots__ = ("_parent",)
+
+    def __init__(self, n: int):
+        self._parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        root = x
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[x] != root:  # Path compression
+            self._parent[x], x = root, self._parent[x]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self._parent[max(ra, rb)] = min(ra, rb)
+
+    def clusters(self) -> List[List[int]]:
+        """Members grouped by root, each cluster and the whole list sorted."""
+        buckets: Dict[int, List[int]] = defaultdict(list)
+        for i in range(len(self._parent)):
+            buckets[self.find(i)].append(i)
+        return [sorted(members) for _, members in sorted(buckets.items())]
+
+
+class DuplicateDetector:
+    """
+    Detects duplicate media files using various strategies.
+
+    Videos: Exact match on size + duration + resolution, plus a second pass that
+            catches re-encodes (same content, different size/codec/resolution)
+    Images: Perceptual hash (if imagehash available) or exact size + resolution
+
+    Performance:
+    - Perceptual hashes are cached to disk across scans
+    - Hash bucketing eliminates O(n²) comparisons
+    """
+
+    # Frame positions sampled for the re-encode pass, as fractions of duration.
+    # Spread out on purpose: a single early frame is often a black frame or a
+    # studio logo, which matches across completely unrelated videos.
+    REENCODE_FRAME_POSITIONS = (0.25, 0.5, 0.75)
+    # How far two durations may drift and still be considered the same content.
+    # Re-encodes land within a frame or two; container padding adds a bit more.
+    REENCODE_DURATION_TOLERANCE_SEC = 1.5
+    # Max per-frame Hamming distance. Every sampled position must be within it.
+    REENCODE_FRAME_THRESHOLD = 8
+
+    def __init__(self):
+        self._group_counter = 0
+        self._image_hashes = _StatValidatedHashCache(".phash_cache.json", "image hashes")
+        self._video_hashes = _StatValidatedHashCache(
+            ".vframe_cache.json", "video frame signatures"
+        )
 
     def _generate_group_id(self) -> str:
         self._group_counter += 1
         return f"dup_{self._group_counter:04d}"
 
-    def find_all_duplicates(self, entries: List, progress_callback=None, batch_size: int = 5000, batch_offset: int = 0) -> Tuple[List[DuplicateGroup], bool]:
+    def find_all_duplicates(self, entries: List, progress_callback=None, batch_size: int = 5000, batch_offset: int = 0, detect_reencodes: bool = True) -> Tuple[List[DuplicateGroup], bool]:
         """
         Find duplicates in the media library with batching support.
 
@@ -305,6 +368,9 @@ class DuplicateDetector:
             progress_callback: Optional callable(str, float) to report status and progress (0-100)
             batch_size: Max number of images to process per batch (default 5000)
             batch_offset: Starting offset for image processing (for pagination)
+            detect_reencodes: Also look for re-encoded copies of the same video
+                (different size/codec, same content). Costs ffmpeg frame
+                extractions on first run; cached afterwards.
 
         Returns:
             Tuple of (List of DuplicateGroup objects, has_more: bool indicating if more batches available)
@@ -330,6 +396,15 @@ class DuplicateDetector:
 
         video_groups = self._find_video_duplicates(videos, progress_callback)
         groups.extend(video_groups)
+
+        # Second video pass: copies that were re-encoded, so no metadata matches
+        if detect_reencodes:
+            already_grouped = {f.path for g in video_groups for f in g.files}
+            groups.extend(
+                self._find_reencoded_video_duplicates(
+                    videos, already_grouped, progress_callback
+                )
+            )
 
         # Find image duplicates (batched)
         if progress_callback:
@@ -458,6 +533,7 @@ class DuplicateDetector:
         if not IMAGEHASH_AVAILABLE:
             return None
 
+        temp_path = None
         try:
             # Create temp file for extracted frame
             with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp:
@@ -486,16 +562,18 @@ class DuplicateDetector:
                 phash = imagehash.phash(img)
                 hash_str = str(phash)
 
-            # Cleanup
-            try:
-                os.remove(temp_path)
-            except Exception:
-                pass
-
             return hash_str
 
         except Exception:
             return None
+        finally:
+            # Always clean up: on an ffmpeg failure or timeout the old code left
+            # the (empty) temp file behind, filling /tmp over a long scan.
+            if temp_path:
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass
 
     def _verify_by_visual_hash(self, files: List, threshold: int = 8) -> List[List]:
         """
@@ -546,12 +624,167 @@ class DuplicateDetector:
 
         return groups
 
-    def _create_video_group(self, videos: List) -> DuplicateGroup:
+    # -- Re-encode detection --------------------------------------------------
+    #
+    # The exact pass above buckets videos by rounded size + duration +
+    # resolution. A re-encoded copy (H.264 -> HEVC, 1080p -> 720p, different
+    # CRF) shares none of those, so it never reaches the same bucket -- and the
+    # visual-hash fallback only ever runs *inside* one bucket, where files
+    # already have identical size and resolution and there is nothing left for
+    # it to find. Re-encodes, the single most common kind of real duplicate in
+    # a transcoded library, were therefore invisible.
+    #
+    # What does survive re-encoding is the picture itself and, to within about
+    # a frame, the duration. So: bucket by duration, then compare perceptual
+    # hashes of frames sampled at the same *relative* positions.
+
+    def _video_frame_signature(self, video) -> Optional[str]:
+        """Perceptual hashes of several frames of one video, ':'-joined.
+
+        Cached on disk keyed by path + mtime + size, because each miss costs one
+        ffmpeg invocation per sampled position.
+        """
+        path = getattr(video, 'file_path', '')
+        try:
+            st = os.stat(path)
+        except OSError:
+            return None
+
+        cached = self._video_hashes.get(path, st)
+        if cached:
+            return cached
+
+        duration = getattr(video, 'duration_sec', 0) or 0
+        if duration <= 0:
+            return None
+
+        hashes = []
+        for fraction in self.REENCODE_FRAME_POSITIONS:
+            hash_str = self._get_video_frame_hash(path, duration * fraction)
+            if not hash_str:
+                return None  # A partial signature would compare unequal lengths
+            hashes.append(hash_str)
+
+        signature = ":".join(hashes)
+        self._video_hashes.set(path, signature, st)
+        return signature
+
+    @staticmethod
+    def _signatures_match(sig_a: str, sig_b: str, threshold: int) -> bool:
+        """True when *every* sampled frame is within the Hamming threshold.
+
+        Requiring all positions rather than a majority is what keeps episodes of
+        the same series apart: they share an intro, not a whole runtime.
+        """
+        frames_a = sig_a.split(":")
+        frames_b = sig_b.split(":")
+        if len(frames_a) != len(frames_b):
+            return False
+        try:
+            return all(
+                _hamming(int(a, 16), int(b, 16)) <= threshold
+                for a, b in zip(frames_a, frames_b)
+            )
+        except ValueError:
+            return False
+
+    def _duration_candidate_pairs(self, videos: List) -> List[Tuple[int, int]]:
+        """Index pairs whose durations are close enough to be the same content.
+
+        Sweeps the duration-sorted list, so this is O(n log n) plus the pairs
+        actually emitted -- not an all-pairs comparison.
+        """
+        order = sorted(
+            range(len(videos)),
+            key=lambda i: (getattr(videos[i], 'duration_sec', 0) or 0, videos[i].file_path),
+        )
+        tolerance = self.REENCODE_DURATION_TOLERANCE_SEC
+
+        pairs = []
+        for a in range(len(order)):
+            dur_a = getattr(videos[order[a]], 'duration_sec', 0) or 0
+            if dur_a <= 0:
+                continue
+            for b in range(a + 1, len(order)):
+                dur_b = getattr(videos[order[b]], 'duration_sec', 0) or 0
+                if dur_b - dur_a > tolerance:
+                    break  # Sorted: everything further out is further away
+                pairs.append((order[a], order[b]))
+        return pairs
+
+    def _find_reencoded_video_duplicates(
+        self, videos: List, skip_paths: Set[str], progress_callback=None
+    ) -> List[DuplicateGroup]:
+        """Group videos that hold the same content at different encodings."""
+        if not IMAGEHASH_AVAILABLE:
+            return []
+
+        candidates = [
+            v for v in videos
+            if v.file_path not in skip_paths and (getattr(v, 'duration_sec', 0) or 0) > 0
+        ]
+        if len(candidates) < 2:
+            return []
+
+        pairs = self._duration_candidate_pairs(candidates)
+        if not pairs:
+            return []
+
+        # Only videos that actually have a duration neighbour get hashed; a file
+        # with a unique runtime can have no re-encode twin, so paying for three
+        # ffmpeg seeks on it would be pure waste.
+        needed = sorted({i for pair in pairs for i in pair})
+        self._video_hashes.load()
+
+        signatures: Dict[int, str] = {}
+        for done, idx in enumerate(needed):
+            if progress_callback and done % 25 == 0:
+                pct = 55 + (done / len(needed)) * 20  # 55-75% range
+                progress_callback(
+                    f"Checking video {done}/{len(needed)} for re-encoded copies", pct
+                )
+            signature = self._video_frame_signature(candidates[idx])
+            if signature:
+                signatures[idx] = signature
+        self._video_hashes.save()
+
+        # Union-Find: whether A and B end up together must not depend on the
+        # order the pairs happen to be visited in.
+        uf = _UnionFind(len(candidates))
+        for i, j in pairs:
+            sig_i, sig_j = signatures.get(i), signatures.get(j)
+            if sig_i and sig_j and self._signatures_match(
+                sig_i, sig_j, self.REENCODE_FRAME_THRESHOLD
+            ):
+                uf.union(i, j)
+
+        groups = []
+        for members in uf.clusters():
+            if len(members) > 1:
+                groups.append(
+                    self._create_video_group(
+                        [candidates[i] for i in members],
+                        match_type="reencode",
+                        confidence=0.75,
+                    )
+                )
+        return groups
+
+    def _create_video_group(
+        self, videos: List, match_type: str = "exact", confidence: float = 0.95
+    ) -> DuplicateGroup:
         """Create a DuplicateGroup from a list of matching videos."""
         dup_files = []
 
+        # Within a re-encode group the codec says nothing about which copy is
+        # the source — the HEVC file is usually the *lossy* derivative of the
+        # H.264 original, so its +20 codec bonus would recommend keeping exactly
+        # the copy the user wants to drop. Resolution and bitrate still do carry
+        # that signal, so only the codec term is dropped.
+        codec_bonus = match_type != "reencode"
+
         for v in videos:
-            quality_score = self._calculate_video_quality_score(v)
+            quality_score = self._calculate_video_quality_score(v, codec_bonus=codec_bonus)
             dup_file = DuplicateFile(
                 path=v.file_path,
                 size_mb=v.size_mb,
@@ -576,18 +809,22 @@ class DuplicateDetector:
 
         return DuplicateGroup(
             group_id=self._generate_group_id(),
-            match_type="exact",
+            match_type=match_type,
             media_type="video",
-            confidence=0.95,
+            confidence=confidence,
             files=dup_files,
             recommended_keep=dup_files[0].path if dup_files else "",
             potential_savings_mb=round(savings, 2),
         )
 
-    def _calculate_video_quality_score(self, video) -> float:
+    def _calculate_video_quality_score(self, video, codec_bonus: bool = True) -> float:
         """
         Calculate a quality score for a video.
         Higher score = better quality = should keep.
+
+        `codec_bonus` rewards modern codecs — right when picking between
+        byte-identical copies, wrong when picking between re-encodes, where the
+        efficient codec marks the lossy derivative rather than the source.
         """
         score = 0.0
 
@@ -609,7 +846,7 @@ class DuplicateDetector:
             score += 5
 
         # Codec contribution (0-20 points)
-        codec = getattr(video, 'codec', '').lower()
+        codec = getattr(video, 'codec', '').lower() if codec_bonus else ''
         if 'hevc' in codec or 'h265' in codec or 'x265' in codec:
             score += 20  # Modern efficient codec
         elif 'h264' in codec or 'avc' in codec or 'x264' in codec:
@@ -664,7 +901,7 @@ class DuplicateDetector:
         import gc
 
         # Load hash cache from disk
-        self._ensure_hash_cache()
+        self._image_hashes.load()
 
         # Phase 1: Compute/retrieve hashes with progress tracking
         hash_data: List[Tuple[str, 'imagehash.ImageHash', Any]] = []
@@ -685,7 +922,7 @@ class DuplicateDetector:
                 continue
 
             # Check cache first
-            cached_hash_str = self._get_cached_hash(path, st)
+            cached_hash_str = self._image_hashes.get(path, st)
             if cached_hash_str:
                 try:
                     phash = imagehash.hex_to_hash(cached_hash_str)
@@ -702,7 +939,7 @@ class DuplicateDetector:
                     phash = imagehash.phash(hash_img)
                     hash_str = str(phash)
                     hash_data.append((hash_str, phash, img))
-                    self._set_cached_hash(path, hash_str, st)
+                    self._image_hashes.set(path, hash_str, st)
                     cache_misses += 1
             except Exception:
                 continue
@@ -712,7 +949,7 @@ class DuplicateDetector:
                 gc.collect()
 
         # Save updated cache to disk
-        self._save_hash_cache()
+        self._image_hashes.save()
 
         if progress_callback:
             progress_callback(f"Hashed {len(hash_data)} images ({cache_hits} cached, {cache_misses} new)", 92)

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -220,9 +220,17 @@ def background_duplicate_scan(
         )
         print(f"🔍 Found {len(results)} duplicate groups (has_more: {has_more})")
 
+        # Replacing the cache wholesale is correct: a run's result now covers
+        # every image with a known hash, not just its own slice, so each run is
+        # a superset of the last. (While batches were slices, this line quietly
+        # threw away everything the previous batch had found.)
         _dup_mgr.cache = [g.to_dict() for g in results]
         _dup_mgr.update_state(
             has_more=has_more,
+            # An opaque continuation token, no longer a list index — the
+            # detector tracks progress by what its hash cache already holds.
+            # It only has to stay non-zero, because loadDuplicates() treats
+            # offset 0 as "show cached results" instead of "scan again".
             next_offset=batch_offset + 5000 if has_more else 0,
         )
         save_duplicate_cache()

--- a/tests/test_duplicate_batching.py
+++ b/tests/test_duplicate_batching.py
@@ -1,0 +1,144 @@
+"""Tests for how the duplicate scan splits work across runs.
+
+The scan used to slice the image list per batch and compare only within the
+slice, which made a pair straddling a boundary permanently unfindable. These
+tests pin down the replacement rule: a run caps how many *new hashes* it
+computes, never which images may be compared with which.
+"""
+import os
+
+import pytest
+
+from arcade_scanner.core.duplicate_detector import IMAGEHASH_AVAILABLE, DuplicateDetector
+
+pytestmark = pytest.mark.skipif(
+    not IMAGEHASH_AVAILABLE, reason="imagehash/Pillow not installed"
+)
+
+
+class FakeImage:
+    def __init__(self, file_path, size_mb=1.0, width=1920, height=1080):
+        self.file_path = file_path
+        self.size_mb = size_mb
+        self.width = width
+        self.height = height
+        self.media_type = "image"
+        self.thumb = ""
+
+
+def make_images(tmp_path, hashes, detector=None):
+    """Create tmp files; seed the detector's cache for non-None hashes.
+
+    A None hash models an image that has not been hashed yet — the file exists
+    but nothing in the cache describes it, so it costs budget to process.
+    """
+    detector = detector or DuplicateDetector()
+    detector._image_hashes.path = str(tmp_path / ".phash_cache.json")
+
+    images = []
+    for i, hash_str in enumerate(hashes):
+        path = tmp_path / f"img_{i:03d}.jpg"
+        path.write_bytes(b"\xff\xd8\xff\xd9")  # not decodable as a real JPEG
+        if hash_str is not None:
+            detector._image_hashes.set(str(path), hash_str)
+        images.append(FakeImage(str(path)))
+
+    detector._image_hashes.dirty = False  # keep save() a no-op
+    return detector, images
+
+
+def grouped(groups):
+    return {frozenset(os.path.basename(f.path) for f in g.files) for g in groups}
+
+
+DUP = "f0f0f0f0f0f0f0f0"
+
+
+def test_duplicates_across_a_batch_boundary_are_found(tmp_path):
+    """The bug this module exists for.
+
+    With the old `all_images[offset:offset + size]` slicing and a batch size of
+    2, these two copies land in different batches and are never compared —
+    not in batch 1, not in batch 2, not ever. Comparison must not be scoped to
+    a batch.
+    """
+    detector, images = make_images(
+        tmp_path, [DUP, "0123456789abcdef", DUP, "1122334455667788"]
+    )
+
+    groups, _ = detector.find_all_duplicates(images, batch_size=2)
+
+    assert grouped(groups) == {frozenset({"img_000.jpg", "img_002.jpg"})}
+
+
+def test_earlier_results_are_not_lost_by_a_later_run(tmp_path):
+    """Each run returns the complete picture, not just its own slice.
+
+    The old code overwrote the group cache with each run's slice-local result,
+    so completing batch 2 discarded everything batch 1 had found.
+    """
+    detector, images = make_images(tmp_path, [DUP, DUP, "aaaabbbbccccdddd", "aaaabbbbccccdddd"])
+
+    first, _ = detector.find_all_duplicates(images, batch_size=2)
+    second, _ = detector.find_all_duplicates(images, batch_size=2)
+
+    assert grouped(first) == grouped(second) == {
+        frozenset({"img_000.jpg", "img_001.jpg"}),
+        frozenset({"img_002.jpg", "img_003.jpg"}),
+    }
+
+
+def test_budget_limits_new_hashes_not_comparisons(tmp_path):
+    """Unhashed images are deferred; already-hashed ones still all compare."""
+    detector, images = make_images(tmp_path, [DUP, DUP, None, None])
+
+    groups, has_more = detector.find_all_duplicates(images, batch_size=0)
+
+    assert grouped(groups) == {frozenset({"img_000.jpg", "img_001.jpg"})}
+    assert has_more is True, "two images still lack a hash"
+
+
+def test_has_more_is_false_once_everything_is_hashed(tmp_path):
+    detector, images = make_images(tmp_path, [DUP, DUP])
+
+    _, has_more = detector.find_all_duplicates(images, batch_size=5000)
+
+    assert has_more is False
+
+
+def test_undecodable_files_do_not_keep_has_more_true(tmp_path):
+    """Broken files must be recorded, or the UI loops on 'more batches'.
+
+    The tmp fixtures are not real JPEGs, so hashing them genuinely fails. If a
+    failure left no trace, every run would retry the same files, spend the same
+    budget, and report more work remaining forever.
+    """
+    detector, images = make_images(tmp_path, [None, None])
+
+    _, first_has_more = detector.find_all_duplicates(images, batch_size=1)
+    _, second_has_more = detector.find_all_duplicates(images, batch_size=1)
+
+    assert first_has_more is True   # one still unattempted
+    assert second_has_more is False  # both now known-undecodable
+    assert detector._image_hashes.get(images[0].file_path) == DuplicateDetector.UNHASHABLE
+
+
+def test_a_repaired_file_is_retried(tmp_path):
+    """The failure marker is stat-validated like any other cache entry."""
+    detector, images = make_images(tmp_path, [None])
+    detector.find_all_duplicates(images, batch_size=1)
+    assert detector._image_hashes.get(images[0].file_path) == DuplicateDetector.UNHASHABLE
+
+    with open(images[0].file_path, "wb") as f:
+        f.write(b"\xff\xd8\xff\xd9\x00")  # different bytes, new size
+
+    assert detector._image_hashes.get(images[0].file_path) is None
+
+
+def test_unhashable_marker_never_matches_a_real_hash(tmp_path):
+    """Two broken files must not be reported as duplicates of each other."""
+    detector, images = make_images(tmp_path, [None, None])
+
+    groups, _ = detector.find_all_duplicates(images, batch_size=10)
+
+    assert groups == []

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -130,13 +130,19 @@ def test_threshold_zero_skips_near_miss_pass(tmp_path):
 
 
 def test_matches_brute_force_on_random_hashes(tmp_path):
-    """Candidate search must find exactly what an all-pairs scan would find.
+    """Candidate search must find everything an all-pairs scan would find.
 
-    This is the general form of the head/tail asymmetry above: for random
-    hashes, every pair the detector groups must be within the threshold, and
-    every pair within the threshold must end up in *some* group together --
-    unless one of them was already consumed by an earlier group (the grouping
-    pass is greedy, and this test pins that down rather than fighting it).
+    This is the general form of the head/tail asymmetry above. Two properties,
+    both stated against a brute-force reference:
+
+    - Completeness: every pair within the threshold lands in the *same* group.
+      The greedy pass this replaced could only promise that at least one of the
+      two ended up grouped somewhere -- with A~B and A~C but B!~C, whichever of
+      B/C lost the race was reported as unique, and which one lost depended on
+      iteration order.
+    - Soundness: a group is not arbitrary. Members chain transitively, so two
+      members may sit further apart than the threshold, but every member has to
+      be within it of *some* other member of its own group.
     """
     import random
 
@@ -165,26 +171,64 @@ def test_matches_brute_force_on_random_hashes(tmp_path):
     parsed = [imagehash.hex_to_hash(h) for h in hashes]
     grouped = grouped_paths(groups)
 
-    # Every grouped pair really is within the threshold.
     index_of = {f"img_{i:03d}.jpg": i for i in range(len(hashes))}
+
+    # Soundness: nobody is in a group they have no near neighbour in.
     for group in grouped:
         members = sorted(index_of[name] for name in group)
-        anchor = members[0]
-        for other in members[1:]:
-            assert parsed[anchor] - parsed[other] <= threshold, (
-                f"grouped {anchor} and {other} at distance "
-                f"{parsed[anchor] - parsed[other]} > {threshold}"
-            )
+        for member in members:
+            assert any(
+                other != member and parsed[member] - parsed[other] <= threshold
+                for other in members
+            ), f"{member} was grouped without a single neighbour within {threshold}"
 
-    # No near pair is missed outright: for every brute-force pair, at least one
-    # of the two must have landed in a group.
-    in_a_group = {name for group in grouped for name in group}
+    # Completeness: every brute-force near pair shares a group.
+    group_of = {
+        index_of[name]: gid for gid, group in enumerate(grouped) for name in group
+    }
     for a in range(len(hashes)):
         for b in range(a + 1, len(hashes)):
             if parsed[a] - parsed[b] <= threshold:
-                assert (
-                    f"img_{a:03d}.jpg" in in_a_group or f"img_{b:03d}.jpg" in in_a_group
-                ), f"pair ({a}, {b}) at distance {parsed[a] - parsed[b]} was dropped entirely"
+                assert group_of.get(a) is not None and group_of.get(a) == group_of.get(b), (
+                    f"pair ({a}, {b}) at distance {parsed[a] - parsed[b]} "
+                    f"did not end up in the same group"
+                )
+
+
+def test_third_near_match_is_not_dropped(tmp_path):
+    """A near-duplicate must not vanish because a group claimed its match first.
+
+    Distances here: B–A = 5, A–C = 5, B–C = 10. With the input in this order,
+    the greedy pass anchored on B, pulled in A (within 5), marked both used,
+    and then found nothing left for C — which was within the threshold of A and
+    should have been reported. C was silently listed as unique instead.
+    """
+    hash_a = "0000000000000000"
+    hash_b = "000000000000001f"  # 5 bits from A
+    hash_c = "0000000000001f00"  # 5 bits from A, 10 from B
+
+    detector, images = make_detector(tmp_path, [hash_b, hash_a, hash_c])
+
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
+
+    assert grouped_paths(groups) == {
+        frozenset({"img_000.jpg", "img_001.jpg", "img_002.jpg"})
+    }
+
+
+def test_grouping_does_not_depend_on_input_order(tmp_path):
+    """The same three images must group the same way however they arrive."""
+    hashes = ["0000000000000000", "000000000000001f", "0000000000001f00"]
+
+    results = []
+    for run, order in enumerate([[0, 1, 2], [2, 1, 0], [1, 0, 2]]):
+        run_dir = tmp_path / f"run{run}"
+        run_dir.mkdir()
+        detector, images = make_detector(run_dir, [hashes[i] for i in order])
+        groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
+        results.append(sorted(len(g.files) for g in groups))
+
+    assert results == [[3], [3], [3]]
 
 
 def test_missing_files_are_skipped(tmp_path):

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -5,15 +5,19 @@ These pin down the near-miss image matching behaviour of
 dirs; no real media library or arcade_data/ is touched.
 
 The detector is driven through its hash cache rather than through real images:
-`_ensure_hash_cache` returns early once `_hash_cache_file` is set, and
-`_save_hash_cache` returns early while the cache is not dirty, so a
-pre-populated `_hash_cache` lets a test choose exact phash values.
+`_StatValidatedHashCache.load()` returns early once `path` is set, and `save()`
+returns early while the cache is not dirty, so a pre-populated cache lets a test
+choose exact phash values without decoding anything.
 """
 import os
 
 import pytest
 
-from arcade_scanner.core.duplicate_detector import IMAGEHASH_AVAILABLE, DuplicateDetector
+from arcade_scanner.core.duplicate_detector import (
+    IMAGEHASH_AVAILABLE,
+    DuplicateDetector,
+    _StatValidatedHashCache,
+)
 
 pytestmark = pytest.mark.skipif(
     not IMAGEHASH_AVAILABLE, reason="imagehash/Pillow not installed"
@@ -40,16 +44,16 @@ def make_detector(tmp_path, hashes):
     detector = DuplicateDetector()
     # Point the cache at a tmp file so _ensure_hash_cache short-circuits and
     # nothing is ever read from or written to the real arcade_data/ dir.
-    detector._hash_cache_file = str(tmp_path / ".phash_cache.json")
+    detector._image_hashes.path = str(tmp_path / ".phash_cache.json")
 
     images = []
     for i, hash_str in enumerate(hashes):
         path = tmp_path / f"img_{i:03d}.jpg"
         path.write_bytes(b"\xff\xd8\xff\xd9")  # not a real JPEG; never decoded
-        detector._set_cached_hash(str(path), hash_str)
+        detector._image_hashes.set(str(path), hash_str)
         images.append(FakeImage(str(path)))
 
-    detector._hash_cache_dirty = False  # keep _save_hash_cache a no-op
+    detector._image_hashes.dirty = False  # keep save() a no-op
     return detector, images
 
 
@@ -201,7 +205,7 @@ def test_missing_files_are_skipped(tmp_path):
 def test_cached_hash_is_reused_while_file_is_unchanged(tmp_path):
     detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
 
-    assert detector._get_cached_hash(images[0].file_path) == "f0f0f0f0f0f0f0f0"
+    assert detector._image_hashes.get(images[0].file_path) == "f0f0f0f0f0f0f0f0"
 
 
 def test_cached_hash_is_dropped_when_file_content_changes(tmp_path):
@@ -217,7 +221,7 @@ def test_cached_hash_is_dropped_when_file_content_changes(tmp_path):
     with open(path, "wb") as f:
         f.write(b"\xff\xd8completely different bytes\xff\xd9")
 
-    assert detector._get_cached_hash(path) is None
+    assert detector._image_hashes.get(path) is None
 
 
 def test_cached_hash_is_dropped_when_only_mtime_changes(tmp_path):
@@ -228,7 +232,7 @@ def test_cached_hash_is_dropped_when_only_mtime_changes(tmp_path):
     st = os.stat(path)
     os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
 
-    assert detector._get_cached_hash(path) is None
+    assert detector._image_hashes.get(path) is None
 
 
 def test_changed_file_is_regrouped_by_its_new_hash(tmp_path):
@@ -241,7 +245,7 @@ def test_changed_file_is_regrouped_by_its_new_hash(tmp_path):
     path = images[1].file_path
     with open(path, "wb") as f:
         f.write(b"\xff\xd8other\xff\xd9")
-    detector._set_cached_hash(path, "0f0f0f0f0f0f0f0f")
+    detector._image_hashes.set(path, "0f0f0f0f0f0f0f0f")
 
     groups = detector._find_image_duplicates_by_hash(images, threshold=5)
 
@@ -254,7 +258,7 @@ def test_legacy_flat_cache_is_migrated_and_stamped(tmp_path):
     path = tmp_path / "legacy.jpg"
     path.write_bytes(b"\xff\xd8\xff\xd9")
 
-    entries, purged, migrated = detector._decode_hash_cache(
+    entries, purged, migrated = _StatValidatedHashCache.decode(
         {str(path): "f0f0f0f0f0f0f0f0"}
     )
 
@@ -269,7 +273,7 @@ def test_decode_purges_orphans_and_malformed_entries(tmp_path):
     present.write_bytes(b"\xff\xd8\xff\xd9")
     st = os.stat(present)
 
-    entries, purged, migrated = detector._decode_hash_cache({
+    entries, purged, migrated = _StatValidatedHashCache.decode({
         "version": 2,
         "entries": {
             str(present): ["f0f0f0f0f0f0f0f0", st.st_mtime_ns, st.st_size],
@@ -285,15 +289,16 @@ def test_decode_purges_orphans_and_malformed_entries(tmp_path):
 
 def test_cache_roundtrips_through_disk(tmp_path):
     detector, images = make_detector(tmp_path, ["f0f0f0f0f0f0f0f0"])
-    detector._hash_cache_dirty = True
-    detector._save_hash_cache()
+    detector._image_hashes.dirty = True
+    detector._image_hashes.save()
 
-    reloaded = DuplicateDetector()
-    reloaded._hash_cache_file = detector._hash_cache_file
     import json
-    with open(detector._hash_cache_file) as f:
+    with open(detector._image_hashes.path) as f:
         raw = json.load(f)
-    reloaded._hash_cache, _, _ = reloaded._decode_hash_cache(raw)
 
-    assert raw["version"] == DuplicateDetector.HASH_CACHE_VERSION
-    assert reloaded._get_cached_hash(images[0].file_path) == "f0f0f0f0f0f0f0f0"
+    reloaded = _StatValidatedHashCache(".phash_cache.json", "image hashes")
+    reloaded.path = detector._image_hashes.path
+    reloaded._entries, _, _ = _StatValidatedHashCache.decode(raw)
+
+    assert raw["version"] == _StatValidatedHashCache.VERSION
+    assert reloaded.get(images[0].file_path) == "f0f0f0f0f0f0f0f0"

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -42,8 +42,8 @@ def make_detector(tmp_path, hashes):
     entry. Returns (detector, [FakeImage, ...]) in the same order.
     """
     detector = DuplicateDetector()
-    # Point the cache at a tmp file so _ensure_hash_cache short-circuits and
-    # nothing is ever read from or written to the real arcade_data/ dir.
+    # Point the cache at a tmp file so load() short-circuits and nothing is
+    # ever read from or written to the real arcade_data/ dir.
     detector._image_hashes.path = str(tmp_path / ".phash_cache.json")
 
     images = []
@@ -71,7 +71,7 @@ def test_identical_hashes_are_grouped(tmp_path):
         tmp_path, ["f0f0f0f0f0f0f0f0", "f0f0f0f0f0f0f0f0", "0123456789abcdef"]
     )
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert grouped_paths(groups) == {frozenset({"img_000.jpg", "img_001.jpg"})}
 
@@ -86,7 +86,7 @@ def test_near_miss_in_hash_tail_is_grouped(tmp_path):
         tmp_path, ["0000000000000000", "0000000000000001"]
     )
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert grouped_paths(groups) == {frozenset({"img_000.jpg", "img_001.jpg"})}
 
@@ -102,7 +102,7 @@ def test_near_miss_in_hash_head_is_grouped(tmp_path):
         tmp_path, ["0000000000000000", "8000000000000000"]
     )
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert grouped_paths(groups) == {frozenset({"img_000.jpg", "img_001.jpg"})}
 
@@ -113,7 +113,7 @@ def test_distant_hashes_are_not_grouped(tmp_path):
         tmp_path, ["0000000000000000", "ffffffffffffffff"]
     )
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert groups == []
 
@@ -124,7 +124,7 @@ def test_threshold_zero_skips_near_miss_pass(tmp_path):
         tmp_path, ["0000000000000000", "0000000000000001"]
     )
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=0)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=0)
 
     assert groups == []
 
@@ -160,7 +160,7 @@ def test_matches_brute_force_on_random_hashes(tmp_path):
     rng.shuffle(hashes)
 
     detector, images = make_detector(tmp_path, hashes)
-    groups = detector._find_image_duplicates_by_hash(images, threshold=threshold)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=threshold)
 
     parsed = [imagehash.hex_to_hash(h) for h in hashes]
     grouped = grouped_paths(groups)
@@ -194,7 +194,7 @@ def test_missing_files_are_skipped(tmp_path):
     )
     os.remove(images[1].file_path)
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert groups == []
 
@@ -247,7 +247,7 @@ def test_changed_file_is_regrouped_by_its_new_hash(tmp_path):
         f.write(b"\xff\xd8other\xff\xd9")
     detector._image_hashes.set(path, "0f0f0f0f0f0f0f0f")
 
-    groups = detector._find_image_duplicates_by_hash(images, threshold=5)
+    groups, _ = detector._find_image_duplicates_by_hash(images, threshold=5)
 
     assert groups == []
 

--- a/tests/test_duplicate_hash_pool.py
+++ b/tests/test_duplicate_hash_pool.py
@@ -1,0 +1,182 @@
+"""Tests for the threaded image-hashing phase.
+
+Hashing dominates a first duplicate scan, and it is the one part of the scan
+that parallelises: PIL and numpy both drop the GIL while decoding. What must
+survive the pool is the *result* — grouping has to stay byte-for-byte what a
+single-threaded run produces, whatever order the pool finishes in.
+"""
+import os
+
+import pytest
+
+from arcade_scanner.core.duplicate_detector import (
+    IMAGEHASH_AVAILABLE,
+    DuplicateDetector,
+    _is_hex,
+)
+
+pytestmark = pytest.mark.skipif(
+    not IMAGEHASH_AVAILABLE, reason="imagehash/Pillow not installed"
+)
+
+
+class FakeImage:
+    def __init__(self, file_path, size_mb=1.0, width=1920, height=1080):
+        self.file_path = file_path
+        self.size_mb = size_mb
+        self.width = width
+        self.height = height
+        self.media_type = "image"
+        self.thumb = ""
+
+
+def real_images(tmp_path, count, dup_of=None):
+    """Write `count` genuinely decodable JPEGs; `dup_of` maps i -> source index.
+
+    Content is seeded noise rather than a gradient: smooth synthetic patterns
+    land within phash distance of each other and chain into one big group, which
+    says nothing about the code under test.
+    """
+    import random
+
+    from PIL import Image
+
+    paths = []
+    for i in range(count):
+        path = tmp_path / f"img_{i:03d}.jpg"
+        source = (dup_of or {}).get(i)
+        if source is not None:
+            path.write_bytes(paths[source].read_bytes())
+        else:
+            rng = random.Random(1000 + i)
+            img = Image.new("RGB", (64, 64))
+            px = img.load()
+            for y in range(0, 64, 8):
+                for x in range(0, 64, 8):
+                    colour = (rng.randrange(256), rng.randrange(256), rng.randrange(256))
+                    for dy in range(8):
+                        for dx in range(8):
+                            px[x + dx, y + dy] = colour
+            img.save(path, quality=95)
+        paths.append(path)
+    return [FakeImage(str(p)) for p in paths]
+
+
+def detector_for(tmp_path, workers, name="cache"):
+    detector = DuplicateDetector()
+    detector._image_hashes.path = str(tmp_path / f".{name}.json")
+    detector._hash_worker_count = lambda pending, w=workers: w
+    return detector
+
+
+def grouped(groups):
+    return sorted(
+        sorted(os.path.basename(f.path) for f in g.files) for g in groups
+    )
+
+
+def test_pool_result_matches_single_threaded(tmp_path):
+    """The core guarantee: threads change the timing, not the answer."""
+    images = real_images(tmp_path, 12, dup_of={4: 0, 9: 2, 11: 0})
+
+    single, _ = detector_for(tmp_path, 1, "single")._find_image_duplicates_by_hash(images)
+    pooled, _ = detector_for(tmp_path, 4, "pooled")._find_image_duplicates_by_hash(images)
+
+    assert grouped(single) == grouped(pooled)
+    assert grouped(single) == [
+        ["img_000.jpg", "img_004.jpg", "img_011.jpg"],
+        ["img_002.jpg", "img_009.jpg"],
+    ]
+
+
+def test_hashes_written_to_cache_match_single_threaded(tmp_path):
+    images = real_images(tmp_path, 8)
+
+    single = detector_for(tmp_path, 1, "single")
+    pooled = detector_for(tmp_path, 4, "pooled")
+    single._find_image_duplicates_by_hash(images)
+    pooled._find_image_duplicates_by_hash(images)
+
+    for img in images:
+        assert single._image_hashes.get(img.file_path) == pooled._image_hashes.get(
+            img.file_path
+        )
+
+
+def test_only_cache_misses_are_hashed(tmp_path):
+    """A second run must not decode anything again."""
+    images = real_images(tmp_path, 6)
+    detector = detector_for(tmp_path, 4)
+    detector._find_image_duplicates_by_hash(images)
+
+    hashed = []
+    original = DuplicateDetector._phash_file
+    detector._phash_file = lambda path: hashed.append(path) or original(path)
+
+    detector._find_image_duplicates_by_hash(images)
+
+    assert hashed == []
+
+
+def test_undecodable_files_do_not_sink_the_batch(tmp_path):
+    """One broken file must not cost the others their hashes.
+
+    They share a pool chunk, so an exception escaping a worker would take the
+    whole chunk's results with it.
+    """
+    images = real_images(tmp_path, 4, dup_of={3: 0})
+    broken = tmp_path / "broken.jpg"
+    broken.write_bytes(b"\xff\xd8not a jpeg at all")
+    images.insert(2, FakeImage(str(broken)))
+
+    detector = detector_for(tmp_path, 4)
+    groups, deferred = detector._find_image_duplicates_by_hash(images)
+
+    assert grouped(groups) == [["img_000.jpg", "img_003.jpg"]]
+    assert deferred == 0
+    assert detector._image_hashes.get(str(broken)) == DuplicateDetector.UNHASHABLE
+
+
+def test_budget_still_caps_work_under_the_pool(tmp_path):
+    images = real_images(tmp_path, 6)
+    detector = detector_for(tmp_path, 4)
+
+    detector._find_image_duplicates_by_hash(images, hash_budget=2)
+
+    hashed = sum(
+        1 for img in images if detector._image_hashes.get(img.file_path) is not None
+    )
+    assert hashed == 2
+
+
+def test_corrupt_cache_entry_is_recomputed(tmp_path):
+    """Garbage in the cache must not silently cost an image its match.
+
+    Comparison parses entries with `int(hash_str, 16)`, so an unparseable value
+    would either raise or have to be dropped. It is treated as a miss instead.
+    """
+    images = real_images(tmp_path, 2, dup_of={1: 0})
+    detector = detector_for(tmp_path, 2)
+    detector._image_hashes.set(images[0].file_path, "not-a-hash")
+
+    groups, _ = detector._find_image_duplicates_by_hash(images)
+
+    assert grouped(groups) == [["img_000.jpg", "img_001.jpg"]]
+    assert _is_hex(detector._image_hashes.get(images[0].file_path))
+
+
+def test_worker_count_stays_within_bounds():
+    count = DuplicateDetector._hash_worker_count
+    cpus = os.cpu_count() or 1
+
+    assert count(0) == 1, "never a zero-thread pool"
+    assert count(1) == 1, "one file needs one thread"
+    assert count(10_000) == min(cpus, 8), "capped at cores, and at 8 overall"
+    assert count(2) <= 2, "never more threads than there is work"
+
+
+def test_is_hex_rejects_the_unhashable_marker():
+    """The failure marker must never be mistaken for a hash."""
+    assert not _is_hex(DuplicateDetector.UNHASHABLE)
+    assert not _is_hex("")
+    assert _is_hex("f0f0f0f0f0f0f0f0")

--- a/tests/test_duplicate_reencodes.py
+++ b/tests/test_duplicate_reencodes.py
@@ -296,6 +296,52 @@ def test_detect_reencodes_flag_disables_the_pass(tmp_path, monkeypatch):
     assert called == [1]
 
 
+# --- what the exact pass rejects must still reach this pass -------------------
+
+
+def test_content_verification_rejects_lookalike_videos(tmp_path):
+    """Same size/duration/resolution, different bytes — not duplicates."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, None, {"size_mb": 1.0, "width": 1920, "height": 1080}),
+        (600.0, None, {"size_mb": 1.0, "width": 1920, "height": 1080}),
+    ])
+    for i, v in enumerate(videos):
+        with open(v.file_path, "wb") as f:
+            f.write(bytes([i]) * 4096)
+
+    assert detector._find_video_duplicates(videos) == []
+
+
+def test_content_rejects_are_handed_to_the_reencode_pass(tmp_path):
+    """The property that makes the inline visual fallback redundant.
+
+    `_verify_by_content_sample` used to run its own one-frame visual check on
+    the files it could not match by bytes. Those files are exactly the ones the
+    exact pass leaves ungrouped, and the re-encode pass takes everything
+    ungrouped — with three sampled frames instead of one, and a cache. So the
+    inline fallback could only ever repeat, more weakly, work that now happens
+    anyway.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A, {"size_mb": 1.0, "width": 1920, "height": 1080}),
+        (600.0, SIG_A_NEAR, {"size_mb": 1.0, "width": 1920, "height": 1080}),
+    ])
+    for i, (v, signature) in enumerate(zip(videos, [SIG_A, SIG_A_NEAR])):
+        with open(v.file_path, "wb") as f:
+            f.write(bytes([i]) * 4096)  # differing bytes, identical metadata
+        # Re-seed: the rewrite changed mtime and size, which correctly
+        # invalidates the frame-signature cache entry from make_detector.
+        detector._video_hashes.set(v.file_path, signature)
+
+    exact = detector._find_video_duplicates(videos)
+    assert exact == [], "precondition: content sampling rejects the pair"
+
+    all_groups, _ = detector.find_all_duplicates(videos)
+
+    assert grouped(all_groups) == {frozenset({"vid_000.mp4", "vid_001.mp4"})}
+    assert all_groups[0].match_type == "reencode"
+
+
 # --- helpers -----------------------------------------------------------------
 
 

--- a/tests/test_duplicate_reencodes.py
+++ b/tests/test_duplicate_reencodes.py
@@ -1,0 +1,317 @@
+"""Tests for the re-encoded-video pass in `DuplicateDetector`.
+
+The exact-match pass buckets videos by rounded size + duration + resolution, so
+a re-encoded copy — same content, different codec/CRF/resolution — never shares
+a bucket with its original. This module covers the second pass that catches
+them: duration bucketing plus multi-frame perceptual hashes.
+
+No ffmpeg runs here. Frame signatures are pre-seeded into the detector's video
+hash cache, which `_video_frame_signature` consults before shelling out; the
+cache is stat-validated, so the tmp files it points at have to actually exist.
+"""
+import os
+
+import pytest
+
+from arcade_scanner.core.duplicate_detector import (
+    IMAGEHASH_AVAILABLE,
+    DuplicateDetector,
+    _UnionFind,
+)
+
+pytestmark = pytest.mark.skipif(
+    not IMAGEHASH_AVAILABLE, reason="imagehash/Pillow not installed"
+)
+
+
+class FakeVideo:
+    """Minimal stand-in for a scanned video entry."""
+
+    def __init__(self, file_path, duration_sec, size_mb=100.0,
+                 width=1920, height=1080, codec="h264", bitrate_mbps=8.0):
+        self.file_path = file_path
+        self.duration_sec = duration_sec
+        self.size_mb = size_mb
+        self.width = width
+        self.height = height
+        self.codec = codec
+        self.bitrate_mbps = bitrate_mbps
+        self.media_type = "video"
+        self.thumb = ""
+
+
+def make_detector(tmp_path, specs):
+    """Build a detector plus videos from (duration, signature, **kwargs) specs.
+
+    `signature` is a ':'-joined list of hex frame hashes, or None to model a
+    video whose frames could not be extracted.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    detector = DuplicateDetector()
+    # Point both caches at tmp so nothing touches the real arcade_data/ dir.
+    detector._image_hashes.path = str(tmp_path / ".phash_cache.json")
+    detector._video_hashes.path = str(tmp_path / ".vframe_cache.json")
+
+    videos = []
+    for i, spec in enumerate(specs):
+        duration, signature = spec[0], spec[1]
+        kwargs = spec[2] if len(spec) > 2 else {}
+        path = tmp_path / f"vid_{i:03d}.mp4"
+        path.write_bytes(b"\x00" * (16 + i))  # never decoded
+        if signature:
+            detector._video_hashes.set(str(path), signature)
+        videos.append(FakeVideo(str(path), duration, **kwargs))
+
+    detector._video_hashes.dirty = False  # keep save() a no-op
+    return detector, videos
+
+
+def grouped(groups):
+    """Set of frozensets of basenames, one per duplicate group."""
+    return {frozenset(os.path.basename(f.path) for f in g.files) for g in groups}
+
+
+SIG_A = "0000000000000000:1111111111111111:2222222222222222"
+SIG_A_NEAR = "0000000000000001:1111111111111111:2222222222222222"  # 1 bit off
+SIG_B = "ffffffffffffffff:eeeeeeeeeeeeeeee:dddddddddddddddd"
+
+
+# --- the gap this pass exists to close ---------------------------------------
+
+
+def test_reencode_with_different_size_and_codec_is_found(tmp_path):
+    """The case the exact pass structurally cannot see.
+
+    Same film, transcoded: half the size, HEVC instead of H.264, 720p instead of
+    1080p. Nothing in the exact signature (size + duration + resolution) matches,
+    so before this pass the pair was simply invisible.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (3600.0, SIG_A, {"size_mb": 4000.0, "codec": "h264", "width": 1920, "height": 1080}),
+        (3600.2, SIG_A_NEAR, {"size_mb": 1200.0, "codec": "hevc", "width": 1280, "height": 720}),
+    ])
+
+    exact = detector._find_video_duplicates(videos)
+    assert exact == [], "precondition: the exact pass must not find this pair"
+
+    groups = detector._find_reencoded_video_duplicates(videos, set())
+
+    assert grouped(groups) == {frozenset({"vid_000.mp4", "vid_001.mp4"})}
+    assert groups[0].match_type == "reencode"
+    assert groups[0].confidence < 0.95, "a frame match is weaker evidence than bytes"
+
+
+def test_savings_and_keep_are_reported_for_reencode_groups(tmp_path):
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A, {"size_mb": 1000.0, "bitrate_mbps": 12.0}),
+        (600.0, SIG_A_NEAR, {"size_mb": 400.0, "bitrate_mbps": 4.0}),
+    ])
+
+    group = detector._find_reencoded_video_duplicates(videos, set())[0]
+
+    assert os.path.basename(group.recommended_keep) == "vid_000.mp4"  # higher bitrate
+    assert group.potential_savings_mb == pytest.approx(400.0)
+
+
+def test_codec_bonus_does_not_recommend_keeping_the_lossy_copy(tmp_path):
+    """The HEVC member of a re-encode group is the derivative, not the source.
+
+    `_calculate_video_quality_score` hands modern codecs +20, which is right
+    when choosing between byte-identical copies and wrong here: it would
+    recommend keeping the shrunken transcode over the original it came from.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A, {"codec": "h264", "width": 1920, "height": 1080,
+                        "bitrate_mbps": 8.0, "size_mb": 600.0}),
+        (600.0, SIG_A_NEAR, {"codec": "hevc", "width": 1920, "height": 1080,
+                             "bitrate_mbps": 2.0, "size_mb": 150.0}),
+    ])
+
+    group = detector._find_reencoded_video_duplicates(videos, set())[0]
+
+    assert os.path.basename(group.recommended_keep) == "vid_000.mp4"
+
+
+def test_codec_bonus_still_applies_to_exact_groups(tmp_path):
+    """Only the re-encode path drops the codec term."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, None, {"codec": "hevc", "bitrate_mbps": 1.0}),
+    ])
+
+    with_bonus = detector._calculate_video_quality_score(videos[0])
+    without = detector._calculate_video_quality_score(videos[0], codec_bonus=False)
+
+    assert with_bonus > without
+
+
+# --- precision ---------------------------------------------------------------
+
+
+def test_same_duration_different_content_is_not_grouped(tmp_path):
+    """Two 22-minute episodes are not duplicates of each other."""
+    detector, videos = make_detector(tmp_path, [
+        (1320.0, SIG_A),
+        (1320.0, SIG_B),
+    ])
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+def test_one_matching_frame_is_not_enough(tmp_path):
+    """A shared intro must not group a whole series together.
+
+    Frame 1 matches exactly; the later positions do not. Requiring *every*
+    sampled position is what separates "same intro" from "same film".
+    """
+    shared_intro = "0000000000000000:aaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbb"
+    detector, videos = make_detector(tmp_path, [
+        (1320.0, SIG_A),
+        (1320.0, shared_intro),
+    ])
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+def test_durations_beyond_tolerance_are_not_compared(tmp_path):
+    """Identical frames but a 30s runtime gap — a trailer, not the film."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (630.0, SIG_A),
+    ])
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+# --- bookkeeping -------------------------------------------------------------
+
+
+def test_files_already_grouped_exactly_are_skipped(tmp_path):
+    """No file may appear in two groups; the exact pass wins."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.0, SIG_A),
+    ])
+
+    groups = detector._find_reencoded_video_duplicates(
+        videos, {videos[0].file_path}
+    )
+
+    assert groups == []
+
+
+def test_videos_without_a_signature_are_ignored(tmp_path):
+    """A video whose frames could not be extracted is dropped, not guessed at."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.0, None),
+    ])
+    # Duration 0 also means "no seek position to sample", so nothing is written.
+    detector._video_hashes.set(videos[1].file_path, "")
+
+    assert detector._find_reencoded_video_duplicates(videos, set()) == []
+
+
+def test_transitive_reencodes_form_one_group(tmp_path):
+    """Three encodes of the same source belong in a single group, not three."""
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.5, SIG_A_NEAR),
+        (601.0, SIG_A),
+    ])
+
+    groups = detector._find_reencoded_video_duplicates(videos, set())
+
+    assert grouped(groups) == {
+        frozenset({"vid_000.mp4", "vid_001.mp4", "vid_002.mp4"})
+    }
+
+
+def test_grouping_is_independent_of_input_order(tmp_path):
+    """Whether A and B land together must not depend on iteration order."""
+    specs = [
+        (600.0, SIG_A),
+        (600.4, SIG_A_NEAR),
+        (600.8, SIG_A),
+        (1320.0, SIG_B),
+    ]
+    detector_a, videos_a = make_detector(tmp_path / "a", specs)
+    detector_b, videos_b = make_detector(tmp_path / "b", list(reversed(specs)))
+
+    groups_a = detector_a._find_reencoded_video_duplicates(videos_a, set())
+    groups_b = detector_b._find_reencoded_video_duplicates(videos_b, set())
+
+    def by_index(groups):
+        return {
+            frozenset(os.path.basename(f.path) for f in g.files) for g in groups
+        }
+
+    # Same three-member cluster either way, just under mirrored filenames.
+    assert len(by_index(groups_a)) == len(by_index(groups_b)) == 1
+    assert {len(g) for g in by_index(groups_a)} == {3}
+    assert {len(g) for g in by_index(groups_b)} == {3}
+
+
+def test_frame_hashing_is_skipped_for_unique_durations(tmp_path, monkeypatch):
+    """Videos with no duration neighbour never reach ffmpeg.
+
+    Each signature costs three ffmpeg seeks, so hashing a file that provably
+    cannot have a twin is pure waste on a large library.
+    """
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.2, SIG_A_NEAR),
+        (9999.0, None),  # unique runtime
+    ])
+
+    hashed = []
+    original = detector._video_frame_signature
+
+    def spy(video):
+        hashed.append(os.path.basename(video.file_path))
+        return original(video)
+
+    monkeypatch.setattr(detector, "_video_frame_signature", spy)
+    detector._find_reencoded_video_duplicates(videos, set())
+
+    assert "vid_002.mp4" not in hashed
+
+
+def test_detect_reencodes_flag_disables_the_pass(tmp_path, monkeypatch):
+    detector, videos = make_detector(tmp_path, [
+        (600.0, SIG_A),
+        (600.2, SIG_A_NEAR),
+    ])
+
+    called = []
+    monkeypatch.setattr(
+        detector,
+        "_find_reencoded_video_duplicates",
+        lambda *a, **kw: called.append(1) or [],
+    )
+
+    detector.find_all_duplicates(videos, detect_reencodes=False)
+    assert called == []
+
+    detector.find_all_duplicates(videos, detect_reencodes=True)
+    assert called == [1]
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def test_signature_length_mismatch_never_matches():
+    two_frames = "0000000000000000:1111111111111111"
+    assert not DuplicateDetector._signatures_match(SIG_A, two_frames, threshold=64)
+
+
+def test_malformed_signature_never_matches():
+    assert not DuplicateDetector._signatures_match(SIG_A, "zz:zz:zz", threshold=64)
+
+
+def test_union_find_clusters_are_sorted_and_complete():
+    uf = _UnionFind(6)
+    uf.union(4, 1)
+    uf.union(1, 0)
+    uf.union(3, 5)
+
+    assert uf.clusters() == [[0, 1, 4], [2], [3, 5]]


### PR DESCRIPTION
> Stacked auf #41 (→ #40 → #39 → #38 → #37). Letzter der Serie.

## Warum das jetzt weg kann

`_verify_by_content_sample` startete für Dateien, die es nicht über Bytes matchen konnte, eine eigene Ein-Frame-Prüfung (`_verify_by_visual_hash`).

Diese Dateien sind genau die, die der Exact-Pass ungruppiert lässt — und alles Ungruppierte übernimmt seit #38 der Re-Encode-Pass:

| | Inline-Fallback | Re-Encode-Pass |
|---|---|---|
| Frames | 1 (bei 2 s bzw. Mitte) | 3 (25/50/75 %) |
| Cache | keiner, jeder Scan neu | stat-validiert, `.vframe_cache.json` |
| Clustering | greedy | Union-Find |
| Sichtbarer Eingaberaum | nur *innerhalb* eines Signatur-Buckets | alles Ungruppierte |

Der letzte Punkt ist der entscheidende: der Fallback sah ausschließlich Dateien mit bereits identischer Größe, Dauer und Auflösung — also den Fall, für den eine visuelle Prüfung am wenigsten beiträgt. Er konnte damit nur schwächer wiederholen, was inzwischen ohnehin passiert.

~50 Zeilen weniger.

## Test

Neuer Test hält die Eigenschaft fest, auf der das Entfernen beruht: zwei Videos mit identischen Metadaten aber unterschiedlichen Bytes werden vom Exact-Pass abgelehnt (Precondition im Test) und landen anschließend im Re-Encode-Pass in einer Gruppe. Dazu ein Test, dass die Inhaltsprüfung Lookalikes weiterhin ablehnt.

`742 passed, 1 xfailed` — volle Suite grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)