### PR TITLE
feat(web): rebuild cinema, duplicate checker and settings per design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ All notable changes to this project will be documented in this file.
   Karten-Hover ist ein ruhiger Border-Lift statt eines mehrfarbigen Glows.
   Die Theme-Auswahl in den Einstellungen und das `theme`-Setting entfallen —
   Light/Dark bleibt über den Header-Toggle erhalten.
+- **Cinema-Player, Duplicate-Checker und Settings nach Design-System-Spec**:
+  Der Player hat jetzt ein Top-Overlay (Dateiname + Mono-Metadaten), eine
+  rechte Action-Rail aus runden 44px-Buttons — neutral bis auf die eine
+  Primäraktion (Optimize) — und eine eigene Transport-Leiste mit
+  3px-Scrubber, Mono-Timestamps und hervorgehobenem Play-Button anstelle der
+  nativen Video-Controls. Der Duplicate-Checker zeigt zwei gleichwertige
+  Spalten mit einer fixen 120px-Entscheidungsspalte (Größendelta, Keep,
+  Discard); die Empfehlung bekommt eine einzelne Accent-Kontur um die
+  Vorschau statt eines flächigen Farbwashs. Das Settings-Panel nutzt die
+  Sidebar-Nav-Optik (Accent-Tint + 3px-Indikator), Mono-Readout-Blöcke für
+  Verzeichnislisten und 38×22-Toggle-Switches.
+
+### Fixed
+- Duplicate-Checker und Settings-Dialog lagen mit `z-index` unter der
+  Sidebar (`z-100`) und wurden von ihr überlappt.
 
 ### Added
 - **Duplikat-Scan findet re-encodete Videos**: Der bisherige Video-Pass gruppiert

--- a/arcade_scanner/server/static/cinema.js
+++ b/arcade_scanner/server/static/cinema.js
@@ -108,6 +108,9 @@ function openCinema(container) {
     modal.classList.add('active');
 
     // Update UI components
+    initCinemaTransport();
+    updateCinemaMeta();
+    updateCinemaTransport();
     updateCinemaButtons();
     updateCinemaInfo();
     updateCinemaTags();
@@ -204,6 +207,153 @@ function navigateCinema(direction) {
     }
 }
 
