### PR TITLE
fix(web): drop leftover neon accents missed by the design system sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Duplicate-Checker und Settings-Dialog lagen mit `z-index` unter der
   Sidebar (`z-100`) und wurden von ihr überlappt.
+- Reste der alten Palette, die per Inline-Style bzw. hartkodiertem Hex an den
+  CSS-Tokens vorbeiliefen: `setWorkspaceMode()` hat der Filterleiste bei jedem
+  Workspace-Wechsel eine Cyan/Gold/Magenta-Border plus Farb-Tint zugewiesen und
+  damit die neutrale Hairline überschrieben; dazu der aktive Datums-Chip, der
+  Hover der Folder-Cards, das HEVC-Label im Treemap und der Batch-Warnhinweis.
 
 ### Added
 - **Duplikat-Scan findet re-encodete Videos**: Der bisherige Video-Pass gruppiert

--- a/arcade_scanner/server/static/batch_operations.js
+++ b/arcade_scanner/server/static/batch_operations.js
@@ -42,7 +42,7 @@ function updateBatchSelection() {
             const warningSpan = document.createElement('span');
             warningSpan.id = 'batchSkipWarning';
             warningSpan.className = 'batch-skip-warning';
-            warningSpan.style.cssText = 'color: #F4B342; font-size: 0.85rem; display: flex; align-items: center; gap: 4px;';
+            warningSpan.style.cssText = 'color: var(--ds-bitrate); font-size: 0.85rem; display: flex; align-items: center; gap: 4px;';
             const countSpan = document.getElementById('batchCount');
             if (countSpan && countSpan.parentElement) {
                 countSpan.parentElement.insertAdjacentElement('afterend', warningSpan);

--- a/arcade_scanner/server/static/filter_engine.js
+++ b/arcade_scanner/server/static/filter_engine.js
@@ -75,11 +75,8 @@ function setDateFilter(val) {
     dateFilter = val;
     // Update active class
     document.querySelectorAll('[data-filter="date"]').forEach(btn => {
+        // Aktiver Chip haengt allein an .active — die Optik kommt aus .ds-chip.
         btn.classList.toggle('active', btn.dataset.value === val);
-        // Update border color
-        btn.style.borderColor = btn.dataset.value === val ? 'rgba(0, 255, 208, 0.5)' : 'rgba(255, 255, 255, 0.1)';
-        btn.style.background = btn.dataset.value === val ? 'rgba(0, 255, 208, 0.15)' : 'rgba(255, 255, 255, 0.05)';
-        btn.style.color = btn.dataset.value === val ? '#00ffd0' : '#9ca3af';
     });
     filterAndSort();
 }

--- a/arcade_scanner/server/static/folder_browser.js
+++ b/arcade_scanner/server/static/folder_browser.js
@@ -396,7 +396,7 @@ function getFolderBreadcrumbs() {
  */
 function createFolderCard(folder) {
     const container = document.createElement('div');
-    container.className = 'group relative w-full bg-arcade-bg dark:bg-[#14141c] rounded-xl overflow-hidden border border-black/8 dark:border-white/5 hover:border-arcade-cyan/50 transition-all duration-300 hover:shadow-[0_0_20px_rgba(0,255,208,0.1)] folder-card cursor-pointer';
+    container.className = 'group relative w-full bg-card rounded-ds-md overflow-hidden border border-[var(--ds-hairline)] hover:border-[var(--ds-hairline-strong)] transition-colors duration-200 folder-card cursor-pointer';
     container.setAttribute('data-path', folder.path);
 
     // Create 2x2 mosaic of thumbnails

--- a/arcade_scanner/server/static/treemap.js
+++ b/arcade_scanner/server/static/treemap.js
@@ -461,7 +461,7 @@ function setupTreemapInteraction() {
                 const isHevc = (video.codec || '').includes('hevc') || (video.codec || '').includes('h265');
                 const isAv1  = (video.codec || '').includes('av1') || (video.codec || '').includes('av01');
                 const codecLabel = isHevc
-                    ? '<span style="color:#00ffd0;font-weight:bold;">HEVC</span>'
+                    ? '<span style="color:var(--ds-hevc);font-weight:bold;">HEVC</span>'
                     : isAv1
                         ? '<span style="color:#c4b5fd;font-weight:bold;">AV1</span>'
                         : (video.codec || 'Unknown').toUpperCase();

--- a/arcade_scanner/server/static/workspace.js
+++ b/arcade_scanner/server/static/workspace.js
@@ -56,22 +56,8 @@ function setWorkspaceMode(mode, preserveCollection = false) {
         if (mode === 'vault') document.body.classList.add('vault-mode');
         else document.body.classList.remove('vault-mode');
 
-        // Update workspace indicator bar with actual colors
-        const wsColors = {
-            lobby: { accent: '#00ffd0', bg: 'rgba(0, 255, 208, 0.05)' },
-            favorites: { accent: '#F4B342', bg: 'rgba(244, 179, 66, 0.05)' },
-            optimized: { accent: '#00ffd0', bg: 'rgba(0, 255, 208, 0.05)' },
-            review: { accent: '#00ffd0', bg: 'rgba(0, 255, 208, 0.05)' },
-            vault: { accent: '#8F0177', bg: 'rgba(143, 1, 119, 0.05)' },
-            duplicates: { accent: '#a855f7', bg: 'rgba(168, 85, 247, 0.05)' },
-            candidates: { accent: '#F4B342', bg: 'rgba(244, 179, 66, 0.05)' }
-        };
-        const colors = wsColors[mode] || wsColors.lobby;
-        const wsIndicator = document.querySelector('.workspace-indicator');
-        if (wsIndicator) {
-            wsIndicator.style.borderBottomColor = colors.accent;
-            wsIndicator.style.backgroundColor = colors.bg;
-        }
+        // Design System: alle Workspaces teilen sich EINEN Accent. Der Indikator
+        // wird komplett ueber CSS-Tokens gestylt — kein Inline-Farb-Mapping mehr.
 
         // Add animation class
         const grid = document.getElementById('videoGrid');


### PR DESCRIPTION
Beim Test der App am laufenden Server (echte Bibliothek, 2731 Dateien) sind fünf Stellen aufgefallen, die die alte Palette per Inline-Style oder hartkodiertem Hex gesetzt haben und deshalb an den CSS-Tokens vorbeiliefen.

Die auffälligste: [workspace.js](arcade_scanner/server/static/workspace.js) hat der Filterleiste bei **jedem** Workspace-Wechsel eine Cyan/Gold/Magenta-Border plus Farb-Tint inline zugewiesen und damit die neutrale Hairline aus `styles.css` überschrieben. Im Dashboard war unter der Filterleiste durchgehend ein türkiser Strich zu sehen. Das Gegenstück in `engine.js` hatte ich in #43 entfernt — dass `setWorkspaceMode()` dasselbe Mapping ein zweites Mal hält, ist mir dabei entgangen.

Die übrigen vier:

- [filter_engine.js](arcade_scanner/server/static/filter_engine.js) — der aktive Datums-Chip wurde per Inline-Style eingefärbt statt über `.ds-chip.active`
- [folder_browser.js](arcade_scanner/server/static/folder_browser.js) — Folder-Cards trugen noch den Cyan-Glow-Hover
- [treemap.js](arcade_scanner/server/static/treemap.js) — HEVC-Label auf das Codec-Token statt `#00ffd0`
- [batch_operations.js](arcade_scanner/server/static/batch_operations.js) — Warnhinweis auf das Bitrate-Token

## Verifikation

Am laufenden Server gegen echte Dateien geprüft:

- Filterleiste hat nach dem Fix kein Inline-Style mehr (`wiInline: null`)
- Cinema-Player am echten Stream: Laden, Play/Pause, Seek vorwärts (75% → 45.2s) und rückwärts (10% → 6.8s), Mute, Prev/Next, Space und Escape — alle `readyState 4`, `video.error` durchgehend `null`, keine Konsolenfehler
- `/stream` beantwortet Range-Requests korrekt (`206 Partial Content` mit passendem `Content-Range`), worauf das Seeking aufsetzt
- `ruff check .` sauber, 742 Tests grün

Nicht geprüft: der Duplicate-Checker mit echten Daten — dafür müsste ein voller Duplikat-Scan über die Bibliothek laufen, den wollte ich nicht ungefragt anstoßen. Die UI ist mit Mock-Daten verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)