+// --- TRANSPORT ---
+// Eigener Transport statt der nativen Controls, damit die Bedienleiste dem
+// Design System folgt (3px-Scrubber mit Accent-Fill, Mono-Timestamps,
+// hervorgehobener Play-Button). Die Tastatur-Shortcuts bleiben unveraendert.
+
+let _cinemaTransportReady = false;
+let _cinemaScrubbing = false;
+
+/**
+ * Format seconds as MM:SS (or H:MM:SS past an hour) for the transport readouts
+ * @param {number} sec
+ * @returns {string}
+ */
+function formatCinemaTime(sec) {
+    if (!isFinite(sec) || sec < 0) sec = 0;
+    const h = Math.floor(sec / 3600);
+    const m = Math.floor((sec % 3600) / 60);
+    const s = Math.floor(sec % 60);
+    const mm = String(m).padStart(2, '0');
+    const ss = String(s).padStart(2, '0');
+    return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/**
+ * Bind the transport controls to the video element. Idempotent — the listeners
+ * are attached once and survive src changes when navigating the playlist.
+ */
+function initCinemaTransport() {
+    if (_cinemaTransportReady) return;
+
+    const video = document.getElementById('cinemaVideo');
+    const scrub = document.getElementById('cinemaScrub');
+    if (!video || !scrub) return;
+
+    video.addEventListener('timeupdate', () => {
+        if (!_cinemaScrubbing) updateCinemaTransport();
+    });
+    video.addEventListener('loadedmetadata', updateCinemaTransport);
+    video.addEventListener('play', updateCinemaTransport);
+    video.addEventListener('pause', updateCinemaTransport);
+    video.addEventListener('volumechange', updateCinemaTransport);
+
+    // Waehrend des Ziehens nicht gegen den Nutzer zurueckschreiben
+    scrub.addEventListener('pointerdown', () => { _cinemaScrubbing = true; });
+    scrub.addEventListener('input', () => {
+        if (!isFinite(video.duration) || !video.duration) return;
+        video.currentTime = (scrub.value / 1000) * video.duration;
+        const cur = document.getElementById('cinemaTimeCur');
+        if (cur) cur.textContent = formatCinemaTime(video.currentTime);
+        const pct = (scrub.value / 10).toFixed(2);
+        scrub.style.background =
+            `linear-gradient(90deg, var(--ds-accent-tint) ${pct}%, rgba(255,255,255,0.25) ${pct}%)`;
+    });
+    const endScrub = () => { _cinemaScrubbing = false; };
+    scrub.addEventListener('pointerup', endScrub);
+    scrub.addEventListener('change', endScrub);
+
+    _cinemaTransportReady = true;
+}
+
+/**
+ * Push the current playback state into the transport UI
+ */
+function updateCinemaTransport() {
+    const video = document.getElementById('cinemaVideo');
+    const bar = document.getElementById('cinemaBottomBar');
+    if (!video || !bar) return;
+
+    // Bilder und SOURCE-Dateien haben keine Wiedergabe — Leiste ausblenden
+    const playable = !video.classList.contains('hidden');
+    bar.style.display = playable ? 'flex' : 'none';
+    if (!playable) return;
+
+    const dur = isFinite(video.duration) ? video.duration : 0;
+    const scrub = document.getElementById('cinemaScrub');
+    if (scrub) {
+        if (!_cinemaScrubbing) {
+            scrub.value = dur ? Math.round((video.currentTime / dur) * 1000) : 0;
+        }
+        // Ein natives range-Input faerbt den zurueckgelegten Teil nicht selbst —
+        // der Fill kommt als harter Farbstopp im Track-Hintergrund.
+        const pct = (scrub.value / 10).toFixed(2);
+        scrub.style.background =
+            `linear-gradient(90deg, var(--ds-accent-tint) ${pct}%, rgba(255,255,255,0.25) ${pct}%)`;
+    }
+
+    const cur = document.getElementById('cinemaTimeCur');
+    if (cur) cur.textContent = formatCinemaTime(video.currentTime);
+    const total = document.getElementById('cinemaTimeDur');
+    if (total) total.textContent = formatCinemaTime(dur);
+
+    const playIcon = document.querySelector('#cinemaPlayBtn .material-icons');
+    if (playIcon) playIcon.textContent = video.paused ? 'play_arrow' : 'pause';
+
+    const muteIcon = document.querySelector('#cinemaMuteBtn .material-icons');
+    if (muteIcon) muteIcon.textContent = (video.muted || video.volume === 0) ? 'volume_off' : 'volume_up';
+}
+
+/**
+ * Fill the mono metadata line under the filename (resolution, codec, bitrate)
+ */
+function updateCinemaMeta() {
+    const meta = document.getElementById('cinemaMeta');
+    if (!meta) return;
+
+    const v = currentCinemaVideo;
+    if (!v) { meta.textContent = ''; return; }
+
+    const parts = [];
+    if (v.Width && v.Height) parts.push(`${v.Width}x${v.Height}`);
+    if (v.codec) parts.push(String(v.codec).toUpperCase());
+    if (v.media_type === 'video' && v.Bitrate_Mbps) parts.push(`${v.Bitrate_Mbps.toFixed(1)} Mbps`);
+    else if (v.Size_MB) parts.push(`${v.Size_MB.toFixed(0)} MB`);
+    meta.textContent = parts.join('  ·  ');
+}
+
+/**
+ * Toggle playback of the current video
+ */
+function cinemaTogglePlay() {
+    const video = document.getElementById('cinemaVideo');
+    if (!video || video.classList.contains('hidden')) return;
+    if (video.paused) video.play(); else video.pause();
+}
+
+/**
+ * Toggle mute on the current video
+ */
+function cinemaToggleMute() {
+    const video = document.getElementById('cinemaVideo');
+    if (!video) return;
+    video.muted = !video.muted;
+}
+
+/**
+ * Toggle fullscreen for the cinema modal
+ */
+function cinemaToggleFullscreen() {
+    const modal = document.getElementById('cinemaModal');
+    if (!modal) return;
+    if (document.fullscreenElement) {
+        document.exitFullscreen();
+    } else if (modal.requestFullscreen) {
+        modal.requestFullscreen();
+    }
+}
+
 // --- KEYBOARD HANDLER ---
 
 /**
@@ -246,13 +396,9 @@ function cinemaKeyHandler(e) {
         e.preventDefault();
         const video = document.getElementById('cinemaVideo');
         if (video && !video.classList.contains('hidden')) {
-            if (video.paused) {
-                video.play();
-                showCinemaToast('▶ Play');
-            } else {
-                video.pause();
-                showCinemaToast('⏸ Pause');
-            }
+            const wasPaused = video.paused;
+            cinemaTogglePlay();
+            showCinemaToast(wasPaused ? '▶ Play' : '⏸ Pause');
         }
 
     } else if (key === 'f') {
@@ -364,13 +510,15 @@ function updateCinemaButtons() {
 
     const favBtn = document.querySelector('.cinema-action-btn[onclick="cinemaFavorite()"]');
     if (favBtn) {
-        favBtn.style.opacity = currentCinemaVideo.favorite ? '0.6' : '1';
+        favBtn.classList.toggle('is-active', !!currentCinemaVideo.favorite);
         favBtn.title = currentCinemaVideo.favorite ? 'Already a Favorite' : 'Add to Favorites';
+        const icon = document.getElementById('cinemaFavIcon');
+        if (icon) icon.textContent = currentCinemaVideo.favorite ? 'star' : 'star_border';
     }
 
     const vaultBtn = document.querySelector('.cinema-action-btn[onclick="cinemaVault()"]');
     if (vaultBtn) {
-        vaultBtn.style.opacity = currentCinemaVideo.hidden ? '0.6' : '1';
+        vaultBtn.classList.toggle('is-active', !!currentCinemaVideo.hidden);
         vaultBtn.title = currentCinemaVideo.hidden ? 'Already in Vault' : 'Move to Vault';
     }
 }

--- a/arcade_scanner/server/static/duplicates.js
+++ b/arcade_scanner/server/static/duplicates.js
@@ -741,6 +741,58 @@ function renderDuplicateCheckerGroup(groupIndex) {
 
     // Render File B
     renderDuplicateFile('B', fileB, fileB.path === recommendedPath);
+
+    // Die Entscheidungsspalte handelt immer auf der Empfehlung
+    window.duplicateCheckerState.recommendedSide =
+        (fileB.path === recommendedPath && fileA.path !== recommendedPath) ? 'B' : 'A';
+    renderDuplicateDelta(fileA, fileB, window.duplicateCheckerState.recommendedSide);
+}
+
+/**
+ * Show how much space keeping the recommended file saves.
+ * Negative percentage = the discarded copy is larger.
+ *
+ * @param {Object} fileA
+ * @param {Object} fileB
+ * @param {string} recommendedSide - 'A' or 'B'
+ */
+function renderDuplicateDelta(fileA, fileB, recommendedSide) {
+    const el = document.getElementById('dupSizeDelta');
+    if (!el) return;
+
+    const keep = recommendedSide === 'B' ? fileB : fileA;
+    const drop = recommendedSide === 'B' ? fileA : fileB;
+    const keepSize = keep.size_mb || 0;
+    const dropSize = drop.size_mb || 0;
+
+    if (!dropSize || keep === drop) {
+        el.textContent = '--';
+        el.classList.remove('text-optimized', 'text-bitrate');
+        el.classList.add('text-text-muted');
+        return;
+    }
+
+    // Positiv = die behaltene Datei ist kleiner (Ersparnis)
+    const pct = Math.round(((dropSize - keepSize) / dropSize) * 100);
+    el.textContent = `${pct >= 0 ? '−' : '+'}${Math.abs(pct)}%`;
+    el.classList.remove('text-text-muted');
+    el.classList.toggle('text-optimized', pct >= 0);
+    el.classList.toggle('text-bitrate', pct < 0);
+}
+
+/**
+ * Keep the recommended file (discards the other copy)
+ */
+function keepRecommendedDuplicate() {
+    keepDuplicateFile(window.duplicateCheckerState?.recommendedSide || 'A');
+}
+
+/**
+ * Discard the recommended file — i.e. keep the other copy instead
+ */
+function discardRecommendedDuplicate() {
+    const rec = window.duplicateCheckerState?.recommendedSide || 'A';
+    keepDuplicateFile(rec === 'A' ? 'B' : 'A');
 }
 
 /**
@@ -775,6 +827,10 @@ function renderDuplicateFile(side, file, isRecommended) {
     const bitrate = file.bitrate_mbps ? file.bitrate_mbps.toFixed(1) + ' Mbps' : '--';
     document.getElementById(`dupFile${side}Bitrate`).textContent = bitrate;
 
+    // Codec-Label in der Kopfzeile der Spalte
+    const codecEl = document.getElementById(`dupFile${side}Codec`);
+    if (codecEl) codecEl.textContent = (file.codec || '').toUpperCase();
+
     // Show/hide recommended badge
     const badge = document.getElementById(`dupFile${side}Badge`);
     if (isRecommended) {
@@ -783,14 +839,12 @@ function renderDuplicateFile(side, file, isRecommended) {
         badge.classList.add('hidden');
     }
 
-    // Highlight recommended panel
-    const panel = document.getElementById(`dupFile${side}`);
-    if (isRecommended) {
-        panel.classList.add('border-green-500/50', 'bg-green-500/5');
-        panel.classList.remove('border-white/10', 'bg-white/[0.02]');
-    } else {
-        panel.classList.remove('border-green-500/50', 'bg-green-500/5');
-        panel.classList.add('border-white/10', 'bg-white/[0.02]');
+    // Empfehlung bekommt eine einzelne Accent-Kontur um die Vorschau —
+    // kein flaechiger Farbwash ueber die ganze Spalte.
+    const preview = document.getElementById(`dupFile${side}Preview`);
+    if (preview) {
+        preview.classList.toggle('border-accent', isRecommended);
+        preview.classList.toggle('border-transparent', !isRecommended);
     }
 }
 

--- a/arcade_scanner/server/static/settings.js
+++ b/arcade_scanner/server/static/settings.js
@@ -314,17 +314,10 @@ function initSettingsNavigation() {
             const sectionId = item.dataset.section;
             if (!sectionId) return;
 
-            // Update active nav item and indicator
-            navItems.forEach(nav => {
-                nav.classList.remove('active', 'text-white', 'bg-white/5');
-                nav.classList.add('text-gray-400');
-                const indicator = nav.querySelector('.active-indicator');
-                if (indicator) indicator.classList.add('opacity-0');
-            });
-            item.classList.add('active', 'text-white', 'bg-white/5');
-            item.classList.remove('text-gray-400');
-            const activeIndicator = item.querySelector('.active-indicator');
-            if (activeIndicator) activeIndicator.classList.remove('opacity-0');
+            // Aktiver Zustand haengt allein an .active — Tint und
+            // Accent-Indikator kommen aus der CSS-Regel (styles.css).
+            navItems.forEach(nav => nav.classList.remove('active'));
+            item.classList.add('active');
 
             // Show corresponding content - toggle hidden class
             contentSections.forEach(section => {
@@ -347,14 +340,7 @@ function initSettingsNavigation() {
         });
     });
 
-    // Set initial active state
-    const initialActive = settingsModal.querySelector('.settings-nav-item.active');
-    if (initialActive) {
-        const indicator = initialActive.querySelector('.active-indicator');
-        if (indicator) indicator.classList.remove('opacity-0');
-        initialActive.classList.add('text-white', 'bg-white/5');
-        initialActive.classList.remove('text-gray-400');
-    }
+    // Der initiale Zustand steht bereits im Markup (.settings-nav-item.active).
 }
 
 /**

--- a/arcade_scanner/server/static/styles.css
+++ b/arcade_scanner/server/static/styles.css
@@ -660,49 +660,9 @@ html {
     letter-spacing: 2px;
 }
 
-.cinema-actions {
-    position: absolute;
-    right: 3%;
-    top: 50%;
-    transform: translateY(-50%);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    z-index: calc(var(--z-modal) + 1);
-}
-
-.cinema-action-btn {
-    background: rgba(20, 1, 35, 0.95);
-    border: 2px solid var(--glass-border);
-    border-radius: 12px;
-    width: 48px;
-    height: 48px;
-    padding: 0;
-    color: white;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: inherit;
-    transition: all 0.3s;
-    backdrop-filter: blur(10px);
-}
-
-.cinema-action-btn:hover {
-    background: var(--pink);
-    border-color: var(--pink);
-    transform: scale(1.1);
-    box-shadow: 0 5px 20px rgb(var(--ds-accent-rgb) / 0.4);
-}
-
-.cinema-action-btn .material-icons {
-    font-size: 24px;
-}
-
-/* Hide button labels, show only icons */
-.cinema-action-btn span:not(.material-icons) {
-    display: none;
-}
+/* .cinema-actions / .cinema-action-btn: Layout und Optik kommen jetzt aus
+   dem Design-System-Block am Dateiende (.cinema-rail-*). Die Klasse
+   .cinema-action-btn bleibt nur noch JS-Hook fuer Favorit/Vault-Zustand. */
 
 .cinema-info-btn {
     position: absolute;
@@ -804,17 +764,19 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-    background: var(--bg);
+    background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-    background: var(--magenta);
+    background: var(--ds-hairline-strong);
     border-radius: 5px;
-    border: 2px solid var(--bg);
+    border: 3px solid transparent;
+    background-clip: padding-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: var(--pink);
+    background: var(--ds-text-muted);
+    background-clip: padding-box;
 }
 
 /* --- LAYOUTS --- */
@@ -2065,16 +2027,14 @@ html {
         z-index: var(--z-toast);
     }
 
-    /* Ensure buttons are reachable on mobile */
+    /* Rail auf Mobile enger stellen; die Labels entfallen dort */
     .cinema-actions {
-        right: 2%;
+        right: 8px;
         gap: 10px;
     }
 
-    .cinema-action-btn {
-        width: 44px;
-        height: 44px;
-        background: rgba(0, 0, 0, 0.9);
+    .cinema-rail-label {
+        display: none;
     }
 
     /* Ensure close button is easy to hit */
@@ -2890,4 +2850,201 @@ html {
 /* outer container slight warmth */
 :root:not(.dark) #settingsModal .settings-container {
     background-color: #ffffff !important;
+}
+
+/* === CINEMA PLAYER (Design System) ===
+   Liegt hier statt im Template, weil CINEMA_MODAL_COMPONENT durch
+   str.format() laeuft und CSS-Klammern dort kollidieren. */
+.cinema-overlay-top {
+    background: linear-gradient(180deg, rgba(0,0,0,0.6), transparent);
+}
+.cinema-overlay-bottom {
+    background: linear-gradient(0deg, rgba(0,0,0,0.75), transparent);
+}
+
+/* Action-Rail */
+.cinema-rail-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+.cinema-rail-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.15);
+    color: #fff;
+    transition: background-color .15s ease, border-color .15s ease;
+}
+.cinema-rail-icon .material-icons { font-size: 20px; }
+.cinema-rail-btn:hover .cinema-rail-icon { background: rgba(255,255,255,0.16); }
+.cinema-rail-label {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.55);
+}
+.cinema-rail-btn:hover .cinema-rail-label { color: #fff; }
+
+/* Genau EINE Primaeraktion traegt den Accent */
+.cinema-rail-btn.is-primary .cinema-rail-icon {
+    background: rgb(var(--ds-accent-rgb) / 0.18);
+    border-color: rgb(var(--ds-accent-rgb) / 0.45);
+    color: var(--ds-accent-tint);
+}
+.cinema-rail-btn.is-primary:hover .cinema-rail-icon {
+    background: rgb(var(--ds-accent-rgb) / 0.3);
+}
+.cinema-rail-btn.is-primary .cinema-rail-label { color: var(--ds-accent-tint); }
+
+/* Aktiver Zustand (Favorit gesetzt / im Vault) */
+.cinema-rail-btn.is-active .cinema-rail-icon { color: var(--ds-bitrate); }
+
+/* Transport */
+.cinema-transport-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    opacity: .9;
+    transition: opacity .15s ease;
+}
+.cinema-transport-btn:hover { opacity: 1; }
+
+/* Scrubber: 3px Track, Accent-Fill */
+.cinema-scrub {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(255,255,255,0.25);
+    cursor: pointer;
+    outline: none;
+}
+.cinema-scrub::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: var(--ds-accent-tint);
+    border: none;
+}
+.cinema-scrub::-moz-range-thumb {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: var(--ds-accent-tint);
+    border: none;
+}
+
+/* === SETTINGS PANEL (Design System) === */
+
+/* Nav-Row spiegelt das Sidebar-Pattern: Accent-Tint + 3px-Indikator */
+#settingsModal .settings-nav-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 10px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--ds-text-label);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color .15s ease, color .15s ease;
+}
+#settingsModal .settings-nav-item:hover {
+    background: var(--ds-fill-soft);
+    color: var(--ds-text);
+}
+#settingsModal .settings-nav-item.active {
+    background: rgb(var(--ds-accent-rgb) / 0.12);
+    color: var(--ds-text);
+    font-weight: 600;
+}
+#settingsModal .settings-nav-indicator {
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3px;
+    height: 15px;
+    border-radius: 0 2px 2px 0;
+    background: var(--ds-accent);
+    opacity: 0;
+    transition: opacity .15s ease;
+}
+#settingsModal .settings-nav-item.active .settings-nav-indicator { opacity: 1; }
+#settingsModal .settings-nav-item.active .material-icons { color: var(--ds-accent-tint); }
+
+/* Gruppierte Einstellungen liegen auf einer Karte */
+.ds-settings-card {
+    background: var(--ds-surface);
+    border: 1px solid var(--ds-hairline-strong);
+    border-radius: 8px;
+    padding: 12px 14px;
+}
+
+/* Mono-Readout-Bloecke (Verzeichnislisten, Exclusions) */
+.ds-textarea {
+    background: var(--ds-surface);
+    border: 1px solid var(--ds-hairline-strong);
+    border-radius: 8px;
+    padding: 12px 14px;
+    font-family: var(--ds-font-mono);
+    font-size: 12.5px;
+    color: var(--ds-text-body);
+    resize: none;
+    transition: border-color .15s ease;
+}
+.ds-textarea:focus {
+    outline: none;
+    border-color: var(--ds-accent);
+}
+.ds-textarea::placeholder { color: var(--ds-text-muted); }
+
+/* Toggle-Switch 38x22 — an den sr-only Peer-Input gekoppelt */
+.ds-peer-switch {
+    position: relative;
+    width: 38px;
+    height: 22px;
+    border-radius: 11px;
+    background: var(--ds-hairline-strong);
+    flex-shrink: 0;
+    transition: background-color .18s ease;
+}
+.ds-peer-switch::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #8a8a94;
+    transition: transform .18s ease, background-color .18s ease;
+}
+.peer:checked ~ .ds-peer-switch,
+.peer:checked + .ds-peer-switch {
+    background: var(--ds-accent);
+}
+.peer:checked ~ .ds-peer-switch::after,
+.peer:checked + .ds-peer-switch::after {
+    transform: translateX(16px);
+    background: #fff;
 }

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -258,318 +258,213 @@ GIF_EXPORT_PANEL_COMPONENT = """
 """
 
 CINEMA_MODAL_COMPONENT = """
-<!-- Cinema Modal (Tailwind) -->
-<div id="cinemaModal" class="fixed inset-0 z-50 bg-black opacity-0 pointer-events-none transition-opacity duration-500 flex flex-col justify-center items-center">
+<!-- Cinema Player -->
+<div id="cinemaModal" class="fixed inset-0 z-50 bg-black opacity-0 pointer-events-none transition-opacity duration-300 flex flex-col justify-center items-center">
     <!-- Active class 'opacity-100 pointer-events-auto' toggled by JS -->
 
-    <button class="absolute top-4 right-4 text-white/50 hover:text-white z-50 p-2" onclick="closeCinema()">
-        <span class="material-icons text-4xl">close</span>
-    </button>
+    <video id="cinemaVideo" preload="metadata" class="max-w-full max-h-full w-auto h-auto outline-none"></video>
 
-    <h2 id="cinemaTitle" class="absolute top-6 left-0 right-0 text-center text-white/80 font-light tracking-[4px] text-lg uppercase pointer-events-none z-40 drop-shadow-lg transition-transform duration-500">Movie Player</h2>
+    <img id="cinemaImage" class="hidden max-w-full max-h-full w-auto h-auto object-contain" src="">
 
-    <video id="cinemaVideo" controls preload="metadata" class="max-w-full max-h-[80vh] w-auto h-auto shadow-[0_0_50px_rgba(0,0,0,0.8)] rounded-lg outline-none transition-all duration-500 origin-bottom"></video>
-
-    <img id="cinemaImage" class="hidden max-w-full max-h-[80vh] w-auto h-auto shadow-[0_0_50px_rgba(0,0,0,0.8)] rounded-lg object-contain transition-all duration-500 origin-bottom" src="">
-
-    <div id="cinemaSourceMessage" class="hidden flex-col items-center justify-center bg-black/60 backdrop-blur-md rounded-2xl p-8 border border-purple-500/30 shadow-[0_0_50px_rgba(168,85,247,0.15)] text-center animate-glow-pulse glow-purple max-w-md w-full mx-4 z-40">
-        <span class="material-icons text-purple-400 text-6xl mb-4">movie_filter</span>
-        <h3 class="text-white text-xl font-bold tracking-widest mb-2">SOURCE MEDIA</h3>
-        <p class="text-gray-400 text-sm mb-6 leading-relaxed">This high-bitrate file exceeds streaming limits and is preserved in raw quality.</p>
-        <div class="flex gap-4 w-full">
-            <button onclick="cinemaLocate()" class="flex-1 py-3 px-4 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-white font-bold text-sm tracking-wide transition-all flex items-center justify-center gap-2">
-                <span class="material-icons text-[18px]">folder_open</span> LOCATE
+    <div id="cinemaSourceMessage" class="hidden flex-col items-center justify-center bg-surface rounded-ds-md p-8 border border-[var(--ds-hairline-strong)] text-center max-w-md w-full mx-4 z-40">
+        <span class="material-icons text-accent-tint text-5xl mb-4">movie_filter</span>
+        <h3 class="text-white text-lg font-semibold mb-2">Source media</h3>
+        <p class="text-body-text text-[13px] mb-6 leading-relaxed">This high-bitrate file exceeds streaming limits and is preserved in raw quality.</p>
+        <div class="flex gap-3 w-full">
+            <button onclick="cinemaLocate()" class="ds-btn ds-btn-secondary flex-1">
+                <span class="material-icons text-[18px]">folder_open</span> Locate
             </button>
-            <a id="cinemaDownloadBtn" href="" download class="flex-1 py-3 px-4 bg-purple-500/20 hover:bg-purple-500 text-purple-300 hover:text-white border border-purple-500/50 hover:shadow-[0_0_20px_rgba(168,85,247,0.4)] rounded-xl font-bold text-sm tracking-wide transition-all flex items-center justify-center gap-2">
-                <span class="material-icons text-[18px]">download</span> DOWNLOAD
+            <a id="cinemaDownloadBtn" href="" download class="ds-btn ds-btn-primary flex-1">
+                <span class="material-icons text-[18px]">download</span> Download
             </a>
         </div>
     </div>
 
-    <div id="cinemaInfoPanel" class="absolute top-20 right-4 w-80 bg-black/80 backdrop-blur-md border border-white/10 rounded-lg p-4 transform translate-x-[120%] transition-transform duration-300 z-40 text-sm text-gray-300 animate-glow-pulse glow-cyan">
-        <div class="flex items-center gap-2 mb-3 text-white font-bold border-b border-white/10 pb-2">
-            <span class="material-icons text-sm">info</span>
+    <!-- Top overlay: Dateiname + Mono-Metadaten links, Close rechts -->
+    <div class="cinema-overlay-top absolute top-0 left-0 right-0 px-5 pt-4 pb-10 z-40 flex items-start justify-between gap-4 pointer-events-none">
+        <div class="min-w-0 pointer-events-auto">
+            <h2 id="cinemaTitle" class="text-[13px] font-semibold text-white truncate">Movie Player</h2>
+            <div id="cinemaMeta" class="text-[11px] font-mono text-white/55 truncate mt-0.5"></div>
+        </div>
+        <button class="pointer-events-auto text-white/80 hover:text-white transition-colors flex-shrink-0" onclick="closeCinema()" title="Close [Esc]">
+            <span class="material-icons text-[22px]">close</span>
+        </button>
+    </div>
+
+    <div id="cinemaInfoPanel" class="absolute top-20 right-[92px] w-80 bg-surface border border-[var(--ds-hairline-strong)] rounded-ds-md p-4 transform translate-x-[140%] transition-transform duration-300 z-40 text-sm text-body-text">
+        <div class="flex items-center gap-2 mb-3 text-white font-semibold border-b border-[var(--ds-hairline-strong)] pb-2">
+            <span class="material-icons text-[16px]">info</span>
             <span>Technical Details</span>
         </div>
         <div id="cinemaInfoContent" class="space-y-2 text-xs font-mono"></div>
     </div>
 
     <!-- Assigned Tags Display (Visible List with Remove X) -->
-    <div id="cinemaAssignedTags" class="absolute top-20 left-4 max-w-sm flex flex-wrap gap-2 z-40 pointer-events-auto">
+    <div id="cinemaAssignedTags" class="absolute top-16 left-5 max-w-sm flex flex-wrap gap-2 z-40 pointer-events-auto">
         <!-- Populated by JS -->
     </div>
 
-    <!-- Tag Picker Dropdown (appears above the Tags button) -->
-    <div id="cinemaTagPanel" class="hidden absolute bottom-24 left-1/2 -translate-x-1/2 bg-black/90 backdrop-blur-md border border-white/10 rounded-xl p-3 z-50 min-w-[200px] max-w-[320px] animate-glow-pulse glow-cyan">
-        <div class="flex items-center gap-2 mb-2 text-white/80 text-xs border-b border-white/10 pb-2">
-            <span class="material-icons text-sm text-arcade-cyan">label</span>
-            <span class="font-semibold uppercase tracking-wide">Assign Tags</span>
+    <!-- Tag Picker Dropdown -->
+    <div id="cinemaTagPanel" class="hidden absolute top-1/2 right-[92px] -translate-y-1/2 bg-surface border border-[var(--ds-hairline-strong)] rounded-ds-md p-3 z-50 min-w-[200px] max-w-[320px]">
+        <div class="flex items-center gap-2 mb-2 pb-2 border-b border-[var(--ds-hairline-strong)]">
+            <span class="material-icons text-[16px] text-accent-tint">label</span>
+            <span class="ds-eyebrow">Assign Tags</span>
         </div>
         <div id="cinemaTagPicker" class="flex flex-wrap gap-1.5">
             <!-- Populated by JS -->
         </div>
     </div>
 
-    <div id="cinemaActions" class="cinema-actions absolute bottom-8 flex gap-3 z-40">
+    <!-- Rechte Action-Rail: neutrale Buttons, Accent nur fuer die Primaeraktion -->
+    <div id="cinemaActions" class="cinema-actions absolute right-5 top-1/2 -translate-y-1/2 flex flex-col gap-3.5 z-40">
 
-        <!-- Info Button -->
-        <button class="flex flex-col items-center gap-1.5 transition-all group" onclick="toggleCinemaInfo()" title="Technical Details [I]">
-            <div class="w-12 h-12 rounded-xl bg-white/8 backdrop-blur-sm flex items-center justify-center border border-white/15 group-hover:bg-white/18 group-hover:border-white/35 group-hover:scale-110 transition-all shadow-lg">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-gray-300 group-hover:text-white transition-colors">
-                    <circle cx="12" cy="12" r="10"/>
-                    <line x1="12" y1="16" x2="12" y2="12"/>
-                    <line x1="12" y1="8" x2="12.01" y2="8"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-gray-500 group-hover:text-white transition-colors">Info</span>
+        <button class="cinema-rail-btn" onclick="toggleCinemaInfo()" title="Technical Details [I]">
+            <span class="cinema-rail-icon"><span class="material-icons">info_outline</span></span>
+            <span class="cinema-rail-label">Info</span>
         </button>
 
-        <!-- Locate Button -->
-        <button id="cinemaLocateBtn" class="flex flex-col items-center gap-1.5 transition-all group" onclick="cinemaLocate()" title="Show in Finder">
-            <div class="w-12 h-12 rounded-xl bg-white/8 backdrop-blur-sm flex items-center justify-center border border-white/15 group-hover:bg-white/18 group-hover:border-white/35 group-hover:scale-110 transition-all shadow-lg">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-gray-300 group-hover:text-white transition-colors">
-                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-                    <polyline points="12 12 17 12 17 17"/>
-                    <line x1="14" y1="10" x2="17" y2="7"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-gray-500 group-hover:text-white transition-colors">Locate</span>
+        <button id="cinemaLocateBtn" class="cinema-rail-btn" onclick="cinemaLocate()" title="Show in Finder">
+            <span class="cinema-rail-icon"><span class="material-icons">folder_open</span></span>
+            <span class="cinema-rail-label">Locate</span>
         </button>
 
-        <!-- Visual Separator -->
-        <div class="w-px h-12 bg-white/8 self-start mt-0.5"></div>
-
-        <!-- Favorite Button -->
-        <button class="flex flex-col items-center gap-1.5 transition-all group" onclick="cinemaFavorite()" title="Toggle Favorite [F]">
-            <div class="w-12 h-12 rounded-xl bg-arcade-gold/12 backdrop-blur-sm flex items-center justify-center border border-arcade-gold/35 group-hover:bg-arcade-gold/25 group-hover:border-arcade-gold/65 group-hover:scale-110 transition-all shadow-lg shadow-arcade-gold/10">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-arcade-gold group-hover:text-yellow-300 transition-colors" id="cinemaFavIcon">
-                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-arcade-gold/75 group-hover:text-arcade-gold transition-colors">Favorite</span>
+        <button class="cinema-rail-btn cinema-action-btn" onclick="cinemaFavorite()" title="Toggle Favorite [F]">
+            <span class="cinema-rail-icon"><span class="material-icons" id="cinemaFavIcon">star_border</span></span>
+            <span class="cinema-rail-label">Favorite</span>
         </button>
 
-        <!-- Tags Button -->
-        <button class="flex flex-col items-center gap-1.5 transition-all group" onclick="toggleCinemaTagPanel()" title="Manage Tags">
-            <div class="w-12 h-12 rounded-xl bg-arcade-cyan/12 backdrop-blur-sm flex items-center justify-center border border-arcade-cyan/35 group-hover:bg-arcade-cyan/25 group-hover:border-arcade-cyan/65 group-hover:scale-110 transition-all shadow-lg shadow-arcade-cyan/10">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-arcade-cyan group-hover:text-cyan-300 transition-colors">
-                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
-                    <line x1="7" y1="7" x2="7.01" y2="7"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-arcade-cyan/75 group-hover:text-arcade-cyan transition-colors">Tags</span>
+        <button class="cinema-rail-btn" onclick="toggleCinemaTagPanel()" title="Manage Tags">
+            <span class="cinema-rail-icon"><span class="material-icons">label</span></span>
+            <span class="cinema-rail-label">Tags</span>
         </button>
 
-        <!-- Vault Button -->
-        <button class="flex flex-col items-center gap-1.5 transition-all group" onclick="cinemaVault()" title="Move to Vault [V]">
-            <div class="w-12 h-12 rounded-xl bg-arcade-magenta/12 backdrop-blur-sm flex items-center justify-center border border-arcade-magenta/35 group-hover:bg-arcade-magenta/25 group-hover:border-arcade-magenta/65 group-hover:scale-110 transition-all shadow-lg shadow-arcade-magenta/10">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-arcade-magenta group-hover:text-pink-400 transition-colors">
-                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-                    <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-                    <circle cx="12" cy="16" r="1" fill="currentColor"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-arcade-magenta/75 group-hover:text-arcade-magenta transition-colors">Vault</span>
+        <button class="cinema-rail-btn cinema-action-btn" onclick="cinemaVault()" title="Move to Vault [V]">
+            <span class="cinema-rail-icon"><span class="material-icons">archive</span></span>
+            <span class="cinema-rail-label">Vault</span>
         </button>
 
-        <!-- Visual Separator -->
-        <div class="w-px h-12 bg-white/8 self-start mt-0.5"></div>
-
-        <!-- GIF Export Button -->
-        <button class="flex flex-col items-center gap-1.5 transition-all group cinema-action-btn" onclick="cinemaExportGif()" title="Export as GIF [G]">
-            <div class="w-12 h-12 rounded-xl bg-purple-500/12 backdrop-blur-sm flex items-center justify-center border border-purple-500/35 group-hover:bg-purple-500/25 group-hover:border-purple-500/65 group-hover:scale-110 transition-all shadow-lg shadow-purple-500/10">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-purple-400 group-hover:text-purple-300 transition-colors">
-                    <rect x="2" y="2" width="20" height="20" rx="3"/>
-                    <path d="M9 12h3v2.5a2.5 2.5 0 0 1-5 0v-5a2.5 2.5 0 0 1 5 0"/>
-                    <line x1="14" y1="8" x2="14" y2="16"/>
-                    <line x1="17" y1="8" x2="19" y2="8"/>
-                    <line x1="17" y1="12" x2="19" y2="12"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-purple-400/75 group-hover:text-purple-400 transition-colors">GIF</span>
+        <button class="cinema-rail-btn" onclick="cinemaExportGif()" title="Export as GIF [G]">
+            <span class="cinema-rail-icon"><span class="material-icons">gif_box</span></span>
+            <span class="cinema-rail-label">GIF</span>
         </button>
 
         {opt_btn}
+    </div>
+
+    <!-- Bottom overlay: Scrubber + Transport -->
+    <div id="cinemaBottomBar" class="cinema-overlay-bottom absolute bottom-0 left-0 right-0 px-5 pb-4 pt-12 z-40 flex flex-col gap-2">
+        <div class="flex items-center gap-3">
+            <span id="cinemaTimeCur" class="text-[11px] font-mono text-white/70 w-[42px] text-right">00:00</span>
+            <input type="range" id="cinemaScrub" class="cinema-scrub flex-1" min="0" max="1000" value="0" step="1" aria-label="Seek">
+            <span id="cinemaTimeDur" class="text-[11px] font-mono text-white/70 w-[42px]">00:00</span>
+        </div>
+        <div class="flex items-center gap-5">
+            <button id="cinemaPrevBtn" class="cinema-transport-btn" onclick="navigateCinema(-1)" title="Previous [left arrow]">
+                <span class="material-icons text-[20px]">skip_previous</span>
+            </button>
+            <button id="cinemaPlayBtn" class="cinema-transport-btn" onclick="cinemaTogglePlay()" title="Play / Pause [Space]">
+                <span class="material-icons text-[34px]">play_arrow</span>
+            </button>
+            <button id="cinemaNextBtn" class="cinema-transport-btn" onclick="navigateCinema(1)" title="Next [right arrow]">
+                <span class="material-icons text-[20px]">skip_next</span>
+            </button>
+            <button id="cinemaMuteBtn" class="cinema-transport-btn" onclick="cinemaToggleMute()" title="Mute">
+                <span class="material-icons text-[22px]">volume_up</span>
+            </button>
+            <button id="cinemaFsBtn" class="cinema-transport-btn ml-auto" onclick="cinemaToggleFullscreen()" title="Fullscreen">
+                <span class="material-icons text-[22px]">fullscreen</span>
+            </button>
+        </div>
     </div>
 </div>
 """
 
 
 DUPLICATE_CHECKER_MODAL_COMPONENT = """
-<!-- Duplicate Checker Fullscreen Modal -->
-<div id="duplicateCheckerModal" class="fixed inset-0 z-50 bg-black opacity-0 pointer-events-none transition-opacity duration-300 flex flex-col">
+<!-- Duplicate Checker: zwei gleichwertige Spalten + fixe Entscheidungsspalte -->
+<div id="duplicateCheckerModal" class="fixed inset-0 z-[120] bg-bg opacity-0 pointer-events-none transition-opacity duration-300 flex flex-col">
     <!-- Active class 'opacity-100 pointer-events-auto' toggled by JS -->
 
-    <!-- Close Button -->
-    <button class="absolute top-6 right-6 text-white/50 hover:text-white z-50 p-2 transition-colors" onclick="closeDuplicateChecker()">
-        <span class="material-icons text-4xl">close</span>
-    </button>
-
-    <!-- Header: Group Counter -->
-    <div class="absolute top-6 left-0 right-0 text-center z-40">
-        <div class="text-white/60 text-sm font-mono mb-1">DUPLICATE GROUP</div>
-        <div class="text-white text-2xl font-bold tracking-wider">
-            <span id="dupCheckerCurrentGroup">1</span> / <span id="dupCheckerTotalGroups">0</span>
+    <!-- Kopfzeile -->
+    <div class="flex items-center justify-between px-6 py-4 border-b border-line/60">
+        <div class="flex items-baseline gap-3">
+            <span class="ds-eyebrow">Duplicate group</span>
+            <span class="font-mono text-[13px] text-text-main">
+                <span id="dupCheckerCurrentGroup">1</span> / <span id="dupCheckerTotalGroups">0</span>
+            </span>
+            <span class="text-[12px] text-text-muted" id="dupCheckerGroupInfo">
+                2 duplicate candidates
+            </span>
         </div>
-        <div class="text-purple-400 text-xs mt-1" id="dupCheckerGroupInfo">
-            2 duplicate candidates • Qualify diff: 0.0 pts
-        </div>
-    </div>
-
-    <!-- Main Comparison Area -->
-    <div class="flex-1 flex items-center justify-center px-8 py-24">
-        <div class="grid grid-cols-2 gap-8 w-full max-w-7xl">
-
-            <!-- File A (Left) -->
-            <div id="dupFileA" class="duplicate-file-panel flex flex-col gap-4 p-6 rounded-2xl border-2 border-white/10 bg-white/[0.02] transition-all hover:border-purple-400/50 hover:scale-[1.02]">
-                <!-- Label -->
-                <div class="flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <div class="w-10 h-10 rounded-full bg-purple-500/20 border-2 border-purple-500/50 flex items-center justify-center">
-                            <span class="text-purple-400 font-bold text-lg">A</span>
-                        </div>
-                        <span class="text-white/60 text-sm font-semibold uppercase tracking-wide">Candidate A</span>
-                    </div>
-                    <div id="dupFileABadge" class="hidden px-3 py-1 rounded-full bg-green-500/20 border border-green-500/50 text-green-400 text-xs font-bold uppercase">
-                        ✓ Higher Quality
-                    </div>
-                </div>
-
-                <!-- Thumbnail -->
-                <div class="relative aspect-video bg-black rounded-lg overflow-hidden cursor-pointer group" onclick="previewDuplicateFile('A')">
-                    <img id="dupFileAThumb" src="" class="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity">
-                    <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                        <span class="material-icons text-white text-4xl drop-shadow-lg">play_circle</span>
-                    </div>
-                </div>
-
-                <!-- Filename -->
-                <div class="text-white font-medium text-sm truncate" id="dupFileAName" title="">filename_a.mp4</div>
-
-                <!-- Metadata Grid -->
-                <div class="grid grid-cols-2 gap-2 text-xs">
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">Quality Score</div>
-                        <div id="dupFileAQuality" class="text-purple-400 font-bold text-lg">213.8</div>
-                    </div>
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">File Size</div>
-                        <div id="dupFileASize" class="text-white font-mono">0.79 MB</div>
-                    </div>
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">Resolution</div>
-                        <div id="dupFileARes" class="text-white font-mono">1436×1436</div>
-                    </div>
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">Bitrate</div>
-                        <div id="dupFileABitrate" class="text-white font-mono">--</div>
-                    </div>
-                </div>
-
-                <!-- Action Button -->
-                <button onclick="keepDuplicateFile('A')" class="w-full py-3 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border-2 border-purple-500/50 hover:border-purple-500 text-purple-400 hover:text-white font-bold text-sm uppercase tracking-wider transition-all flex items-center justify-center gap-2 group">
-                    <span class="material-icons">check_circle</span>
-                    <span>Keep A</span>
-                    <span class="text-xs opacity-60 group-hover:opacity-100">(Press 1 or ←)</span>
-                </button>
-            </div>
-
-            <!-- File B (Right) -->
-            <div id="dupFileB" class="duplicate-file-panel flex flex-col gap-4 p-6 rounded-2xl border-2 border-white/10 bg-white/[0.02] transition-all hover:border-purple-400/50 hover:scale-[1.02]">
-                <!-- Label -->
-                <div class="flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <div class="w-10 h-10 rounded-full bg-purple-500/20 border-2 border-purple-500/50 flex items-center justify-center">
-                            <span class="text-purple-400 font-bold text-lg">B</span>
-                        </div>
-                        <span class="text-white/60 text-sm font-semibold uppercase tracking-wide">Candidate B</span>
-                    </div>
-                    <div id="dupFileBBadge" class="hidden px-3 py-1 rounded-full bg-green-500/20 border border-green-500/50 text-green-400 text-xs font-bold uppercase">
-                        ✓ Higher Quality
-                    </div>
-                </div>
-
-                <!-- Thumbnail -->
-                <div class="relative aspect-video bg-black rounded-lg overflow-hidden cursor-pointer group" onclick="previewDuplicateFile('B')">
-                    <img id="dupFileBThumb" src="" class="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity">
-                    <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                        <span class="material-icons text-white text-4xl drop-shadow-lg">play_circle</span>
-                    </div>
-                </div>
-
-                <!-- Filename -->
-                <div class="text-white font-medium text-sm truncate" id="dupFileBName" title="">filename_b.mp4</div>
-
-                <!-- Metadata Grid -->
-                <div class="grid grid-cols-2 gap-2 text-xs">
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">Quality Score</div>
-                        <div id="dupFileBQuality" class="text-purple-400 font-bold text-lg">213.8</div>
-                    </div>
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">File Size</div>
-                        <div id="dupFileBSize" class="text-white font-mono">0.79 MB</div>
-                    </div>
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">Resolution</div>
-                        <div id="dupFileBRes" class="text-white font-mono">1436×1436</div>
-                    </div>
-                    <div class="bg-white/5 rounded-lg p-2">
-                        <div class="text-gray-500 mb-1">Bitrate</div>
-                        <div id="dupFileBBitrate" class="text-white font-mono">--</div>
-                    </div>
-                </div>
-
-                <!-- Action Button -->
-                <button onclick="keepDuplicateFile('B')" class="w-full py-3 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border-2 border-purple-500/50 hover:border-purple-500 text-purple-400 hover:text-white font-bold text-sm uppercase tracking-wider transition-all flex items-center justify-center gap-2 group">
-                    <span class="material-icons">check_circle</span>
-                    <span>Keep B</span>
-                    <span class="text-xs opacity-60 group-hover:opacity-100">(Press 2 or →)</span>
-                </button>
-            </div>
-
-        </div>
-    </div>
-
-    <!-- Bottom Action Bar -->
-    <div class="absolute bottom-8 left-0 right-0 flex items-center justify-center gap-4 z-40">
-        <!-- Skip Button -->
-        <button onclick="skipDuplicateGroup()" class="px-6 py-3 rounded-lg bg-white/5 hover:bg-white/10 border border-white/20 hover:border-white/40 text-white/60 hover:text-white font-semibold text-sm transition-all flex items-center gap-2">
-            <span class="material-icons text-lg">skip_next</span>
-            <span>Skip</span>
-            <span class="text-xs opacity-60">(S or Space)</span>
-        </button>
-
-        <!-- Any is Fine Button -->
-        <button onclick="markAnyIsFine()" class="px-6 py-3 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/50 hover:border-green-500 text-green-400 hover:text-white font-semibold text-sm transition-all flex items-center gap-2">
-            <span class="material-icons text-lg">done_all</span>
-            <span>Any is Fine</span>
-            <span class="text-xs opacity-60">(A)</span>
+        <button class="text-text-muted hover:text-text-main transition-colors" onclick="closeDuplicateChecker()" title="Close [Esc]">
+            <span class="material-icons text-[22px]">close</span>
         </button>
     </div>
 
-    <!-- Keyboard Shortcuts Legend -->
-    <div class="absolute bottom-24 left-1/2 -translate-x-1/2 bg-black/80 backdrop-blur-md border border-white/10 rounded-xl px-6 py-3 z-30">
-        <div class="flex items-center gap-6 text-xs text-white/60">
-            <div class="flex items-center gap-2">
-                <kbd class="px-2 py-1 bg-white/10 rounded font-mono font-bold text-white">1</kbd>
-                <span>Keep A</span>
+    <!-- Vergleich -->
+    <div class="flex-1 flex items-center justify-center px-6 py-8 overflow-auto">
+        <div class="w-full max-w-6xl">
+            <div class="flex items-start gap-6">
+
+                <!-- File A -->
+                <div id="dupFileA" class="flex-1 min-w-0 flex flex-col gap-2">
+                    <div class="flex items-center justify-between">
+                        <span class="ds-eyebrow">File A</span>
+                        <span class="ds-eyebrow" id="dupFileACodec"></span>
+                    </div>
+                    <div id="dupFileAPreview" class="relative aspect-video bg-black rounded-ds-md overflow-hidden cursor-pointer group border-[1.5px] border-transparent" onclick="previewDuplicateFile('A')">
+                        <img id="dupFileAThumb" src="" class="w-full h-full object-cover">
+                        <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                            <span class="material-icons text-white text-4xl">play_circle</span>
+                        </div>
+                        <span id="dupFileABadge" class="hidden ds-badge ds-badge-accent absolute bottom-1.5 left-1.5">Recommended</span>
+                    </div>
+                    <div class="flex items-center justify-between gap-3 font-mono text-[11px] text-label">
+                        <span class="truncate" id="dupFileAName" title="">filename_a.mp4</span>
+                        <span id="dupFileASize" class="flex-shrink-0">0.79 MB</span>
+                    </div>
+                    <div class="font-mono text-[11px] text-text-muted truncate">
+                        <span id="dupFileARes">--</span> &middot; <span id="dupFileABitrate">--</span> &middot; Q <span id="dupFileAQuality">--</span>
+                    </div>
+                </div>
+
+                <!-- Entscheidungsspalte -->
+                <div class="w-[120px] flex-shrink-0 flex flex-col items-stretch gap-2.5 pt-6">
+                    <div id="dupSizeDelta" class="font-mono text-[22px] font-extrabold text-optimized text-center leading-none">--</div>
+                    <button id="dupKeepBtn" onclick="keepRecommendedDuplicate()" class="ds-btn ds-btn-primary w-full">Keep</button>
+                    <button id="dupDiscardBtn" onclick="discardRecommendedDuplicate()" class="ds-btn ds-btn-secondary w-full">Discard</button>
+                </div>
+
+                <!-- File B -->
+                <div id="dupFileB" class="flex-1 min-w-0 flex flex-col gap-2">
+                    <div class="flex items-center justify-between">
+                        <span class="ds-eyebrow">File B</span>
+                        <span class="ds-eyebrow" id="dupFileBCodec"></span>
+                    </div>
+                    <div id="dupFileBPreview" class="relative aspect-video bg-black rounded-ds-md overflow-hidden cursor-pointer group border-[1.5px] border-transparent" onclick="previewDuplicateFile('B')">
+                        <img id="dupFileBThumb" src="" class="w-full h-full object-cover">
+                        <div class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                            <span class="material-icons text-white text-4xl">play_circle</span>
+                        </div>
+                        <span id="dupFileBBadge" class="hidden ds-badge ds-badge-accent absolute bottom-1.5 left-1.5">Recommended</span>
+                    </div>
+                    <div class="flex items-center justify-between gap-3 font-mono text-[11px] text-label">
+                        <span class="truncate" id="dupFileBName" title="">filename_b.mp4</span>
+                        <span id="dupFileBSize" class="flex-shrink-0">0.79 MB</span>
+                    </div>
+                    <div class="font-mono text-[11px] text-text-muted truncate">
+                        <span id="dupFileBRes">--</span> &middot; <span id="dupFileBBitrate">--</span> &middot; Q <span id="dupFileBQuality">--</span>
+                    </div>
+                </div>
+
             </div>
-            <div class="flex items-center gap-2">
-                <kbd class="px-2 py-1 bg-white/10 rounded font-mono font-bold text-white">2</kbd>
-                <span>Keep B</span>
-            </div>
-            <div class="flex items-center gap-2">
-                <kbd class="px-2 py-1 bg-white/10 rounded font-mono font-bold text-white">S</kbd>
-                <span>Skip</span>
-            </div>
-            <div class="flex items-center gap-2">
-                <kbd class="px-2 py-1 bg-white/10 rounded font-mono font-bold text-white">A</kbd>
-                <span>Auto</span>
-            </div>
-            <div class="flex items-center gap-2">
-                <kbd class="px-2 py-1 bg-white/10 rounded font-mono font-bold text-white">ESC</kbd>
-                <span>Exit</span>
+
+            <!-- Tastatur-Hinweis + Zusatzaktionen -->
+            <div class="mt-6 flex items-center gap-5 font-mono text-[11px] text-text-muted">
+                <span>&larr; keep A</span>
+                <span>&rarr; keep B</span>
+                <button onclick="skipDuplicateGroup()" class="hover:text-text-main transition-colors">space skip</button>
+                <button onclick="markAnyIsFine()" class="hover:text-text-main transition-colors">A auto-keep</button>
             </div>
         </div>
     </div>
@@ -1600,77 +1495,70 @@ SETUP_WIZARD_COMPONENT = """
 """
 
 SETTINGS_MODAL_COMPONENT = """
-<div id="settingsModal" class="hidden fixed inset-0 z-40 bg-black/80 backdrop-blur-sm opacity-0 transition-opacity duration-300 flex items-center justify-center p-4 md:p-8">
-    <div class="settings-container w-full h-full md:w-2/3 md:h-auto md:max-w-5xl md:max-h-[85vh] bg-arcade-bg dark:bg-[#1a1a24] rounded-2xl animate-glow-pulse glow-cyan flex flex-col md:flex-row overflow-hidden border border-black/10 dark:border-white/10 transform scale-95 transition-transform duration-300">
+<div id="settingsModal" class="hidden fixed inset-0 z-[120] bg-black/70 opacity-0 transition-opacity duration-300 flex items-center justify-center p-4 md:p-8">
+    <div class="settings-container w-full h-full md:w-2/3 md:h-auto md:max-w-5xl md:max-h-[85vh] bg-bg rounded-ds-lg flex flex-col md:flex-row overflow-hidden border border-[var(--ds-hairline-strong)] transform scale-95 transition-transform duration-300">
 
-        <!-- Sidebar Navigation -->
-        <aside class="w-full md:w-56 bg-[#f1f3f5] dark:bg-[#12121a] border-b md:border-b-0 md:border-r border-black/10 dark:border-white/5 flex md:flex-col shrink-0">
-            <div class="p-4 md:p-5 flex items-center gap-3 border-b border-black/8 dark:border-white/5 md:border-none">
-                <span class="material-icons text-arcade-gold text-xl">settings</span>
-                <h2 class="font-semibold tracking-wide text-lg text-text-main dark:text-white">Settings</h2>
+        <!-- Linke Navigation: spiegelt das Sidebar-Pattern -->
+        <aside class="w-full md:w-[200px] bg-header border-b md:border-b-0 md:border-r border-line/60 flex md:flex-col shrink-0">
+            <div class="px-4 py-4 flex items-center gap-2.5 md:border-b md:border-line/60">
+                <span class="material-icons text-accent text-[18px]">settings</span>
+                <h2 class="font-bold text-[14px] text-text-main">Settings</h2>
             </div>
 
-            <nav class="flex md:flex-col overflow-x-auto md:overflow-visible p-2 md:px-3 md:py-2 gap-1">
-                <button class="settings-nav-item active flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="scanning">
-                    <span class="material-icons text-lg">folder_open</span>
+            <nav class="flex md:flex-col overflow-x-auto md:overflow-visible p-2 md:px-3 md:py-3 gap-0.5">
+                <button class="settings-nav-item active" data-section="scanning">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">folder_open</span>
                     <span class="hidden md:inline">Scanning</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-                <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="performance">
-                    <span class="material-icons text-lg">speed</span>
+                <button class="settings-nav-item" data-section="performance">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">speed</span>
                     <span class="hidden md:inline">Performance</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-                <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="interface">
-                    <span class="material-icons text-lg">palette</span>
+                <button class="settings-nav-item" data-section="interface">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">palette</span>
                     <span class="hidden md:inline">Interface</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-
-                <div class="w-px h-6 md:w-full md:h-px bg-white/10 md:my-2 mx-2 md:mx-0"></div>
-
-                <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="storage">
-                    <span class="material-icons text-lg">storage</span>
+                <button class="settings-nav-item" data-section="storage">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">storage</span>
                     <span class="hidden md:inline">Storage</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-                <div class="w-px h-6 md:w-full md:h-px bg-white/10 md:my-2 mx-2 md:mx-0"></div>
-                <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="privacy">
-                    <span class="material-icons text-lg">security</span>
+                <button class="settings-nav-item" data-section="privacy">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">security</span>
                     <span class="hidden md:inline">Privacy</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-                <div class="w-px h-6 md:w-full md:h-px bg-white/10 md:my-2 mx-2 md:mx-0"></div>
-                 <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="backup">
-                    <span class="material-icons text-lg">save</span>
-                    <span class="hidden md:inline">Backup & Restore</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
+                <button class="settings-nav-item" data-section="backup">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">save</span>
+                    <span class="hidden md:inline">Backup &amp; Restore</span>
                 </button>
-                <div class="w-px h-6 md:w-full md:h-px bg-white/10 md:my-2 mx-2 md:mx-0"></div>
-                <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="queue">
-                    <span class="material-icons text-lg">cloud_sync</span>
+                <button class="settings-nav-item" data-section="queue">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">cloud_sync</span>
                     <span class="hidden md:inline">Remote Queue</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
-                <button class="settings-nav-item flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-gray-400 hover:bg-white/5 hover:text-white transition-all whitespace-nowrap relative" data-section="autotagging">
-                    <span class="material-icons text-lg">sell</span>
+                <button class="settings-nav-item" data-section="autotagging">
+                    <span class="settings-nav-indicator"></span>
+                    <span class="material-icons text-[18px]">sell</span>
                     <span class="hidden md:inline">Auto-Tagging</span>
-                    <div class="active-indicator absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-6 bg-arcade-cyan rounded-r opacity-0 transition-opacity"></div>
                 </button>
             </nav>
         </aside>
 
-        <!-- Main Content -->
-        <main class="flex-1 flex flex-col min-w-0 bg-arcade-bg dark:bg-[#1a1a24]">
+        <!-- Inhalt -->
+        <main class="flex-1 flex flex-col min-w-0 bg-bg">
 
-            <!-- Header -->
-            <header class="p-5 md:p-6 border-b border-white/5 flex justify-between items-center">
+            <header class="px-[26px] py-[18px] border-b border-line/60 flex justify-between items-start">
                 <div>
-                    <h1 id="section-title" class="text-xl md:text-2xl font-bold text-white">Scanning</h1>
-                    <p id="section-subtitle" class="text-sm text-gray-500 mt-0.5">Configure video library scanning</p>
+                    <h1 id="section-title" class="text-[16px] font-bold text-text-main">Scanning</h1>
+                    <p id="section-subtitle" class="text-[12px] text-text-muted mt-0.5">Configure video library scanning</p>
                 </div>
-                <button class="text-gray-500 hover:text-white transition-colors p-2 hover:bg-white/5 rounded-lg" title="Close (ESC)" onclick="closeSettings()">
-                    <span class="material-icons">close</span>
+                <button class="text-text-muted hover:text-text-main transition-colors" title="Close (ESC)" onclick="closeSettings()">
+                    <span class="material-icons text-[22px]">close</span>
                 </button>
             </header>
 
@@ -1681,16 +1569,16 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section active space-y-6" id="content-scanning">
                     <section class="space-y-3">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">folder</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">folder</span>
                                 Scan Directories
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Paths to scan for video files. One per line.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Paths to scan for video files. One per line.</p>
                         </div>
-                        <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsTargets" placeholder="/Users/username/Videos" rows="4" oninput="markSettingsUnsaved()"></textarea>
+                        <textarea class="w-full ds-textarea" id="settingsTargets" placeholder="/Users/username/Videos" rows="4" oninput="markSettingsUnsaved()"></textarea>
 
-                        <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 flex gap-3 text-sm text-blue-300">
-                             <span class="material-icons text-blue-400 text-lg">info</span>
+                        <div class="ds-settings-card flex gap-3 text-[12px] text-body-text">
+                             <span class="material-icons text-text-muted text-lg">info</span>
                              <div>
                                  <strong>Default:</strong> Home directory
                                  <span id="defaultTargetsHint" class="opacity-70 text-xs block mt-0.5"></span>
@@ -1700,40 +1588,40 @@ SETTINGS_MODAL_COMPONENT = """
 
                     <section class="space-y-3">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
                                 <span class="material-icons text-lg text-gray-400">block</span>
                                 System Exclusions
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Default paths excluded from scanning.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Default paths excluded from scanning.</p>
                         </div>
-                        <div id="defaultExclusionsContainer" class="bg-black/30 rounded-xl p-4 border border-white/5 space-y-2 max-h-48 overflow-y-auto">
+                        <div id="defaultExclusionsContainer" class="ds-settings-card space-y-2 max-h-48 overflow-y-auto">
                             <!-- Populated by JS -->
                         </div>
                     </section>
 
                     <section class="space-y-3">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-pink">remove_circle</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">remove_circle</span>
                                 Custom Exclusions
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Additional paths to exclude.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Additional paths to exclude.</p>
                         </div>
-                        <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsExcludes" placeholder="/Volumes/Backup" rows="2" oninput="markSettingsUnsaved()"></textarea>
+                        <textarea class="w-full ds-textarea" id="settingsExcludes" placeholder="/Volumes/Backup" rows="2" oninput="markSettingsUnsaved()"></textarea>
                     </section>
 
                     <section class="space-y-3">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
                                 <span class="material-icons text-lg text-gray-400">notes</span>
                                 Logging
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Control terminal output density during scans.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Control terminal output density during scans.</p>
                         </div>
-                        <label class="flex items-center gap-3 cursor-pointer select-none group bg-black/30 p-4 rounded-xl border border-white/5 hover:border-arcade-cyan/30 transition-all">
+                        <label class="flex items-center gap-3 cursor-pointer select-none group bg-surface p-4 rounded-xl border border-white/5 hover:border-[var(--ds-hairline-strong)] transition-all">
                             <div class="relative inline-flex items-center">
                                 <input type="checkbox" id="settingsVerboseScanning" class="sr-only peer" onchange="markSettingsUnsaved()">
-                                <div class="w-11 h-6 bg-gray-700 rounded-full peer peer-focus:ring-2 peer-focus:ring-arcade-cyan/50 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-arcade-cyan"></div>
+                                <div class="ds-peer-switch"></div>
                             </div>
                             <div>
                                 <span class="text-white font-medium">Verbose Scanning Logs</span>
@@ -1747,14 +1635,14 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section hidden space-y-6" id="content-performance">
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-gold">straighten</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">straighten</span>
                                 File Size Threshold
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Ignore videos smaller than this size.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Ignore videos smaller than this size.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Minimum Size</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Files below this are skipped</div>
@@ -1776,14 +1664,14 @@ SETTINGS_MODAL_COMPONENT = """
 
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">image</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">image</span>
                                 Image Size Threshold
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Ignore images smaller than this. Filters out tiny icons/thumbnails.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Ignore images smaller than this. Filters out tiny icons/thumbnails.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Minimum Size</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Images below this are skipped</div>
@@ -1805,14 +1693,14 @@ SETTINGS_MODAL_COMPONENT = """
 
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-pink">local_fire_department</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">local_fire_department</span>
                                 Bitrate Classification
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Videos above this are marked as HIGH bitrate.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Videos above this are marked as HIGH bitrate.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Bitrate Threshold</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Default: 15,000 kbps</div>
@@ -1834,32 +1722,32 @@ SETTINGS_MODAL_COMPONENT = """
 
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">speed</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">speed</span>
                                 Thumbnail Pre-computation
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Generate thumbnails during scan to prevent lag while scrolling.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Generate thumbnails during scan to prevent lag while scrolling.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Pre-compute Thumbnails</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Highly recommended for NAS users.</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
                                 <input type="checkbox" id="settingsPrecomputeThumbs" class="sr-only peer" onchange="markSettingsUnsaved()">
-                                <div class="w-11 h-6 bg-gray-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-arcade-cyan"></div>
+                                <div class="ds-peer-switch"></div>
                             </label>
                         </div>
                     </section>
 
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-gold">tune</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">tune</span>
                                 Encoding Quality
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Trade-off between encoding speed and output file size. Best quality takes longer but shrinks files more.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Trade-off between encoding speed and output file size. Best quality takes longer but shrinks files more.</p>
                         </div>
 
                         <div class="grid grid-cols-3 gap-2" id="encodingPresetGroup">
@@ -1893,11 +1781,11 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section hidden space-y-6" id="content-interface">
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
                                 <span class="material-icons text-lg text-accent">palette</span>
                                 Appearance
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Arcade Scanner nutzt ein einheitliches Design System.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Arcade Scanner nutzt ein einheitliches Design System.</p>
                         </div>
 
                         <div class="bg-surface rounded-ds-md p-4 border border-white/10">
@@ -1907,35 +1795,35 @@ SETTINGS_MODAL_COMPONENT = """
 
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
                                 <span class="material-icons text-lg text-arcade-magenta">auto_awesome</span>
                                 Visual Features
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Customize the dashboard experience.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Customize the dashboard experience.</p>
                         </div>
 
 
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Video Optimizer</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Enable video compression features <span class="text-amber-400">(restart required)</span></div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
                                 <input type="checkbox" id="settingsOptimizer" class="sr-only peer" checked onchange="markSettingsUnsaved()">
-                                <div class="w-12 h-7 bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-arcade-cyan/30 rounded-full peer peer-checked:after:translate-x-5 peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:shadow-md after:transition-all peer-checked:bg-arcade-gold"></div>
+                                <div class="ds-peer-switch"></div>
                             </label>
                         </div>
 
                         <!-- INCLUDE PHOTOS -->
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Include Photos</div>
-                                <div class="text-xs text-gray-500 mt-0.5">Include <span class="text-arcade-cyan">.jpg, .png, .gif</span> etc. in library</div>
+                                <div class="text-xs text-gray-500 mt-0.5">Include <span class="text-accent">.jpg, .png, .gif</span> etc. in library</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
                                 <input type="checkbox" id="settingsScanImages" class="sr-only peer" onchange="onIncludePhotosChange(this)">
-                                <div class="w-12 h-7 bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-arcade-cyan/30 rounded-full peer peer-checked:after:translate-x-5 peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:shadow-md after:transition-all peer-checked:bg-arcade-cyan"></div>
+                                <div class="ds-peer-switch"></div>
                             </label>
                         </div>
 
@@ -1969,23 +1857,23 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section hidden space-y-6" id="content-storage">
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">pie_chart</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">pie_chart</span>
                                 Cache Statistics
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Disk space used by generated assets.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Disk space used by generated assets.</p>
                         </div>
 
                         <div class="grid grid-cols-2 gap-3">
-                            <div class="bg-black/40 p-4 rounded-xl border border-white/5 flex flex-col items-center gap-2">
+                            <div class="bg-surface p-4 rounded-xl border border-white/5 flex flex-col items-center gap-2">
                                 <span class="material-icons text-gray-500 text-2xl">image</span>
                                 <span class="text-xs text-gray-500 uppercase tracking-wider">Thumbnails</span>
                                 <span class="text-lg font-mono text-white" id="statThumbnails">—</span>
                             </div>
-                            <div class="bg-black/40 p-4 rounded-xl border border-arcade-cyan/30 flex flex-col items-center gap-2">
-                                <span class="material-icons text-arcade-cyan text-2xl">storage</span>
+                            <div class="bg-surface p-4 rounded-xl border border-accent/30 flex flex-col items-center gap-2">
+                                <span class="material-icons text-accent text-2xl">storage</span>
                                 <span class="text-xs text-gray-500 uppercase tracking-wider">Total</span>
-                                <span class="text-lg font-mono text-arcade-cyan" id="statTotal">—</span>
+                                <span class="text-lg font-mono text-accent" id="statTotal">—</span>
                             </div>
                         </div>
 
@@ -2001,40 +1889,40 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section hidden space-y-6" id="content-privacy">
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">shield</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">shield</span>
                                 Safe Mode Configuration
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Define what content is hidden when Safe Mode is enabled.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Define what content is hidden when Safe Mode is enabled.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Enable Safe Mode</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Hide sensitive content based on tags and directories</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
                                 <input type="checkbox" id="settingsSafeMode" class="sr-only peer" onchange="markSettingsUnsaved()">
-                                <div class="w-12 h-7 bg-gray-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-arcade-cyan/30 rounded-full peer peer-checked:after:translate-x-5 peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-6 after:w-6 after:shadow-md after:transition-all peer-checked:bg-green-500"></div>
+                                <div class="ds-peer-switch"></div>
                             </label>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 space-y-4">
+                        <div class="ds-settings-card space-y-4">
                             <div>
                                 <label class="block text-xs font-medium text-white mb-2">Sensitive Directories</label>
-                                <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsSensitiveDirs" placeholder="/path/to/private" rows="3" oninput="markSettingsUnsaved()"></textarea>
+                                <textarea class="w-full ds-textarea" id="settingsSensitiveDirs" placeholder="/path/to/private" rows="3" oninput="markSettingsUnsaved()"></textarea>
                                 <p class="text-xs text-gray-500 mt-1">One absolute path per line. Files in these folders will be hidden.</p>
                             </div>
 
                             <div>
                                 <label class="block text-xs font-medium text-white mb-2">Sensitive Tags</label>
-                                <input type="text" id="settingsSensitiveTags" placeholder="nsfw, adult" class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none" oninput="markSettingsUnsaved()">
+                                <input type="text" id="settingsSensitiveTags" placeholder="nsfw, adult" class="w-full bg-surface border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-accent focus:outline-none" oninput="markSettingsUnsaved()">
                                 <p class="text-xs text-gray-500 mt-1">Comma separated list of tags to hide.</p>
                             </div>
 
                             <div>
                                 <label class="block text-xs font-medium text-white mb-2">Sensitive Collections</label>
-                                <textarea class="w-full bg-black/40 border border-white/10 rounded-xl p-4 text-sm text-gray-300 font-mono focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all resize-none placeholder-gray-600" id="settingsSensitiveCollections" placeholder="My Private Collection" rows="3" oninput="markSettingsUnsaved()"></textarea>
+                                <textarea class="w-full ds-textarea" id="settingsSensitiveCollections" placeholder="My Private Collection" rows="3" oninput="markSettingsUnsaved()"></textarea>
                                 <p class="text-xs text-gray-500 mt-1">One collection name per line. These collections will be hidden from the sidebar.</p>
                             </div>
                         </div>
@@ -2045,14 +1933,14 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section hidden space-y-6" id="content-backup">
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">cloud_download</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">cloud_download</span>
                                 Export Settings
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Download your current configuration, including collections and tags.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Download your current configuration, including collections and tags.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl p-4 border border-white/5 flex items-center justify-between gap-4">
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
                                 <div class="text-white font-medium text-sm">Backup Configuration</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Saves as arcade_settings_backup.json</div>
@@ -2066,20 +1954,20 @@ SETTINGS_MODAL_COMPONENT = """
 
                     <section class="space-y-4">
                          <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-pink">cloud_upload</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">cloud_upload</span>
                                 Import Settings
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Restore configuration from a backup file. Existing settings will be overwritten.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Restore configuration from a backup file. Existing settings will be overwritten.</p>
                         </div>
 
-                         <div class="bg-black/30 rounded-xl p-4 border border-white/5 space-y-4">
+                         <div class="ds-settings-card space-y-4">
                             <div class="flex items-center gap-4">
                                 <div class="flex-1">
                                     <label class="block text-sm font-medium text-white mb-1">Select Backup File</label>
                                     <input type="file" id="settingsImportFile" accept=".json" class="block w-full text-xs text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-xs file:font-medium file:bg-white/10 file:text-white hover:file:bg-white/20 cursor-pointer">
                                 </div>
-                                <button onclick="importSettings()" class="px-4 py-2 bg-arcade-cyan/20 hover:bg-arcade-cyan/30 text-arcade-cyan rounded-lg text-sm font-medium transition-colors border border-arcade-cyan/30 flex items-center gap-2 h-[38px] mt-6">
+                                <button onclick="importSettings()" class="px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded-lg text-sm font-medium transition-colors border border-accent/30 flex items-center gap-2 h-[38px] mt-6">
                                     <span class="material-icons text-sm">upload</span>
                                     Restore
                                 </button>
@@ -2096,14 +1984,14 @@ SETTINGS_MODAL_COMPONENT = """
                 <div class="content-section hidden space-y-6" id="content-queue">
                     <section class="space-y-4">
                         <div>
-                            <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                <span class="material-icons text-lg text-arcade-cyan">cloud_sync</span>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">cloud_sync</span>
                                 Encoding Queue
                             </h3>
-                            <p class="text-sm text-gray-500 mt-1">Files queued for remote Mac encoding. The Mac worker polls for pending jobs.</p>
+                            <p class="text-[12px] text-text-muted mt-1">Files queued for remote Mac encoding. The Mac worker polls for pending jobs.</p>
                         </div>
 
-                        <div class="bg-black/30 rounded-xl border border-white/5 overflow-hidden">
+                        <div class="bg-surface rounded-xl border border-white/5 overflow-hidden">
                             <table class="w-full text-sm">
                                 <thead>
                                     <tr class="border-b border-white/5 text-gray-500 text-xs uppercase tracking-wider">
@@ -2120,9 +2008,9 @@ SETTINGS_MODAL_COMPONENT = """
                             </table>
                         </div>
 
-                        <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 flex gap-3 text-sm text-blue-300">
-                            <span class="material-icons text-blue-400 text-lg">info</span>
-                            <div>Start the Mac worker with: <code class="px-2 py-0.5 bg-black/40 rounded text-arcade-cyan">python3 mac_worker.py --server http://&lt;ip&gt;:8000 --user admin</code></div>
+                        <div class="ds-settings-card flex gap-3 text-[12px] text-body-text">
+                            <span class="material-icons text-text-muted text-lg">info</span>
+                            <div>Start the Mac worker with: <code class="px-2 py-0.5 bg-surface rounded text-accent">python3 mac_worker.py --server http://&lt;ip&gt;:8000 --user admin</code></div>
                         </div>
                     </section>
                 </div>
@@ -2131,14 +2019,14 @@ SETTINGS_MODAL_COMPONENT = """
                     <section class="space-y-4">
                         <div class="flex items-center justify-between">
                             <div>
-                                <h3 class="text-base font-medium text-white flex items-center gap-2">
-                                    <span class="material-icons text-lg text-arcade-cyan">sell</span>
+                                <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                    <span class="material-icons text-lg text-accent">sell</span>
                                     Auto-Tagging-Regeln
                                 </h3>
-                                <p class="text-sm text-gray-500 mt-1">Regeln vergeben ihr Tag automatisch nach jedem Scan. Anlegen im Collection-Editor ("Als Regel").</p>
+                                <p class="text-[12px] text-text-muted mt-1">Regeln vergeben ihr Tag automatisch nach jedem Scan. Anlegen im Collection-Editor ("Als Regel").</p>
                             </div>
                             <button id="autotagRunBtn" onclick="runAutoTagRules()"
-                                    class="px-3 py-1.5 rounded-lg text-xs font-bold bg-arcade-cyan/20 text-arcade-cyan hover:bg-arcade-cyan/30 transition-colors">
+                                    class="px-3 py-1.5 rounded-lg text-xs font-bold bg-accent/20 text-accent hover:bg-accent/30 transition-colors">
                                 Jetzt ausführen
                             </button>
                         </div>
@@ -2157,7 +2045,7 @@ SETTINGS_MODAL_COMPONENT = """
                 </div>
                 <div class="flex gap-3">
                     <button class="px-4 py-2 rounded-lg text-sm font-medium text-text-muted dark:text-gray-400 hover:text-text-main dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 transition-all" onclick="closeSettings()">Cancel</button>
-                    <button id="saveSettingsBtn" class="px-5 py-2 rounded-lg text-sm font-bold text-black bg-arcade-cyan hover:bg-cyan-300 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-arcade-cyan/20 transition-all flex items-center gap-2" onclick="saveSettings()">
+                    <button id="saveSettingsBtn" class="px-5 py-2 rounded-lg text-sm font-bold text-black bg-accent hover:bg-cyan-300 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-accent/20 transition-all flex items-center gap-2" onclick="saveSettings()">
                         <span class="material-icons text-lg save-icon">save</span>
                         <svg class="animate-spin h-4 w-4 save-spinner hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/arcade_scanner/templates/dashboard_template.py
+++ b/arcade_scanner/templates/dashboard_template.py
@@ -78,15 +78,11 @@ def generate_html_report(results, report_file, server_port=8000):
     # 2. Prepare Cinema Modal (Conditional Optimize Button)
     opt_btn_html = ""
     if config.optimizer_available and config.settings.enable_optimizer:
+        # Die einzige Primaeraktion der Rail — traegt als einzige den Accent.
         opt_btn_html = """
-        <button class="flex flex-col items-center gap-1.5 transition-all group" onclick="cinemaOptimize()" title="Optimize Video [O]" aria-label="Optimize this video">
-            <div class="w-12 h-12 rounded-xl bg-arcade-cyan/12 backdrop-blur-sm flex items-center justify-center border border-arcade-cyan/35 group-hover:bg-arcade-cyan/25 group-hover:border-arcade-cyan/65 group-hover:scale-110 transition-all shadow-lg shadow-arcade-cyan/10">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="text-arcade-cyan group-hover:text-cyan-300 transition-colors">
-                    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" fill="currentColor" fill-opacity="0.15"/>
-                    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
-                </svg>
-            </div>
-            <span class="text-[9px] font-semibold tracking-wider uppercase text-arcade-cyan/75 group-hover:text-arcade-cyan transition-colors">Optimize</span>
+        <button class="cinema-rail-btn is-primary" onclick="cinemaOptimize()" title="Optimize Video [O]" aria-label="Optimize this video">
+            <span class="cinema-rail-icon"><span class="material-icons">bolt</span></span>
+            <span class="cinema-rail-label">Optimize</span>
         </button>
         """
 


### PR DESCRIPTION
Stufe 2 des Design-Handoffs. **Basiert auf #43** — bitte den erst mergen, dann rebased dieser PR automatisch auf `main`.

## Cinema-Player

- Top-Overlay: Dateiname (13px 600) + Mono-Metadatenzeile (Auflösung · Codec · Bitrate), Close-Icon rechts.
- Rechte Action-Rail statt der Button-Reihe unten: runde 44px-Buttons, alle neutral — **nur** Optimize trägt den Accent-Tint. Das war der Kern der Spec-Notiz ("one accent for the primary action, neutral icon buttons for the rest").
- Eigene Transport-Leiste statt `<video controls>`: 3px-Scrubber mit Accent-Fill, Mono-Timestamps, hervorgehobener Play-Button (34px vs. 20–22px), Prev/Next/Mute/Fullscreen. Die bestehenden Tastatur-Shortcuts sind unverändert; Space geht jetzt durch `cinemaTogglePlay()`.
- Favorit/Vault zeigen ihren Zustand über `.is-active` statt über Opacity.

## Duplicate-Checker

- Zwei `flex-1`-Spalten + fixe 120px-Entscheidungsspalte: Größendelta (Mono 22px 800, grün bei Ersparnis), Keep (primary), Discard (secondary).
- Die Empfehlung bekommt eine einzelne 1.5px-Accent-Kontur um die Vorschau — kein flächiger Farbwash mehr über die ganze Spalte.
- Keyboard-Hinweis als Mono-Caption; Skip und Auto-Keep sind dort als Textbuttons erreichbar geblieben, damit die Funktionen nicht nur noch per Tastatur existieren.

## Settings

- Linke Nav (200px) übernimmt das Sidebar-Pattern: Accent-Tint plus 3px-Indikator. Der aktive Zustand hängt jetzt allein an `.active` statt an einer Handvoll per JS gesetzter Utility-Klassen — das war vorher über drei Stellen in [settings.js](arcade_scanner/server/static/settings.js) verteilt.
- Mono-Readout-Blöcke für Verzeichnislisten/Exclusions, `.ds-settings-card` für gruppierte Einstellungen, 38×22-Toggle-Switches.
- Die Section-Heading-Icons waren ein Gold/Cyan/Pink-Mix und sind jetzt einheitlich Accent; die blauen Info-Boxen laufen auf der neutralen Karte.

## Zwei Dinge, die nicht reines Styling sind

1. **Der native Video-Transport ist ersetzt.** Die Spec zeichnet eine eigene Bedienleiste, und native Controls lassen sich nicht darauf hinstylen. Damit hängen Scrubbing, Play/Pause, Mute und Fullscreen jetzt an eigenem Code (~120 Zeilen in [cinema.js](arcade_scanner/server/static/cinema.js)). Getestet habe ich das im Browser gegen ein gemocktes Video-Element — am echten Stream mit Buffering solltest du einmal drüberschauen.
2. **z-index-Fix**: Duplicate-Checker (`z-50`) und Settings (`z-40`) lagen unter der Sidebar (`z-[100]`) und wurden von ihr überlappt. Das war vorher schon so, fiel beim dunklen Vollbild-Overlay nur nicht auf. Beide stehen jetzt auf `z-[120]`.

## Verifikation

- `pytest`: 742 passed, 1 xfailed
- `ruff check .`: unverändert 2 Findings, beide bereits auf `dev`
- Alle drei Screens im Browser gerendert und gegen `screenshots/cinema-player.png`, `duplicate-checker.png` und `settings.png` gegengeprüft; Nav-Umschaltung, Toggle-Zustände und Scrubber-Fill live getestet

🤖 Generated with [Claude Code](https://claude.com/claude-code)