### PR TITLE
fix(queue): Remote-Encoding-Offloading reparieren und Fortschritt anzeigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,39 @@ All notable changes to this project will be documented in this file.
   Verzeichnislisten und 38×22-Toggle-Switches.
 
 ### Fixed
+- **Remote-Encoding (Mac-Worker) wieder zuverlässig.** Der Worker meldet sich
+  jetzt selbst neu an, wenn die Session abläuft — bisher lief er nach jedem
+  Server-Neustart endlos in `401`, weil Sessions nur im RAM liegen und
+  `_login()` einmalig beim Start aufgerufen wurde. Ohne `--user`/`--password`
+  bricht er mit klarer Meldung ab, statt still nichts zu tun; die veralteten
+  Beispiele ohne Credentials in Doku und Settings-Hinweis sind korrigiert.
+- Download und Upload eines Jobs suchten die Job-ID in den *neuesten* 100
+  Einträgen, während der Worker den *ältesten* Job bekommt — ab 100 Jobs in der
+  Queue schlug der Download deshalb zuverlässig mit 404 fehl. Beide Endpunkte
+  nutzen jetzt einen direkten Lookup per ID.
+- Queue-Endpunkte lieferten Dateipfade mit kaputtem Encoding (Surrogates)
+  escaped zurück, sodass Down-/Upload die Datei nicht fanden.
+- Abgestürzte Worker hinterließen Jobs dauerhaft auf `downloading`/`encoding`;
+  dieselbe Datei ließ sich danach nie wieder einreihen. Jobs ohne Heartbeat
+  werden nach 15 Minuten neu eingereiht (nach 3 Versuchen `failed`).
+- Ein Abbruch durch den Nutzer konnte von einer verspäteten Statusmeldung des
+  Workers wieder überschrieben werden; `saved_bytes` wurde bei jedem
+  Zwischenstatus auf 0 zurückgesetzt.
+- Nach einem abgebrochenen Lauf konnte der Worker eine alte `_opt.mp4` aus dem
+  Arbeitsverzeichnis als Erfolg hochladen — jeder Job bekommt jetzt ein eigenes
+  Verzeichnis, und der „Datei liegt zufällig da"-Fallback ist entfernt.
+- Der Upload las die komplette Datei in den RAM (mehrere GB pro Job) und wurde
+  serverseitig weder auf Größe noch auf Vollständigkeit geprüft: eine
+  abgebrochene Verbindung galt als fertiger Encode. Jetzt Streaming-Upload,
+  Größenlimit und Integritätsprüfung (ffprobe-Dauer + strikter Decode) vor dem
+  atomaren Replace.
+- Im Standard-Modus (Review Mode aus) legte der Upload nur eine `_opt.mp4`
+  neben das Original, ersetzte nichts und erzeugte keinen Datenbankeintrag.
+  Die optimierte Datei tritt jetzt atomar an die Stelle des Originals und
+  übernimmt dessen Metadaten.
+- Unerreichbare Kopien der Queue-Routen in `api_handler.py` entfernt — sie
+  hatten keine Auth-Prüfung und wären bei einer Änderung der
+  Dispatch-Reihenfolge scharf geworden.
 - Duplicate-Checker und Settings-Dialog lagen mit `z-index` unter der
   Sidebar (`z-100`) und wurden von ihr überlappt.
 - Reste der alten Palette, die per Inline-Style bzw. hartkodiertem Hex an den
@@ -46,6 +79,14 @@ All notable changes to this project will be documented in this file.
   Hover der Folder-Cards, das HEVC-Label im Treemap und der Batch-Warnhinweis.
 
 ### Added
+- **Fortschrittsanzeige für Remote-Encodes.** Die Remote-Queue in den
+  Einstellungen zeigt jetzt Fortschrittsbalken, aktuelle Phase, Restzeit und
+  den Worker-Namen; der Poll-Takt geht auf 2 s, solange Jobs laufen, und auf
+  10 s im Leerlauf. Der Worker sendet dafür alle 10 s einen Heartbeat an das
+  neue `POST /api/queue/progress`, gespeist aus dem neuen optionalen
+  `progress_callback` von `process_file()`. Die Prozentangabe gilt pro
+  Encode-Pass — die Qualitätssuche startet den Balken mehrfach neu, deshalb
+  steht die Phase daneben.
 - **Duplikat-Scan findet re-encodete Videos**: Der bisherige Video-Pass gruppiert
   nach gerundeter Größe + Dauer + Auflösung. Eine transkodierte Kopie (H.264 →
   HEVC, 1080p → 720p, anderer CRF) teilt keinen dieser Werte und landete damit

--- a/arcade_scanner/config.py
+++ b/arcade_scanner/config.py
@@ -49,6 +49,9 @@ STATIC_DIR = os.path.join(PROJECT_ROOT, "arcade_scanner", "server", "static")
 
 # Security Constants
 MAX_REQUEST_SIZE = 1024 * 1024  # 1 MB limit for API requests
+# Encoded videos come back from the remote worker as one raw body, so they need
+# their own (much larger) ceiling — see routes/queue.py /api/queue/upload.
+MAX_UPLOAD_SIZE = 64 * 1024 * 1024 * 1024  # 64 GB
 ALLOWED_VIDEO_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.mpg', '.mpeg']
 ALLOWED_THUMBNAIL_PREFIX = "thumb_"
 

--- a/arcade_scanner/core/media_replace.py
+++ b/arcade_scanner/core/media_replace.py
@@ -1,0 +1,73 @@
+"""Server-side integrity check + atomic replace for uploaded encodes.
+
+Deliberate twin of ``verify_output_integrity`` / ``promote_staging`` in
+``scripts/video_optimizer.py`` (~line 385). That script is standalone: it runs
+on a remote Mac without this package installed, so it cannot import from here,
+and importing *it* from the server would need a sys.path hack. Keep both in
+sync when the verification rules change.
+"""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def verify_media_integrity(path: Path, expected_duration: float,
+                           tolerance: float = 1.5) -> Tuple[bool, str]:
+    """Cheap insurance before an atomic replace: correct duration + clean decode.
+
+    Catches truncated moov atoms and half-transferred uploads, which a plain
+    byte-count check on the request body cannot distinguish from a short encode.
+    Pass ``expected_duration <= 0`` to skip the duration comparison.
+    """
+    path = Path(path)
+    try:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(path)],
+            capture_output=True, text=True, timeout=60,
+        )
+        out_duration = float(probe.stdout.strip())
+    except (subprocess.SubprocessError, ValueError, OSError) as e:
+        return (False, f"ffprobe failed: {e}")
+
+    if expected_duration > 0 and abs(out_duration - expected_duration) > tolerance:
+        return (False, f"duration mismatch: {out_duration:.1f}s vs expected {expected_duration:.1f}s")
+
+    try:
+        decode = subprocess.run(
+            ["ffmpeg", "-v", "error", "-xerror", "-i", str(path),
+             "-an", "-sn", "-f", "null", "-"],
+            capture_output=True, text=True, timeout=1800,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        return (False, f"decode check failed to run: {e}")
+
+    if decode.returncode != 0:
+        return (False, f"decode errors: {decode.stderr.strip()[:200]}")
+    return (True, "ok")
+
+
+def atomic_replace(staging: Path, target: Path) -> None:
+    """Move `staging` onto `target` atomically.
+
+    ``os.replace`` is only atomic within one filesystem; across a mount it
+    silently degrades to copy+delete, which would leave a half-written file
+    where the original used to be. Refuse that case instead.
+    """
+    staging, target = Path(staging), Path(target)
+    anchor = target if target.exists() else target.parent
+    try:
+        same_fs = os.stat(staging).st_dev == os.stat(anchor).st_dev
+    except OSError as e:
+        raise RuntimeError(f"cannot stat replace endpoints: {e}") from e
+    if not same_fs:
+        raise RuntimeError(
+            f"refusing non-atomic replace across filesystems: {staging} → {target}"
+        )
+    os.replace(staging, target)
+    logger.info("Replaced %s", target)

--- a/arcade_scanner/database/sqlite_store.py
+++ b/arcade_scanner/database/sqlite_store.py
@@ -168,7 +168,12 @@ class SQLiteStore:
                 completed_at INTEGER DEFAULT 0,
                 worker_id TEXT DEFAULT '',
                 result_message TEXT DEFAULT '',
-                saved_bytes INTEGER DEFAULT 0
+                saved_bytes INTEGER DEFAULT 0,
+                progress_pct REAL DEFAULT 0,
+                eta_seconds INTEGER DEFAULT 0,
+                phase TEXT DEFAULT '',
+                last_seen INTEGER DEFAULT 0,
+                attempts INTEGER DEFAULT 0
             )
         """)
         # Add target_codec column to existing installations (migration)
@@ -176,6 +181,19 @@ class SQLiteStore:
             conn.execute("ALTER TABLE encoding_queue ADD COLUMN target_codec TEXT DEFAULT 'hevc'")
         except Exception:
             pass  # Column already exists
+
+        # Migration: progress/heartbeat columns for the remote worker
+        for _ddl in (
+            "ALTER TABLE encoding_queue ADD COLUMN progress_pct REAL DEFAULT 0",
+            "ALTER TABLE encoding_queue ADD COLUMN eta_seconds INTEGER DEFAULT 0",
+            "ALTER TABLE encoding_queue ADD COLUMN phase TEXT DEFAULT ''",
+            "ALTER TABLE encoding_queue ADD COLUMN last_seen INTEGER DEFAULT 0",
+            "ALTER TABLE encoding_queue ADD COLUMN attempts INTEGER DEFAULT 0",
+        ):
+            try:
+                conn.execute(_ddl)
+            except Exception:
+                pass  # Column already exists
 
         # Embedding storage (similarity part 1) — written by scripts/media_indexer.py,
         # read by routes/similar.py. Vectors are L2-normalized float32 blobs.
@@ -343,6 +361,10 @@ class SQLiteStore:
         conn = self._ensure_connection()
 
         with self._write_lock:
+            # A worker that died mid-job leaves its row on downloading/encoding
+            # forever, which also blocks queue_encode() for that file. There is
+            # no background scheduler in this app, so reclaim lazily here.
+            self._reclaim_stale_locked()
             while True:
                 cursor = conn.execute(
                     "SELECT id, file_path, size_bytes, target_codec FROM encoding_queue WHERE status = 'pending' ORDER BY created_at ASC LIMIT 1"
@@ -352,9 +374,12 @@ class SQLiteStore:
                     return None
 
                 job_id = row["id"]
+                now = int(time.time())
                 cursor = conn.execute(
-                    "UPDATE encoding_queue SET status = 'downloading', started_at = ?, worker_id = ? WHERE id = ? AND status = 'pending'",
-                    (int(time.time()), worker_id, job_id)
+                    "UPDATE encoding_queue SET status = 'downloading', started_at = ?, "
+                    "worker_id = ?, last_seen = ?, progress_pct = 0, eta_seconds = 0, "
+                    "phase = 'download' WHERE id = ? AND status = 'pending'",
+                    (now, worker_id, now, job_id)
                 )
                 if cursor.rowcount == 0:
                     continue  # Someone else claimed it first — try the next one.
@@ -366,12 +391,62 @@ class SQLiteStore:
                     "target_codec": row["target_codec"] or "hevc",
                 }
 
-    def update_job_status(self, job_id: int, status: str, **kwargs: Any) -> None:
-        """Update a job's status and optional fields (result_message, saved_bytes, completed_at)."""
+    def _reclaim_stale_locked(self, timeout_seconds: int = 900, max_attempts: int = 3) -> int:
+        """Requeue (or fail) jobs whose worker stopped reporting. Caller holds the lock.
+
+        `last_seen` is only written by workers that speak the progress protocol;
+        older rows fall back to `started_at` so they cannot hang forever either.
+        """
+        conn = self._ensure_connection()
+        cutoff = int(time.time()) - timeout_seconds
+        stale = (
+            "status IN ('downloading', 'encoding', 'uploading') "
+            "AND COALESCE(NULLIF(last_seen, 0), started_at, 0) < ?"
+        )
+
+        # Out of retries → give up so the row stops being 'active'.
+        dead = conn.execute(
+            f"UPDATE encoding_queue SET status = 'failed', completed_at = ?, "
+            f"result_message = 'Worker vanished' WHERE {stale} AND attempts >= ?",
+            (int(time.time()), cutoff, max_attempts)
+        ).rowcount
+
+        requeued = conn.execute(
+            f"UPDATE encoding_queue SET status = 'pending', worker_id = '', started_at = 0, "
+            f"progress_pct = 0, eta_seconds = 0, phase = '', last_seen = 0, "
+            f"attempts = attempts + 1 WHERE {stale}",
+            (cutoff,)
+        ).rowcount
+
+        if dead or requeued:
+            print(f"♻️  Queue reclaim: {requeued} requeued, {dead} failed (worker timeout)")
+        return dead + requeued
+
+    def get_job(self, job_id: int) -> Optional[dict]:
+        """Look up a single job by id. `file_path` comes back usable for os.* calls."""
+        conn = self._ensure_connection()
+        with self._write_lock:
+            row = conn.execute(
+                "SELECT * FROM encoding_queue WHERE id = ?", (job_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        job = dict(row)
+        job["file_path"] = self._decode_safe_path(job["file_path"])
+        return job
+
+    def update_job_status(self, job_id: int, status: str, guard_active: bool = False,
+                          **kwargs: Any) -> bool:
+        """Update a job's status and optional fields. Returns True if a row changed.
+
+        With `guard_active` the update only fires while the job is still running,
+        so a late status report from the worker cannot resurrect a job the user
+        cancelled in the meantime.
+        """
         conn = self._ensure_connection()
 
-        sets = ["status = ?"]
-        vals: List[Any] = [status]
+        sets = ["status = ?", "last_seen = ?"]
+        vals: List[Any] = [status, int(time.time())]
 
         if status in ("done", "failed"):
             sets.append("completed_at = ?")
@@ -382,12 +457,30 @@ class SQLiteStore:
                 sets.append(f"{key} = ?")
                 vals.append(kwargs[key])
 
+        where = "id = ?"
         vals.append(job_id)
+        if guard_active:
+            where += " AND status NOT IN ('cancelled', 'done', 'failed')"
+
         with self._write_lock:
-            conn.execute(
-                f"UPDATE encoding_queue SET {', '.join(sets)} WHERE id = ?",
+            cursor = conn.execute(
+                f"UPDATE encoding_queue SET {', '.join(sets)} WHERE {where}",
                 tuple(vals)
             )
+            return cursor.rowcount > 0
+
+    def update_job_progress(self, job_id: int, progress_pct: float = 0.0,
+                            eta_seconds: int = 0, phase: str = "") -> bool:
+        """Store a worker heartbeat. False means the job is gone or no longer active."""
+        conn = self._ensure_connection()
+        with self._write_lock:
+            cursor = conn.execute(
+                "UPDATE encoding_queue SET progress_pct = ?, eta_seconds = ?, phase = ?, "
+                "last_seen = ? WHERE id = ? AND status NOT IN ('cancelled', 'done', 'failed')",
+                (max(0.0, min(100.0, float(progress_pct))), int(eta_seconds), phase,
+                 int(time.time()), job_id)
+            )
+            return cursor.rowcount > 0
 
     def get_queue_status(self, limit: int = 20) -> List[dict]:
         """Return active + recent jobs for the UI."""
@@ -395,7 +488,8 @@ class SQLiteStore:
         with self._write_lock:
             cursor = conn.execute(
                 """SELECT id, file_path, status, size_bytes, created_at, started_at,
-                          completed_at, worker_id, result_message, saved_bytes
+                          completed_at, worker_id, result_message, saved_bytes,
+                          progress_pct, eta_seconds, phase, last_seen, attempts
                    FROM encoding_queue
                    ORDER BY
                        CASE WHEN status IN ('pending','downloading','encoding','uploading') THEN 0 ELSE 1 END,
@@ -403,7 +497,10 @@ class SQLiteStore:
                    LIMIT ?""",
                 (limit,)
             )
-            return [dict(row) for row in cursor.fetchall()]
+            jobs = [dict(row) for row in cursor.fetchall()]
+        for job in jobs:
+            job["file_path"] = self._decode_safe_path(job["file_path"])
+        return jobs
 
     def get_active_queue_paths(self) -> set[str]:
         """file_paths of jobs currently pending or being processed."""

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -2,12 +2,10 @@ import http.server
 import json
 import mimetypes
 import os
-import socket
 import ssl
 import threading
 import time
 from http.cookies import SimpleCookie
-from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
 
 from arcade_scanner.config import (
@@ -826,79 +824,8 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
 
                 send_json(self, {"tags": tags})
 
-            # Unreachable block removed
-
-
-            # ================================================================
-            # DUPLICATE DETECTION API
-            # ================================================================
-            elif self.path.startswith("/api/queue/next"):
-                try:
-                    params = parse_qs(urlparse(self.path).query)
-                    worker_id = params.get("worker_id", [socket.gethostname()])[0]
-                    job = db.get_next_pending(worker_id=worker_id)
-                    if job:
-                        send_json(self, job)
-                    else:
-                        self.send_response(204)
-                        self.end_headers()
-                except Exception as e:
-                    print(f"❌ Error in queue/next: {e}")
-                    self.send_error(500, str(e))
-
-            elif self.path.startswith("/api/queue/check?"):
-                try:
-                    params = parse_qs(urlparse(self.path).query)
-                    job_id = int(params.get("job_id", [0])[0])
-                    cancelled = db.is_job_cancelled(job_id) if job_id else False
-                    send_json(self, {"cancelled": cancelled})
-                except Exception as e:
-                    self.send_error(500, str(e))
-
-            elif self.path.startswith("/api/queue/download?"):
-                try:
-                    params = parse_qs(urlparse(self.path).query)
-                    job_id = int(params.get("job_id", [0])[0])
-                    if not job_id:
-                        self.send_error(400, "Missing job_id")
-                        return
-
-                    # Look up job to get file path
-                    jobs = db.get_queue_status(limit=100)
-                    job = next((j for j in jobs if j["id"] == job_id), None)
-                    if not job:
-                        self.send_error(404, "Job not found")
-                        return
-
-                    file_path = job["file_path"]
-                    if not os.path.exists(file_path):
-                        db.update_job_status(job_id, "failed", result_message="Source file not found")
-                        self.send_error(404, "Source file not found")
-                        return
-
-                    file_size = os.path.getsize(file_path)
-                    filename = os.path.basename(file_path)
-                    mime, _ = mimetypes.guess_type(file_path)
-
-                    self.send_response(200)
-                    self.send_header("Content-Type", mime or "application/octet-stream")
-                    self.send_header("Content-Length", str(file_size))
-                    self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
-                    self.send_header("X-Original-Path", file_path)
-                    self.end_headers()
-
-                    # Stream in 8KB chunks
-                    with open(file_path, 'rb') as f:
-                        while True:
-                            chunk = f.read(8192)
-                            if not chunk:
-                                break
-                            self.wfile.write(chunk)
-
-                    print(f"📤 Queue download: {filename} ({file_size / (1024*1024):.1f} MB) for job {job_id}")
-                except Exception as e:
-                    print(f"❌ Error in queue/download: {e}")
-                    self.send_error(500, str(e))
+            # NOTE: the /api/queue/* endpoints live in routes/queue.py and are
+            # dispatched at the top of do_GET/do_POST — never add copies here.
 
             else:
                 # 404 for anything else
@@ -1033,113 +960,8 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
                 handle_post_remove_photos(self)
                 return
 
-            # ================================================================
-            # DUPLICATE DETECTION - DELETE FILES
-            # ================================================================
-            # ================================================================
-            # GIF EXPORT
-            # ================================================================
-            elif self.path == "/api/queue/cancel":
-                try:
-                    content_len = int(self.headers.get('Content-Length', 0))
-                    post_body = self.rfile.read(content_len)
-                    data = json.loads(post_body)
-                    job_id = int(data.get("job_id", 0))
-
-                    if db.cancel_job(job_id):
-                        print(f"🗑️ Cancelled queue job {job_id}")
-                        self.send_response(200)
-                        self.send_header("Content-Type", "application/json")
-                        self.end_headers()
-                        self.wfile.write(json.dumps({"success": True}).encode())
-                    else:
-                        self.send_response(200)
-                        self.send_header("Content-Type", "application/json")
-                        self.end_headers()
-                        self.wfile.write(json.dumps({"success": False, "error": "Job not cancellable"}).encode())
-                except Exception as e:
-                    print(f"❌ Error in queue/cancel: {e}")
-                    self.send_error(500, str(e))
-
-            elif self.path.startswith("/api/queue/upload?"):
-                try:
-                    params = parse_qs(urlparse(self.path).query)
-                    job_id = int(params.get("job_id", [0])[0])
-                    if not job_id:
-                        self.send_error(400, "Missing job_id")
-                        return
-
-                    # Look up job
-                    jobs = db.get_queue_status(limit=100)
-                    job = next((j for j in jobs if j["id"] == job_id), None)
-                    if not job:
-                        self.send_error(404, "Job not found")
-                        return
-
-                    original_path = job["file_path"]
-                    orig_stem = Path(original_path).stem
-                    orig_dir = os.path.dirname(original_path)
-                    opt_path = os.path.join(orig_dir, f"{orig_stem}_opt.mp4")
-
-                    content_len = int(self.headers.get('Content-Length', 0))
-
-                    # Stream upload to disk in chunks
-                    with open(opt_path, 'wb') as out:
-                        remaining = content_len
-                        while remaining > 0:
-                            chunk_size = min(8192, remaining)
-                            chunk = self.rfile.read(chunk_size)
-                            if not chunk:
-                                break
-                            out.write(chunk)
-                            remaining -= len(chunk)
-
-                    opt_size = os.path.getsize(opt_path)
-                    orig_size = os.path.getsize(original_path) if os.path.exists(original_path) else 0
-                    saved = orig_size - opt_size
-
-                    db.update_job_status(job_id, "done", saved_bytes=saved,
-                                        result_message=f"Optimized: {opt_size/(1024*1024):.1f}MB (saved {saved/(1024*1024):.1f}MB)")
-
-                    print(f"✅ Upload received for job {job_id}: {os.path.basename(opt_path)} ({opt_size/(1024*1024):.1f} MB, saved {saved/(1024*1024):.1f} MB)")
-
-                    # Trigger report regeneration
-                    try:
-                        current_port = self.server.server_address[1]
-                        report_debouncer.schedule(current_port)
-                    except Exception as e:
-                        print(f"⚠️ Report scheduling after upload failed: {e}")
-
-                    self.send_response(200)
-                    self.send_header("Content-Type", "application/json")
-                    self.end_headers()
-                    self.wfile.write(json.dumps({"success": True, "opt_path": opt_path, "saved_bytes": saved}).encode())
-
-                except Exception as e:
-                    print(f"❌ Error in queue/upload: {e}")
-                    self.send_error(500, str(e))
-
-            elif self.path == "/api/queue/complete":
-                try:
-                    content_len = int(self.headers.get('Content-Length', 0))
-                    post_body = self.rfile.read(content_len)
-                    data = json.loads(post_body)
-
-                    job_id = int(data.get("job_id", 0))
-                    status = data.get("status", "done")
-                    message = data.get("message", "")
-                    saved_bytes = int(data.get("saved_bytes", 0))
-
-                    db.update_job_status(job_id, status, result_message=message, saved_bytes=saved_bytes)
-                    print(f"📋 Job {job_id} completed: {status} — {message}")
-
-                    self.send_response(200)
-                    self.send_header("Content-Type", "application/json")
-                    self.end_headers()
-                    self.wfile.write(json.dumps({"success": True}).encode())
-                except Exception as e:
-                    print(f"❌ Error in queue/complete: {e}")
-                    self.send_error(500, str(e))
+            # NOTE: the /api/queue/* endpoints live in routes/queue.py and are
+            # dispatched at the top of do_POST — never add copies here.
 
             else:
                 self.send_error(404)

--- a/arcade_scanner/server/routes/queue.py
+++ b/arcade_scanner/server/routes/queue.py
@@ -14,6 +14,7 @@ POST-Endpunkte:
   /api/queue/add        → Job zur Queue hinzufügen
   /api/queue/cancel     → Job abbrechen
   /api/queue/upload?    → optimierte Datei hochladen
+  /api/queue/progress   → Worker-Heartbeat (Fortschritt/Phase/ETA)
   /api/queue/complete   → Job als erledigt markieren
   /api/export/gif       → GIF-Konvertierung starten
 """
@@ -31,7 +32,8 @@ import uuid
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-from arcade_scanner.config import config
+from arcade_scanner.config import MAX_UPLOAD_SIZE, config
+from arcade_scanner.core.media_replace import atomic_replace, verify_media_integrity
 from arcade_scanner.database import db
 from arcade_scanner.security import SecurityError, is_path_allowed, sanitize_path
 from arcade_scanner.server.api_handler import _media_cache
@@ -45,6 +47,62 @@ from arcade_scanner.server.response_helpers import (
 # ---------------------------------------------------------------------------
 
 GIF_JOBS: dict[str, dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# Upload-Helfer für den Remote-Worker
+# ---------------------------------------------------------------------------
+
+def _unlink_quiet(path: str) -> None:
+    try:
+        if path and os.path.exists(path):
+            os.remove(path)
+    except OSError:
+        pass
+
+
+def _receive_upload(handler, dest_path: str, content_len: int) -> int:
+    """Stream the request body to disk. Returns the number of bytes written.
+
+    A short count means the connection died mid-upload — the caller must not
+    treat that as a finished encode.
+    """
+    written = 0
+    with open(dest_path, "wb") as out:
+        while written < content_len:
+            chunk = handler.rfile.read(min(8192, content_len - written))
+            if not chunk:
+                break
+            out.write(chunk)
+            written += len(chunk)
+    return written
+
+
+def _replace_media_entry(original_path: str, new_path: str, codec: str) -> None:
+    """Carry the original's metadata over to the file that replaced it.
+
+    Mirrors the review-mode bookkeeping below: the path is the primary key, so
+    the old row has to go before the new one can be written.
+    """
+    import time
+
+    orig_entry = db.get(original_path)
+    if not orig_entry:
+        return
+
+    entry_dict = orig_entry.model_dump(by_alias=True)
+    db.remove(original_path)
+
+    entry_dict["FilePath"] = new_path
+    entry_dict["Size_MB"] = os.path.getsize(new_path) / (1024 * 1024)
+    entry_dict["Status"] = "OK"
+    entry_dict["Bitrate_Mbps"] = 0  # Rescan/analyze fills this in again
+    entry_dict["codec"] = codec
+    entry_dict["optimized_at"] = int(time.time())
+    entry_dict["OriginalPath"] = None
+
+    from arcade_scanner.models.video_entry import VideoEntry
+    db.upsert(VideoEntry(**entry_dict))
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +292,9 @@ def handle_get(handler) -> bool:
         try:
             params = parse_qs(urlparse(path).query)
             job_id = int(params.get("job_id", [0])[0])
-            cancelled = db.is_job_cancelled(job_id) if job_id else False
+            # A job that no longer exists counts as cancelled — otherwise the
+            # worker keeps encoding for a row the user already deleted.
+            cancelled = (db.is_job_cancelled(job_id) or db.get_job(job_id) is None) if job_id else False
             send_json(handler, {"cancelled": cancelled})
         except Exception as e:
             handler.send_error(500, str(e))
@@ -252,8 +312,7 @@ def handle_get(handler) -> bool:
                 handler.send_error(400, "Missing job_id")
                 return True
 
-            jobs = db.get_queue_status(limit=100)
-            job = next((j for j in jobs if j["id"] == job_id), None)
+            job = db.get_job(job_id)
             if not job:
                 handler.send_error(404, "Job not found")
                 return True
@@ -461,8 +520,7 @@ def handle_post(handler) -> bool:
                 handler.send_error(400, "Missing job_id")
                 return True
 
-            jobs = db.get_queue_status(limit=100)
-            job = next((j for j in jobs if j["id"] == job_id), None)
+            job = db.get_job(job_id)
             if not job:
                 handler.send_error(404, "Job not found")
                 return True
@@ -471,6 +529,48 @@ def handle_post(handler) -> bool:
             orig_stem = Path(original_path).stem
             orig_ext = Path(original_path).suffix
             orig_dir = os.path.dirname(original_path)
+
+            content_len = int(handler.headers.get("Content-Length", 0))
+            if content_len <= 0:
+                handler.send_error(400, "Missing Content-Length")
+                return True
+            # An encode should never exceed its source by much; the hard cap
+            # keeps a bogus header from filling the media disk.
+            limit = min(int(job.get("size_bytes") or 0) * 2 or MAX_UPLOAD_SIZE, MAX_UPLOAD_SIZE)
+            if content_len > limit:
+                db.update_job_status(job_id, "failed",
+                                     result_message=f"Upload too large ({content_len} > {limit})")
+                handler.send_error(413, "Upload too large")
+                return True
+
+            # Receive next to the original so the later os.replace stays atomic.
+            part_path = os.path.join(orig_dir, f".{orig_stem}.job{job_id}.part")
+            received = _receive_upload(handler, part_path, content_len)
+            if received != content_len:
+                _unlink_quiet(part_path)
+                db.update_job_status(
+                    job_id, "failed",
+                    result_message=f"Upload truncated ({received}/{content_len} bytes)")
+                handler.send_error(400, "Upload truncated")
+                return True
+
+            # Never let a corrupt encode replace or shadow the original.
+            expected_duration = 0.0
+            try:
+                orig_meta = db.get(original_path)
+                expected_duration = float(getattr(orig_meta, "duration_sec", 0) or 0)
+            except Exception:
+                pass
+            ok, reason = verify_media_integrity(Path(part_path), expected_duration)
+            if not ok:
+                _unlink_quiet(part_path)
+                db.update_job_status(job_id, "failed",
+                                     result_message=f"Integrity check failed: {reason}")
+                print(f"❌ Upload for job {job_id} rejected: {reason}")
+                send_json(handler, {"success": False, "error": reason})
+                return True
+
+            orig_size = os.path.getsize(original_path) if os.path.exists(original_path) else 0
 
             if config.settings.enable_review_mode:
                 # Review Mode: Move both files to a dedicated folder
@@ -487,20 +587,12 @@ def handle_post(handler) -> bool:
                 target_orig_path = os.path.join(review_job_dir, f"{orig_stem}_original{orig_ext}")
                 opt_path = os.path.join(review_job_dir, f"{orig_stem}_optimized.mp4")
 
-                # 1. Save uploaded optimized file
-                content_len = int(handler.headers.get("Content-Length", 0))
-                with open(opt_path, "wb") as out:
-                    remaining = content_len
-                    while remaining > 0:
-                        chunk = handler.rfile.read(min(8192, remaining))
-                        if not chunk:
-                            break
-                        out.write(chunk)
-                        remaining -= len(chunk)
+                # 1. Move the verified upload into the review folder
+                import shutil
+                shutil.move(part_path, opt_path)
 
                 # 2. Move original file
                 if os.path.exists(original_path):
-                    import shutil
                     shutil.move(original_path, target_orig_path)
 
                     # 3. Update Database for original
@@ -532,20 +624,17 @@ def handle_post(handler) -> bool:
                 else:
                     print(f"⚠️ Original file not found at {original_path}, skipping move.")
             else:
-                # Standard Mode: Overwrite in source directory
-                opt_path = os.path.join(orig_dir, f"{orig_stem}_opt.mp4")
-                content_len = int(handler.headers.get("Content-Length", 0))
-                with open(opt_path, "wb") as out:
-                    remaining = content_len
-                    while remaining > 0:
-                        chunk = handler.rfile.read(min(8192, remaining))
-                        if not chunk:
-                            break
-                        out.write(chunk)
-                        remaining -= len(chunk)
+                # Standard Mode: the optimized file takes the original's place.
+                opt_path = str(Path(original_path).with_suffix(".mp4"))
+                atomic_replace(Path(part_path), Path(opt_path))
+                # A .mkv source becomes .mp4, so the old file survives the replace.
+                if opt_path != original_path:
+                    _unlink_quiet(original_path)
+                _replace_media_entry(original_path, opt_path, job.get("target_codec") or "hevc")
 
             opt_size = os.path.getsize(opt_path)
-            orig_size = os.path.getsize(original_path) if not config.settings.enable_review_mode and os.path.exists(original_path) else (os.path.getsize(target_orig_path) if config.settings.enable_review_mode and os.path.exists(target_orig_path) else 0)
+            if config.settings.enable_review_mode and os.path.exists(target_orig_path):
+                orig_size = os.path.getsize(target_orig_path)
             saved = orig_size - opt_size
 
             db.update_job_status(
@@ -572,6 +661,29 @@ def handle_post(handler) -> bool:
             handler.send_error(500, str(e))
         return True
 
+    # POST /api/queue/progress
+    if path == "/api/queue/progress":
+        user_name = require_auth(handler)
+        if user_name is None:
+            return True
+        try:
+            content_len = int(handler.headers.get("Content-Length", 0))
+            data = json.loads(handler.rfile.read(content_len))
+            job_id = int(data.get("job_id", 0))
+            alive = db.update_job_progress(
+                job_id,
+                progress_pct=float(data.get("progress_pct", 0) or 0),
+                eta_seconds=int(data.get("eta_seconds", 0) or 0),
+                phase=str(data.get("phase", "")),
+            )
+            # Doubles as the cancel channel: no row updated means the job is
+            # cancelled or gone, and the worker should stop.
+            send_json(handler, {"success": alive, "cancelled": not alive})
+        except Exception as e:
+            print(f"❌ Error in queue/progress: {e}")
+            handler.send_error(500, str(e))
+        return True
+
     # POST /api/queue/complete
     if path == "/api/queue/complete":
         user_name = require_auth(handler)
@@ -583,10 +695,14 @@ def handle_post(handler) -> bool:
             job_id = int(data.get("job_id", 0))
             status = data.get("status", "done")
             message = data.get("message", "")
-            saved_bytes = int(data.get("saved_bytes", 0))
-            db.update_job_status(job_id, status, result_message=message, saved_bytes=saved_bytes)
+            extra = {"result_message": message}
+            # Intermediate reports carry no savings — writing a default 0 here
+            # would wipe the real number on every status change.
+            if "saved_bytes" in data:
+                extra["saved_bytes"] = int(data.get("saved_bytes") or 0)
+            applied = db.update_job_status(job_id, status, guard_active=True, **extra)
             print(f"📋 Job {job_id} completed: {status} — {message}")
-            send_json(handler, {"success": True})
+            send_json(handler, {"success": applied, "cancelled": not applied})
         except Exception as e:
             print(f"❌ Error in queue/complete: {e}")
             handler.send_error(500, str(e))

--- a/arcade_scanner/server/static/settings.js
+++ b/arcade_scanner/server/static/settings.js
@@ -875,6 +875,9 @@ window.importSettings = importSettings;
 
 // --- REMOTE QUEUE STATUS ---
 let _queuePollInterval = null;
+let _queuePollMs = 0;
+
+const QUEUE_ACTIVE_STATES = ['pending', 'downloading', 'encoding', 'uploading'];
 
 async function loadQueueStatus() {
     try {
@@ -885,9 +888,12 @@ async function loadQueueStatus() {
         if (!tbody) return;
 
         if (!jobs.length) {
-            tbody.innerHTML = '<tr><td colspan="5" class="px-4 py-8 text-center text-gray-600">No jobs yet</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="7" class="px-4 py-8 text-center text-gray-600">No jobs yet</td></tr>';
+            _retuneQueuePolling(false);
             return;
         }
+
+        _retuneQueuePolling(jobs.some(j => QUEUE_ACTIVE_STATES.includes(j.status)));
 
         const statusBadge = (s) => {
             const map = {
@@ -910,13 +916,40 @@ async function loadQueueStatus() {
             return `${Math.floor(diff / 3600)}h ago`;
         };
 
+        const eta = (secs) => {
+            if (!secs || secs <= 0) return '';
+            if (secs < 60) return ` · ${secs}s left`;
+            if (secs < 3600) return ` · ${Math.round(secs / 60)}m left`;
+            return ` · ${(secs / 3600).toFixed(1)}h left`;
+        };
+
+        // Percentages are per encode pass — the quality search restarts the bar
+        // several times, which is what the phase label explains.
+        const progressCell = (j) => {
+            if (!QUEUE_ACTIVE_STATES.includes(j.status)) {
+                return j.saved_bytes > 0
+                    ? `<span class="text-xs text-green-400">−${(j.saved_bytes / (1024 * 1024)).toFixed(1)}MB</span>`
+                    : '<span class="text-xs text-gray-600">—</span>';
+            }
+            const pct = Math.max(0, Math.min(100, Number(j.progress_pct) || 0));
+            const phase = j.phase || j.status;
+            return `<div class="min-w-[120px]">
+                        <div class="h-1.5 rounded-full bg-white/10 overflow-hidden">
+                            <div class="h-full bg-accent transition-all" style="width: ${pct}%"></div>
+                        </div>
+                        <div class="text-[10px] text-gray-500 mt-1 truncate">${escapeHtml(phase)} ${Math.round(pct)}%${eta(j.eta_seconds)}</div>
+                    </div>`;
+        };
+
         tbody.innerHTML = jobs.map(j => `
             <tr class="border-b border-white/5 hover:bg-white/5 transition-colors">
                 <td class="px-4 py-3">${statusBadge(j.status)}</td>
-                <td class="px-4 py-3 text-white text-xs font-mono truncate max-w-[200px]" title="${j.file_path}">${j.file_path.split(/[\\/]/).pop()}</td>
+                <td class="px-4 py-3 text-white text-xs font-mono truncate max-w-[200px]" title="${escapeHtml(j.file_path)}">${escapeHtml(j.file_path.split(/[\\/]/).pop())}</td>
+                <td class="px-4 py-3">${progressCell(j)}</td>
+                <td class="px-4 py-3 text-gray-500 text-xs hidden lg:table-cell">${escapeHtml(j.worker_id || '—')}</td>
                 <td class="px-4 py-3 text-gray-500 text-xs hidden md:table-cell">${timeAgo(j.created_at)}</td>
-                <td class="px-4 py-3 text-gray-400 text-xs hidden md:table-cell">${j.result_message || (j.saved_bytes > 0 ? `Saved ${(j.saved_bytes / (1024 * 1024)).toFixed(1)}MB` : '—')}</td>
-                <td class="px-4 py-3 text-right">${['pending', 'downloading', 'encoding'].includes(j.status) ? `<button onclick="cancelQueueJob(${j.id})" class="text-xs text-red-400 hover:text-red-300 transition-colors">Cancel</button>` : ''}</td>
+                <td class="px-4 py-3 text-gray-400 text-xs hidden md:table-cell">${escapeHtml(j.result_message || (j.saved_bytes > 0 ? `Saved ${(j.saved_bytes / (1024 * 1024)).toFixed(1)}MB` : '—'))}</td>
+                <td class="px-4 py-3 text-right">${QUEUE_ACTIVE_STATES.includes(j.status) ? `<button onclick="cancelQueueJob(${j.id})" class="text-xs text-red-400 hover:text-red-300 transition-colors">Cancel</button>` : ''}</td>
             </tr>
         `).join('');
     } catch (e) {
@@ -937,16 +970,29 @@ async function cancelQueueJob(jobId) {
     }
 }
 
+// Fast enough to watch a progress bar move, slow enough to stay quiet when
+// nothing is running.
+function _retuneQueuePolling(hasActiveJobs) {
+    if (!_queuePollInterval) return;
+    const wanted = hasActiveJobs ? 2000 : 10000;
+    if (wanted === _queuePollMs) return;
+    clearInterval(_queuePollInterval);
+    _queuePollMs = wanted;
+    _queuePollInterval = setInterval(loadQueueStatus, wanted);
+}
+
 // Start polling when queue section is visible
 function startQueuePolling() {
     if (_queuePollInterval) return;
+    _queuePollMs = 2000;
+    _queuePollInterval = setInterval(loadQueueStatus, _queuePollMs);
     loadQueueStatus();
-    _queuePollInterval = setInterval(loadQueueStatus, 5000);
 }
 
 function stopQueuePolling() {
     if (_queuePollInterval) clearInterval(_queuePollInterval);
     _queuePollInterval = null;
+    _queuePollMs = 0;
 }
 
 // Hook into settings nav to start/stop polling

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -1997,20 +1997,22 @@ SETTINGS_MODAL_COMPONENT = """
                                     <tr class="border-b border-white/5 text-gray-500 text-xs uppercase tracking-wider">
                                         <th class="text-left px-4 py-3">Status</th>
                                         <th class="text-left px-4 py-3">File</th>
+                                        <th class="text-left px-4 py-3">Progress</th>
+                                        <th class="text-left px-4 py-3 hidden lg:table-cell">Worker</th>
                                         <th class="text-left px-4 py-3 hidden md:table-cell">Queued</th>
                                         <th class="text-left px-4 py-3 hidden md:table-cell">Result</th>
                                         <th class="text-right px-4 py-3">Action</th>
                                     </tr>
                                 </thead>
                                 <tbody id="queueTableBody">
-                                    <tr><td colspan="5" class="px-4 py-8 text-center text-gray-600">No jobs yet</td></tr>
+                                    <tr><td colspan="7" class="px-4 py-8 text-center text-gray-600">No jobs yet</td></tr>
                                 </tbody>
                             </table>
                         </div>
 
                         <div class="ds-settings-card flex gap-3 text-[12px] text-body-text">
                             <span class="material-icons text-text-muted text-lg">info</span>
-                            <div>Start the Mac worker with: <code class="px-2 py-0.5 bg-surface rounded text-accent">python3 mac_worker.py --server http://&lt;ip&gt;:8000 --user admin</code></div>
+                            <div>Start the Mac worker with: <code class="px-2 py-0.5 bg-surface rounded text-accent">python3 scripts/mac_worker.py --server http://&lt;ip&gt;:8000 --user admin --password &lt;pw&gt;</code><br>Credentials are required — the queue API rejects anonymous workers.</div>
                         </div>
                     </section>
                 </div>

--- a/dev-docs/video-optimizer.md
+++ b/dev-docs/video-optimizer.md
@@ -417,13 +417,44 @@ match (±1.5s) plus a full error-strict video decode (`ffmpeg -xerror -f null`).
 Catches truncated moov atoms and encoder/driver corruption that 3-window SSIM
 sampling can miss.
 
-### Worker Scheduling (mac_worker.py)
+### Remote Worker (mac_worker.py)
 
 ```bash
 python3 scripts/mac_worker.py --server http://nas:8000 \
-    --schedule "01:00-08:00" \   # only work in this window (overnight OK)
-    --pause-on-battery           # pause while unplugged (pmset -g batt)
+    --user admin --password <pw> \  # required — the queue API rejects anonymous workers
+    --schedule "01:00-08:00" \      # only work in this window (overnight OK)
+    --pause-on-battery              # pause while unplugged (pmset -g batt)
 ```
+
+Credentials also come from `ARCADE_SERVER` / `ARCADE_USER` / `ARCADE_PASSWORD`
+or a `.env` next to the script.
+
+**Job lifecycle.** `pending → downloading → encoding → uploading → done |
+failed | cancelled`. The worker claims the *oldest* pending job via
+`GET /api/queue/next` (compare-and-swap in `SQLiteStore.get_next_pending`),
+downloads the source, runs `process_file()` in a per-job work directory
+(`~/encoding-queue/job_<id>/`), then uploads to `POST /api/queue/upload`.
+
+**Progress & heartbeat.** `process_file(..., progress_callback=...)` fires
+from the ffmpeg reader loop and only writes local state; a daemon thread in
+the worker POSTs it to `/api/queue/progress` every 10 s. Percentages are *per
+encode pass* — the quality search restarts the bar, which is what the `phase`
+label is for. The same call is the cancel channel: a response of
+`{"cancelled": true}` stops the job.
+
+**Recovery.** Sessions live in the server's memory, so a server restart
+invalidates the worker's token — it re-authenticates automatically on the
+first 401. If the worker itself dies, `get_next_pending` lazily requeues jobs
+whose heartbeat is older than 15 minutes (3 attempts, then `failed`);
+otherwise the row would stay "active" forever and block re-queuing that file.
+
+**Upload handling.** The body is streamed to `.<stem>.job<id>.part` next to
+the original, verified with `arcade_scanner/core/media_replace.py`
+(`verify_media_integrity`: ffprobe duration + strict decode), and only then
+promoted via `os.replace`. Standard mode replaces the original and rewrites
+its database row; review mode moves both files into `.review/job_<id>_<stem>/`
+as before. A truncated or corrupt upload fails the job and leaves the original
+untouched.
 
 ### New Constants
 

--- a/scripts/mac_worker.py
+++ b/scripts/mac_worker.py
@@ -8,6 +8,10 @@ encodes it using VideoToolbox, and uploads the result.
 Usage:
     python3 mac_worker.py --server http://192.168.1.100:8000 --user admin --password secret
 
+Credentials are mandatory: every /api/queue/* endpoint requires a session.
+Server sessions live in memory, so the worker re-authenticates automatically
+whenever a request comes back 401 (e.g. after a server restart).
+
 Requirements:
     - macOS with VideoToolbox (Apple Silicon or Intel with T2)
     - ffmpeg installed (brew install ffmpeg)
@@ -17,9 +21,11 @@ Requirements:
 import argparse
 import json
 import os
+import shutil
 import signal
 import socket
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -72,52 +78,76 @@ signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
 
+class AuthError(Exception):
+    """Raised when the worker cannot (re-)establish a session."""
+
+
 class WorkerClient:
     """HTTP client for the Arcade Server queue API."""
 
     def __init__(self, server_url: str, username: str = "", password: str = ""):
         self.server = server_url.rstrip("/")
+        self.username = username
+        self.password = password
         self.session_token = None
         self.hostname = socket.gethostname()
 
         if username:
-            self._login(username, password)
+            self._login()
 
-    def _login(self, username: str, password: str):
-        """Authenticate and store session token."""
+    def _login(self):
+        """Authenticate and store the session token."""
         url = f"{self.server}/api/login"
-        data = json.dumps({"username": username, "password": password}).encode()
+        data = json.dumps({"username": self.username, "password": self.password}).encode()
         req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
 
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
-                # Extract session cookie
                 cookie_header = resp.headers.get("Set-Cookie", "")
                 if "session_token=" in cookie_header:
-                    token = cookie_header.split("session_token=")[1].split(";")[0]
-                    self.session_token = token
-                    print(f"{G}✓ Authenticated as '{username}'{NC}")
-                else:
-                    print(f"{Y}⚠ Login succeeded but no session token received{NC}")
+                    self.session_token = cookie_header.split("session_token=")[1].split(";")[0]
+                    print(f"{G}✓ Authenticated as '{self.username}'{NC}")
+                    return
+                raise AuthError("login succeeded but no session token received")
         except urllib.error.HTTPError as e:
-            print(f"{R}✗ Login failed: {e.code} {e.reason}{NC}")
-            sys.exit(1)
-        except Exception as e:
-            print(f"{R}✗ Connection failed: {e}{NC}")
-            sys.exit(1)
+            raise AuthError(f"login failed: {e.code} {e.reason}") from e
+        except urllib.error.URLError as e:
+            raise AuthError(f"connection failed: {e}") from e
 
-    def _headers(self) -> dict:
-        h = {}
+    def _headers(self, extra: dict | None = None) -> dict:
+        h = dict(extra or {})
         if self.session_token:
             h["Cookie"] = f"session_token={self.session_token}"
         return h
 
+    def _open(self, url: str, data=None, method: str = "GET", timeout: int = 10,
+              headers: dict | None = None):
+        """Perform one request, re-authenticating once on 401.
+
+        Sessions are held in the server's memory, so every server restart
+        invalidates this worker's token. Without the retry the worker would
+        just log 401s forever.
+        """
+        for attempt in (1, 2):
+            req = urllib.request.Request(url, data=data, headers=self._headers(headers),
+                                         method=method)
+            try:
+                return urllib.request.urlopen(req, timeout=timeout)
+            except urllib.error.HTTPError as e:
+                if e.code == 401 and attempt == 1 and self.username:
+                    print(f"{Y}⚠ Session expired — re-authenticating...{NC}")
+                    self._login()
+                    if callable(getattr(data, "seek", None)):
+                        data.seek(0)  # rewind a streamed body before the retry
+                    continue
+                raise
+        raise AuthError("unreachable")  # pragma: no cover
+
     def poll_next_job(self) -> dict | None:
         """Check for next pending job. Returns job dict or None."""
         url = f"{self.server}/api/queue/next?worker_id={self.hostname}"
-        req = urllib.request.Request(url, headers=self._headers())
         try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with self._open(url, timeout=10) as resp:
                 if resp.status == 204:
                     return None
                 return json.loads(resp.read())
@@ -126,16 +156,18 @@ class WorkerClient:
                 return None
             print(f"{R}✗ Poll error: {e.code}{NC}")
             return None
+        except AuthError as e:
+            print(f"{R}✗ Authentication error: {e}{NC}")
+            return None
         except Exception as e:
             print(f"{R}✗ Poll connection error: {e}{NC}")
             return None
 
-    def download_file(self, job_id: int, dest_path: str) -> bool:
+    def download_file(self, job_id: int, dest_path: str, on_progress=None) -> bool:
         """Download source file from server."""
         url = f"{self.server}/api/queue/download?job_id={job_id}"
-        req = urllib.request.Request(url, headers=self._headers())
         try:
-            with urllib.request.urlopen(req, timeout=3600) as resp:
+            with self._open(url, timeout=3600) as resp:
                 total = int(resp.headers.get("Content-Length", 0))
                 downloaded = 0
                 with open(dest_path, "wb") as f:
@@ -149,6 +181,8 @@ class WorkerClient:
                             pct = downloaded * 100 // total
                             mb = downloaded / (1024 * 1024)
                             print(f"\r  ↓ {mb:.1f}/{total/(1024*1024):.1f} MB ({pct}%)", end="", flush=True)
+                            if on_progress:
+                                on_progress(downloaded, total)
                 print()  # newline after progress
                 return True
         except Exception as e:
@@ -156,51 +190,134 @@ class WorkerClient:
             return False
 
     def upload_file(self, job_id: int, file_path: str) -> bool:
-        """Upload optimized file to server."""
+        """Upload optimized file to server.
+
+        The body is streamed straight from the file handle — reading a
+        multi-GB encode into memory first would blow up the worker.
+        """
         url = f"{self.server}/api/queue/upload?job_id={job_id}"
         file_size = os.path.getsize(file_path)
-
-        headers = self._headers()
-        headers["Content-Length"] = str(file_size)
-        headers["Content-Type"] = "application/octet-stream"
+        headers = {
+            "Content-Length": str(file_size),
+            "Content-Type": "application/octet-stream",
+        }
 
         try:
             with open(file_path, "rb") as f:
-                req = urllib.request.Request(url, data=f.read(), headers=headers, method="POST")
-                with urllib.request.urlopen(req, timeout=3600) as resp:
+                with self._open(url, data=f, method="POST", timeout=3600,
+                                headers=headers) as resp:
                     result = json.loads(resp.read())
+                    if not result.get("success", False):
+                        print(f"{R}✗ Server rejected upload: {result.get('error', 'unknown')}{NC}")
                     return result.get("success", False)
         except Exception as e:
             print(f"{R}✗ Upload failed: {e}{NC}")
             return False
 
-    def update_status(self, job_id: int, status: str, **kwargs):
-        """Report job status to server."""
+    def update_status(self, job_id: int, status: str, **kwargs) -> bool:
+        """Report job status. False means the server no longer wants this job."""
         url = f"{self.server}/api/queue/complete"
         data = {"job_id": job_id, "status": status}
         data.update(kwargs)
         body = json.dumps(data).encode()
 
-        headers = self._headers()
-        headers["Content-Type"] = "application/json"
-        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-
         try:
-            with urllib.request.urlopen(req, timeout=10):
-                pass
+            with self._open(url, data=body, method="POST", timeout=10,
+                            headers={"Content-Type": "application/json"}) as resp:
+                result = json.loads(resp.read() or b"{}")
+                return bool(result.get("success", True))
         except Exception as e:
             print(f"{Y}⚠ Status update failed: {e}{NC}")
+            return True  # a network hiccup is not a cancellation
 
-    def check_cancelled(self, job_id: int) -> bool:
-        """Check if a job was cancelled by the user."""
-        url = f"{self.server}/api/queue/check?job_id={job_id}"
-        req = urllib.request.Request(url, headers=self._headers())
+    def report_progress(self, job_id: int, progress_pct: float, eta_seconds: int,
+                        phase: str) -> bool:
+        """Heartbeat. False means the job was cancelled or is gone."""
+        url = f"{self.server}/api/queue/progress"
+        body = json.dumps({
+            "job_id": job_id,
+            "progress_pct": round(progress_pct, 1),
+            "eta_seconds": int(eta_seconds),
+            "phase": phase,
+        }).encode()
+
         try:
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with self._open(url, data=body, method="POST", timeout=10,
+                            headers={"Content-Type": "application/json"}) as resp:
+                result = json.loads(resp.read() or b"{}")
+                return not result.get("cancelled", False)
+        except Exception as e:
+            print(f"{Y}⚠ Heartbeat failed: {e}{NC}")
+            return True  # unreachable server != cancelled job
+
+    def check_cancelled(self, job_id: int) -> bool | None:
+        """Was the job cancelled? None means 'could not find out'."""
+        url = f"{self.server}/api/queue/check?job_id={job_id}"
+        try:
+            with self._open(url, timeout=5) as resp:
                 data = json.loads(resp.read())
                 return data.get("cancelled", False)
-        except Exception:
-            return False
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return True  # job is gone — nothing left to encode for
+            print(f"{Y}⚠ Cancel check failed: {e.code}{NC}")
+            return None
+        except Exception as e:
+            print(f"{Y}⚠ Cancel check failed: {e}{NC}")
+            return None
+
+
+class JobReporter:
+    """Pushes progress to the server on a timer and watches for cancellation.
+
+    The optimizer's callback runs inside the ffmpeg reader loop, so it may only
+    touch local state — this thread does the network I/O, which also gives the
+    server a heartbeat during phases the callback never sees (probing, SSIM,
+    transfers). A stalled worker is what lets the server requeue the job.
+    """
+
+    INTERVAL = 10
+
+    def __init__(self, client: WorkerClient, job_id: int):
+        self.client = client
+        self.job_id = job_id
+        self.cancelled = threading.Event()
+        self._state = {"pct": 0.0, "eta": 0, "phase": ""}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self):
+        self._thread.start()
+        return self
+
+    def stop(self):
+        self._stop.set()
+
+    def set_phase(self, phase: str, pct: float = 0.0, eta: int = 0):
+        with self._lock:
+            self._state = {"pct": pct, "eta": eta, "phase": phase}
+
+    def on_encode_progress(self, current: float, total: float, label: str):
+        """process_file's progress_callback — local writes only, no I/O."""
+        pct = (current * 100.0 / total) if total > 0 else 0.0
+        with self._lock:
+            self._state = {"pct": min(100.0, pct), "eta": 0, "phase": label}
+
+    def on_transfer_progress(self, done: int, total: int):
+        pct = (done * 100.0 / total) if total > 0 else 0.0
+        with self._lock:
+            self._state["pct"] = min(100.0, pct)
+
+    def _run(self):
+        while not self._stop.wait(self.INTERVAL):
+            with self._lock:
+                state = dict(self._state)
+            alive = self.client.report_progress(
+                self.job_id, state["pct"], state["eta"], state["phase"])
+            if not alive:
+                self.cancelled.set()
+                return
 
 
 def process_job(client: WorkerClient, job: dict, work_dir: str):
@@ -212,28 +329,55 @@ def process_job(client: WorkerClient, job: dict, work_dir: str):
 
     print(f"\n{B}{C}═══ Job #{job_id}: {filename} ═══{NC}")
 
+    # One directory per job: two files with the same basename from different
+    # library folders would otherwise collide, and a leftover <stem>_opt.mp4
+    # would make process_file skip the encode and hand back the stale file.
+    job_dir = os.path.join(work_dir, f"job_{job_id}")
+    if os.path.exists(job_dir):
+        shutil.rmtree(job_dir, ignore_errors=True)
+    os.makedirs(job_dir, exist_ok=True)
+
+    reporter = JobReporter(client, job_id).start()
+    try:
+        _run_job(client, job, job_id, filename, stem, job_dir, reporter)
+    finally:
+        reporter.stop()
+        shutil.rmtree(job_dir, ignore_errors=True)
+
+
+def _is_cancelled(client: WorkerClient, reporter: "JobReporter", job_id: int) -> bool:
+    if reporter.cancelled.is_set():
+        return True
+    # None = the server could not be asked; treat that as "keep going" so a
+    # network blip does not throw away a finished encode.
+    return client.check_cancelled(job_id) is True
+
+
+def _run_job(client, job, job_id, filename, stem, job_dir, reporter):
     # 1. Download
-    src_path = os.path.join(work_dir, filename)
+    src_path = os.path.join(job_dir, filename)
     print(f"  {C}↓ Downloading...{NC}")
+    reporter.set_phase("download")
     client.update_status(job_id, "downloading")
 
-    if not client.download_file(job_id, src_path):
+    if not client.download_file(job_id, src_path, on_progress=reporter.on_transfer_progress):
         client.update_status(job_id, "failed", message="Download failed")
         return
 
     src_size = os.path.getsize(src_path)
     print(f"  {G}✓ Downloaded: {src_size / (1024*1024):.1f} MB{NC}")
 
-    # Check for cancellation before encoding
-    if client.check_cancelled(job_id):
+    if _is_cancelled(client, reporter, job_id):
         print(f"  {Y}⏹ Job cancelled by user{NC}")
-        _cleanup(src_path)
         return
 
     # 2. Encode
     target_codec = job.get("target_codec", "hevc")
     print(f"  {C}⚡ Encoding with VideoToolbox (codec: {target_codec})...{NC}")
-    client.update_status(job_id, "encoding")
+    reporter.set_phase("encode")
+    if not client.update_status(job_id, "encoding"):
+        print(f"  {Y}⏹ Server dropped the job — stopping{NC}")
+        return
 
     try:
         from video_optimizer import ENCODER_PROFILES, detect_encoder, process_file
@@ -242,7 +386,6 @@ def process_job(client: WorkerClient, job: dict, work_dir: str):
         if not encoder_key or encoder_key not in ENCODER_PROFILES:
             print(f"  {R}✗ No hardware encoder detected{NC}")
             client.update_status(job_id, "failed", message="No hardware encoder on this Mac")
-            _cleanup(src_path)
             return
 
         # AV1 codec override: map hardware encoder → AV1 variant
@@ -261,28 +404,21 @@ def process_job(client: WorkerClient, job: dict, work_dir: str):
         profile = ENCODER_PROFILES[encoder_key]
         print(f"  Using encoder: {profile['name']}")
 
-        opt_path = os.path.join(work_dir, f"{stem}_opt.mp4")
+        opt_path = os.path.join(job_dir, f"{stem}_opt.mp4")
 
-        success, saved_bytes = process_file(
+        success, _ = process_file(
             src_path, profile,
             min_size_mb=0,  # No minimum — always encode
             copy_audio=False,
             audio_mode="enhanced",
-            video_mode="compress"
+            video_mode="compress",
+            progress_callback=reporter.on_encode_progress,
         )
 
-        # Check if output exists
         if not success or not os.path.exists(opt_path):
-            # process_file puts output next to input. Check for it.
-            expected_opt = os.path.join(work_dir, f"{stem}_opt.mp4")
-            if os.path.exists(expected_opt):
-                opt_path = expected_opt
-                success = True
-            else:
-                print(f"  {R}✗ Encoding failed or no output produced{NC}")
-                client.update_status(job_id, "failed", message="Encoding failed")
-                _cleanup(src_path)
-                return
+            print(f"  {R}✗ Encoding failed or no output produced{NC}")
+            client.update_status(job_id, "failed", message="Encoding failed")
+            return
 
         opt_size = os.path.getsize(opt_path)
         saved = src_size - opt_size
@@ -291,43 +427,26 @@ def process_job(client: WorkerClient, job: dict, work_dir: str):
     except ImportError:
         print(f"  {R}✗ video_optimizer.py not found in {SCRIPT_DIR}{NC}")
         client.update_status(job_id, "failed", message="video_optimizer.py not found")
-        _cleanup(src_path)
         return
     except Exception as e:
         print(f"  {R}✗ Encoding error: {e}{NC}")
         client.update_status(job_id, "failed", message=f"Encoding error: {e}")
-        _cleanup(src_path)
         return
 
-    # Check for cancellation before upload
-    if client.check_cancelled(job_id):
+    if _is_cancelled(client, reporter, job_id):
         print(f"  {Y}⏹ Job cancelled by user{NC}")
-        _cleanup(src_path, opt_path)
         return
 
     # 3. Upload
     print(f"  {C}↑ Uploading optimized file...{NC}")
+    reporter.set_phase("upload")
     client.update_status(job_id, "uploading")
 
     if client.upload_file(job_id, opt_path):
         print(f"  {G}✓ Upload complete!{NC}")
+        print(f"{B}{G}═══ Job #{job_id} done ═══{NC}\n")
     else:
-        client.update_status(job_id, "failed", message="Upload failed",
-                           saved_bytes=saved)
-
-    # 4. Cleanup
-    _cleanup(src_path, opt_path)
-    print(f"  {G}✓ Temp files cleaned up{NC}")
-    print(f"{B}{G}═══ Job #{job_id} done ═══{NC}\n")
-
-
-def _cleanup(*paths):
-    for p in paths:
-        try:
-            if p and os.path.exists(p):
-                os.remove(p)
-        except Exception:
-            pass
+        client.update_status(job_id, "failed", message="Upload failed", saved_bytes=saved)
 
 
 def load_env(env_path=".env"):
@@ -410,8 +529,18 @@ Environment Variables:
         print("  Battery:   pause when unplugged")
     print()
 
-    # Auth
-    client = WorkerClient(args.server, args.user, args.password)
+    # Auth — every /api/queue/* endpoint requires a session, so there is no
+    # anonymous mode to fall back to.
+    if not args.user:
+        print(f"{R}✗ No username given. Use --user/--password (or ARCADE_USER/"
+              f"ARCADE_PASSWORD) — the queue API rejects anonymous workers.{NC}")
+        sys.exit(2)
+
+    try:
+        client = WorkerClient(args.server, args.user, args.password)
+    except AuthError as e:
+        print(f"{R}✗ {e}{NC}")
+        sys.exit(1)
 
     # Main loop
     print(f"{C}Polling for jobs...{NC}")

--- a/scripts/video_optimizer.py
+++ b/scripts/video_optimizer.py
@@ -606,6 +606,19 @@ def show_progress(current, total, encoder="", bitrate="0kb/s", speed="0x", elaps
     sys.stdout.write(f"\r\033[2K {G}{encoder}{NC} [{arrow}{spaces}] {BG}{int(percent)}%{NC} | {speed} | {bitrate} | {elapsed_str} / {eta_str}")
     sys.stdout.flush()
 
+def _report_progress(callback, current, total, label=""):
+    """Feed an optional embedding caller (see process_file's progress_callback).
+
+    Swallows everything: a broken callback must never kill a running encode.
+    """
+    if callback is None:
+        return
+    try:
+        callback(float(current), float(total), label)
+    except Exception:
+        pass
+
+
 def analyze_packet_hotspots(input_path, bucket_len: float = 5.0) -> dict:
     """Sum video packet bytes per bucket_len-second bucket (no decode, fast).
 
@@ -928,8 +941,16 @@ def estimate_optimal_q(input_path, profile, quality_values, bitrate_values,
             except OSError:
                 pass
 
-def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None, audio_mode='enhanced', ss=None, to=None, video_mode='compress', q_override=None, presearch=True, scale_height=None):
-    """Process a single video file. Returns (success, bytes_saved)."""
+def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None, audio_mode='enhanced', ss=None, to=None, video_mode='compress', q_override=None, presearch=True, scale_height=None, progress_callback=None):
+    """Process a single video file. Returns (success, bytes_saved).
+
+    `progress_callback(done_seconds, total_seconds, label)` is called while
+    ffmpeg runs, so an embedding caller (scripts/mac_worker.py) can report
+    progress upstream. It fires from the ffmpeg reader loop — it must return
+    fast and must not do network I/O, or it stalls the progress pipe.
+    Percentages are per pass: the quality search runs several passes and each
+    one restarts at 0, which is what `label` is for.
+    """
     input_path = Path(input_path)
     is_trim = ss is not None or to is not None
 
@@ -1227,6 +1248,7 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
                             elapsed = time.time() - encode_start
                             duration_to_show = trim_duration if is_trim else info['duration']
                             show_progress(ms / 1000000, duration_to_show, 'copy', "copy", "fast", elapsed)
+                            _report_progress(progress_callback, ms / 1000000, duration_to_show, 'copy')
                          except ValueError:
                             pass
 
@@ -1343,6 +1365,8 @@ def process_file(input_path, profile, min_size_mb=0, copy_audio=False, port=None
                             elapsed = time.time() - encode_start
                             duration_to_show = trim_duration if is_trim else info['duration']
                             show_progress(ms / 1000000, duration_to_show, profile['codec'], cur_stats["bitrate"], cur_stats["speed"], elapsed)
+                            _report_progress(progress_callback, ms / 1000000, duration_to_show,
+                                             f"encode Q={quality_val}")
 
                             # Rolling projection: predict final size from current progress.
                             # Use out_time_ms + _abort_size (updated from total_size= just before).

--- a/tests/test_mac_worker.py
+++ b/tests/test_mac_worker.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/mac_worker.py — the remote encoding worker.
+
+The worker talks to the server over plain urllib, so everything here mocks
+``urllib.request.urlopen``. The interesting cases are the ones that used to
+strand a worker silently: an expired session (server sessions are in-memory,
+so every restart invalidates the token) and a cancel check that cannot reach
+the server.
+"""
+import io
+import json
+import sys
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import mac_worker  # noqa: E402
+
+
+class FakeResponse(io.BytesIO):
+    """Minimal stand-in for the object urlopen returns."""
+
+    def __init__(self, payload=b"{}", status=200, headers=None):
+        super().__init__(payload)
+        self.status = status
+        self.headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def login_response(token="tok-1"):
+    return FakeResponse(b"{}", headers={"Set-Cookie": f"session_token={token}; Path=/"})
+
+
+def http_error(code):
+    return urllib.error.HTTPError("http://x", code, "err", {}, None)
+
+
+@pytest.fixture
+def client():
+    with patch("urllib.request.urlopen", return_value=login_response()):
+        return mac_worker.WorkerClient("http://srv:8000", "admin", "pw")
+
+
+class TestAuthentication:
+    def test_login_stores_the_session_token(self, client):
+        assert client.session_token == "tok-1"
+
+    def test_bad_credentials_raise_instead_of_exiting(self):
+        """sys.exit() in a library method would kill callers that can retry."""
+        with patch("urllib.request.urlopen", side_effect=http_error(401)):
+            with pytest.raises(mac_worker.AuthError):
+                mac_worker.WorkerClient("http://srv:8000", "admin", "wrong")
+
+    def test_a_401_triggers_exactly_one_re_login_and_retry(self, client):
+        """A server restart drops the in-memory session; the worker must not
+        spin on 401 forever."""
+        responses = [
+            http_error(401),                       # first poll: session gone
+            login_response("tok-2"),               # re-login
+            FakeResponse(json.dumps({"id": 7}).encode()),  # retried poll
+        ]
+
+        def fake_open(req, timeout=None):
+            item = responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            job = client.poll_next_job()
+
+        assert job == {"id": 7}
+        assert client.session_token == "tok-2"
+        assert responses == []
+
+    def test_a_failed_re_login_does_not_hide_the_error(self, client):
+        with patch("urllib.request.urlopen", side_effect=http_error(401)):
+            assert client.poll_next_job() is None  # reported, not crashed
+
+
+class TestCancelCheck:
+    def test_a_cancelled_job_is_reported(self, client):
+        with patch("urllib.request.urlopen",
+                   return_value=FakeResponse(b'{"cancelled": true}')):
+            assert client.check_cancelled(1) is True
+
+    def test_a_network_error_is_unknown_not_false(self, client):
+        """False would mean 'definitely still running' — a dropped packet must
+        not be able to state that."""
+        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            assert client.check_cancelled(1) is None
+
+    def test_a_vanished_job_counts_as_cancelled(self, client):
+        with patch("urllib.request.urlopen", side_effect=http_error(404)):
+            assert client.check_cancelled(1) is True
+
+    def test_unknown_cancel_state_keeps_the_job_running(self, client):
+        """_is_cancelled must not throw away a finished encode over a blip."""
+        reporter = MagicMock()
+        reporter.cancelled.is_set.return_value = False
+        with patch.object(client, "check_cancelled", return_value=None):
+            assert mac_worker._is_cancelled(client, reporter, 1) is False
+
+
+class TestUpload:
+    def test_the_body_is_streamed_not_read_into_memory(self, client, tmp_path):
+        """A multi-GB encode read via f.read() would blow up the worker."""
+        payload = tmp_path / "out.mp4"
+        payload.write_bytes(b"z" * 4096)
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["data"] = req.data
+            captured["length"] = req.get_header("Content-length")
+            return FakeResponse(b'{"success": true}')
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            assert client.upload_file(1, str(payload)) is True
+
+        assert hasattr(captured["data"], "read"), "body must be a file object"
+        assert captured["length"] == "4096"
+
+    def test_a_rejected_upload_is_not_reported_as_success(self, client, tmp_path):
+        payload = tmp_path / "out.mp4"
+        payload.write_bytes(b"z")
+        with patch("urllib.request.urlopen",
+                   return_value=FakeResponse(b'{"success": false, "error": "corrupt"}')):
+            assert client.upload_file(1, str(payload)) is False
+
+
+class TestJobReporter:
+    def test_a_cancelled_heartbeat_sets_the_event(self, client):
+        reporter = mac_worker.JobReporter(client, 5)
+        reporter.INTERVAL = 0.01
+        with patch.object(client, "report_progress", return_value=False):
+            reporter.start()
+            assert reporter.cancelled.wait(2.0) is True
+        reporter.stop()
+
+    def test_the_encode_callback_only_touches_local_state(self, client):
+        """It runs inside the ffmpeg reader loop — network I/O there stalls
+        the progress pipe."""
+        reporter = mac_worker.JobReporter(client, 5)
+        with patch("urllib.request.urlopen", side_effect=AssertionError("no I/O here")):
+            reporter.on_encode_progress(30.0, 60.0, "encode Q=60")
+        assert reporter._state == {"pct": 50.0, "eta": 0, "phase": "encode Q=60"}
+
+    def test_progress_survives_a_zero_length_source(self, client):
+        reporter = mac_worker.JobReporter(client, 5)
+        reporter.on_encode_progress(0.0, 0.0, "encode")
+        assert reporter._state["pct"] == 0.0
+
+    def test_an_unreachable_server_is_not_a_cancellation(self, client):
+        with patch("urllib.request.urlopen", side_effect=OSError("down")):
+            assert client.report_progress(1, 10.0, 0, "encode") is True

--- a/tests/test_media_replace.py
+++ b/tests/test_media_replace.py
@@ -1,0 +1,115 @@
+"""Tests for arcade_scanner/core/media_replace.py.
+
+This is the last gate before an uploaded encode overwrites a library file, so
+the failure modes matter more than the happy path.
+"""
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arcade_scanner.core.media_replace import atomic_replace, verify_media_integrity
+
+
+class TestAtomicReplace:
+    def test_the_target_is_overwritten(self, tmp_path):
+        target = tmp_path / "a.mp4"
+        target.write_bytes(b"old")
+        staging = tmp_path / ".a.part"
+        staging.write_bytes(b"new")
+
+        atomic_replace(staging, target)
+
+        assert target.read_bytes() == b"new"
+        assert not staging.exists()
+
+    def test_a_missing_target_is_created(self, tmp_path):
+        staging = tmp_path / ".a.part"
+        staging.write_bytes(b"new")
+        target = tmp_path / "a.mp4"
+
+        atomic_replace(staging, target)
+
+        assert target.read_bytes() == b"new"
+
+    def test_a_cross_filesystem_move_is_refused(self, tmp_path):
+        """os.replace degrades to copy+delete across mounts — that is not
+        atomic, and a crash mid-copy would destroy the original."""
+        staging = tmp_path / ".a.part"
+        staging.write_bytes(b"new")
+        target = tmp_path / "a.mp4"
+        target.write_bytes(b"old")
+
+        devs = {str(staging): 1, str(target): 2}
+        real_stat = Path(staging).stat()
+
+        def fake_stat(path, **kwargs):
+            st = MagicMock()
+            st.st_dev = devs.get(str(path), real_stat.st_dev)
+            return st
+
+        with patch("arcade_scanner.core.media_replace.os.stat", side_effect=fake_stat):
+            with pytest.raises(RuntimeError, match="filesystems"):
+                atomic_replace(staging, target)
+
+        assert target.read_bytes() == b"old"
+
+
+class TestVerifyMediaIntegrity:
+    def _probe(self, duration):
+        return MagicMock(stdout=str(duration), returncode=0)
+
+    def test_a_matching_duration_and_clean_decode_pass(self, tmp_path):
+        path = tmp_path / "a.mp4"
+        path.write_bytes(b"x")
+        with patch("arcade_scanner.core.media_replace.subprocess.run",
+                   side_effect=[self._probe(60.0), MagicMock(returncode=0, stderr="")]):
+            assert verify_media_integrity(path, 60.0) == (True, "ok")
+
+    def test_a_short_file_is_rejected(self, tmp_path):
+        """The classic truncated upload: valid header, missing tail."""
+        path = tmp_path / "a.mp4"
+        path.write_bytes(b"x")
+        with patch("arcade_scanner.core.media_replace.subprocess.run",
+                   return_value=self._probe(12.0)):
+            ok, reason = verify_media_integrity(path, 60.0)
+        assert ok is False
+        assert "duration mismatch" in reason
+
+    def test_decode_errors_are_rejected(self, tmp_path):
+        path = tmp_path / "a.mp4"
+        path.write_bytes(b"x")
+        with patch("arcade_scanner.core.media_replace.subprocess.run",
+                   side_effect=[self._probe(60.0),
+                                MagicMock(returncode=1, stderr="moov atom not found")]):
+            ok, reason = verify_media_integrity(path, 60.0)
+        assert ok is False
+        assert "moov atom" in reason
+
+    def test_an_unparseable_probe_is_rejected(self, tmp_path):
+        path = tmp_path / "a.mp4"
+        path.write_bytes(b"x")
+        with patch("arcade_scanner.core.media_replace.subprocess.run",
+                   return_value=MagicMock(stdout="N/A", returncode=0)):
+            ok, reason = verify_media_integrity(path, 60.0)
+        assert ok is False
+        assert "ffprobe failed" in reason
+
+    def test_an_unknown_expected_duration_skips_the_comparison(self, tmp_path):
+        """Files the scanner never probed still get the decode check."""
+        path = tmp_path / "a.mp4"
+        path.write_bytes(b"x")
+        with patch("arcade_scanner.core.media_replace.subprocess.run",
+                   side_effect=[self._probe(3.0), MagicMock(returncode=0, stderr="")]):
+            assert verify_media_integrity(path, 0)[0] is True
+
+    def test_a_hanging_ffmpeg_is_reported_not_raised(self, tmp_path):
+        path = tmp_path / "a.mp4"
+        path.write_bytes(b"x")
+        with patch("arcade_scanner.core.media_replace.subprocess.run",
+                   side_effect=[self._probe(60.0),
+                                subprocess.TimeoutExpired("ffmpeg", 1800)]):
+            ok, reason = verify_media_integrity(path, 60.0)
+        assert ok is False
+        assert "decode check failed to run" in reason

--- a/tests/test_optimizer_ffmpeg.py
+++ b/tests/test_optimizer_ffmpeg.py
@@ -128,3 +128,35 @@ class TestProbeExtraction:
         from video_optimizer import extract_probe_clip
         probe = extract_probe_clip(tmp_path / "nope.mp4", [1.0], segment_sec=4.0, work_dir=tmp_path)
         assert probe is None
+
+
+class TestProgressCallback:
+    """scripts/mac_worker.py passes a callback so it can report encode
+    progress upstream; the local CLI passes none."""
+
+    def test_process_file_accepts_a_progress_callback(self):
+        import inspect
+
+        from video_optimizer import process_file
+        params = inspect.signature(process_file).parameters
+        assert params["progress_callback"].default is None
+        # Positional callers (mac_worker, main) must keep working.
+        assert list(params).index("progress_callback") == len(params) - 1
+
+    def test_a_broken_callback_never_kills_the_encode(self):
+        from video_optimizer import _report_progress
+
+        def boom(*_args):
+            raise RuntimeError("callback exploded")
+
+        _report_progress(boom, 1.0, 2.0, "encode")  # must not raise
+
+    def test_no_callback_is_a_no_op(self):
+        from video_optimizer import _report_progress
+        _report_progress(None, 1.0, 2.0, "encode")
+
+    def test_the_callback_receives_position_duration_and_label(self):
+        from video_optimizer import _report_progress
+        seen = []
+        _report_progress(lambda *a: seen.append(a), 30, 60, "encode Q=60")
+        assert seen == [(30.0, 60.0, "encode Q=60")]

--- a/tests/test_routes_queue.py
+++ b/tests/test_routes_queue.py
@@ -75,9 +75,13 @@ class FakeDB:
         self.queued = []
         self.cancelled = []
         self.status_updates = []
+        self.progress_updates = []
 
     def get_queue_status(self, limit=20):
         return self.jobs
+
+    def get_job(self, job_id):
+        return next((j for j in self.jobs if j["id"] == job_id), None)
 
     def get_next_pending(self, worker_id=""):
         return self.next_job
@@ -93,8 +97,14 @@ class FakeDB:
         self.cancelled.append(job_id)
         return True
 
-    def update_job_status(self, job_id, status, **kwargs):
+    def update_job_status(self, job_id, status, guard_active=False, **kwargs):
         self.status_updates.append((job_id, status))
+        self.status_kwargs = kwargs
+        return True
+
+    def update_job_progress(self, job_id, progress_pct=0.0, eta_seconds=0, phase=""):
+        self.progress_updates.append((job_id, progress_pct, eta_seconds, phase))
+        return True
 
 
 def run_route(handler, fake_db=None, path_allowed=True, post=False):
@@ -129,6 +139,7 @@ POST_ROUTES = [
     ("/api/queue/add", {"file_path": "/media/a.mp4"}),
     ("/api/queue/cancel", {"job_id": 1}),
     ("/api/queue/upload?job_id=1", None),
+    ("/api/queue/progress", {"job_id": 1, "progress_pct": 42, "phase": "encode Q=60"}),
     ("/api/queue/complete", {"job_id": 1, "status": "done"}),
 ]
 
@@ -310,11 +321,21 @@ class TestQueueCheck:
 
     def test_running_job_is_not_reported_as_cancelled(self):
         handler = FakeHandler("/api/queue/check?job_id=1")
+        jobs = [{"id": 1, "file_path": "/media/a.mp4", "status": "encoding"}]
 
         with patch("arcade_scanner.server.routes.queue.send_json") as send_json:
-            run_route(handler)
+            run_route(handler, fake_db=FakeDB(jobs=jobs))
 
         assert send_json.call_args[0][1] == {"cancelled": False}
+
+    def test_a_deleted_job_counts_as_cancelled(self):
+        """Otherwise the worker keeps encoding for a row that no longer exists."""
+        handler = FakeHandler("/api/queue/check?job_id=1")
+
+        with patch("arcade_scanner.server.routes.queue.send_json") as send_json:
+            run_route(handler, fake_db=FakeDB(jobs=[]))
+
+        assert send_json.call_args[0][1] == {"cancelled": True}
 
 
 class TestQueueDownload:
@@ -336,6 +357,131 @@ class TestQueueDownload:
 
         assert handler.error == 404
         assert db.status_updates == [(1, "failed")]
+
+
+def db_status(fake_db):
+    return fake_db.status_updates
+
+
+class TestQueueComplete:
+    def test_intermediate_report_does_not_clear_saved_bytes(self):
+        """The worker posts 'encoding' with no savings yet — that must not
+        overwrite the real number a later 'done' will carry."""
+        handler = FakeHandler("/api/queue/complete",
+                              body={"job_id": 1, "status": "encoding"})
+
+        _, db = run_route(handler, post=True)
+
+        assert db.status_updates == [(1, "encoding")]
+        assert "saved_bytes" not in db.status_kwargs
+
+    def test_reported_saved_bytes_are_passed_through(self):
+        handler = FakeHandler("/api/queue/complete",
+                              body={"job_id": 1, "status": "failed", "saved_bytes": 512})
+
+        _, db = run_route(handler, post=True)
+
+        assert db.status_kwargs["saved_bytes"] == 512
+
+
+class TestQueueProgress:
+    def test_a_heartbeat_is_stored(self):
+        handler = FakeHandler("/api/queue/progress",
+                              body={"job_id": 3, "progress_pct": 42.5,
+                                    "eta_seconds": 90, "phase": "encode Q=60"})
+
+        with patch("arcade_scanner.server.routes.queue.send_json") as send_json:
+            _, db = run_route(handler, post=True)
+
+        assert db.progress_updates == [(3, 42.5, 90, "encode Q=60")]
+        assert send_json.call_args[0][1] == {"success": True, "cancelled": False}
+
+
+class TestQueueUpload:
+    """The upload handler replaces real files, so these run against tmp_path."""
+
+    def test_an_oversized_body_is_refused(self, tmp_path):
+        src = tmp_path / "a.mp4"
+        src.write_bytes(b"x" * 100)
+        jobs = [{"id": 1, "file_path": str(src), "size_bytes": 100}]
+        handler = FakeHandler("/api/queue/upload?job_id=1")
+        handler.headers = {"Content-Length": str(10 * 1024)}
+
+        _, db = run_route(handler, fake_db=FakeDB(jobs=jobs), post=True)
+
+        assert handler.error == 413
+        assert db.status_updates == [(1, "failed")]
+        assert not list(tmp_path.glob(".*part"))
+
+    def test_a_truncated_upload_never_touches_the_original(self, tmp_path):
+        src = tmp_path / "a.mp4"
+        src.write_bytes(b"original")
+        jobs = [{"id": 1, "file_path": str(src), "size_bytes": 8}]
+        handler = FakeHandler("/api/queue/upload?job_id=1")
+        handler.rfile = FakeRFile(b"half")          # promises 8, delivers 4
+        handler.headers = {"Content-Length": "8"}
+
+        fake_db = FakeDB(jobs=jobs)
+        with patch("arcade_scanner.server.routes.queue.db", fake_db):
+            queue.handle_post(handler)
+
+        assert handler.error == 400
+        assert src.read_bytes() == b"original"
+        assert db_status(fake_db) == [(1, "failed")]
+        assert not list(tmp_path.glob(".*part"))
+
+    def test_standard_mode_replaces_the_original(self, tmp_path):
+        src = tmp_path / "a.mkv"
+        src.write_bytes(b"original-bytes-long")
+        jobs = [{"id": 1, "file_path": str(src), "size_bytes": 19, "target_codec": "hevc"}]
+        handler = FakeHandler("/api/queue/upload?job_id=1")
+        handler.rfile = FakeRFile(b"opt")
+        handler.headers = {"Content-Length": "3"}
+
+        fake_db = FakeDB(jobs=jobs)
+        fake_db.get = MagicMock(return_value=None)   # no media row → no bookkeeping
+        settings = MagicMock()
+        settings.settings.enable_review_mode = False
+
+        with patch("arcade_scanner.server.routes.queue.db", fake_db), \
+             patch("arcade_scanner.server.routes.queue.config", settings), \
+             patch("arcade_scanner.server.routes.queue.verify_media_integrity",
+                   return_value=(True, "ok")), \
+             patch("arcade_scanner.server.routes.queue._media_cache"), \
+             patch("arcade_scanner.server.routes.queue.send_json") as send_json:
+            queue.handle_post(handler)
+
+        assert not src.exists(), "the .mkv original must be gone after the replace"
+        assert (tmp_path / "a.mp4").read_bytes() == b"opt"
+        assert not list(tmp_path.glob("*_opt.mp4")), "no leftover _opt.mp4 sidecar"
+        assert not list(tmp_path.glob(".*part"))
+        assert send_json.call_args[0][1]["success"] is True
+        assert db_status(fake_db) == [(1, "done")]
+
+    def test_a_failed_integrity_check_keeps_the_original(self, tmp_path):
+        src = tmp_path / "a.mp4"
+        src.write_bytes(b"original")
+        jobs = [{"id": 1, "file_path": str(src), "size_bytes": 8}]
+        handler = FakeHandler("/api/queue/upload?job_id=1")
+        handler.rfile = FakeRFile(b"broken!!")
+        handler.headers = {"Content-Length": "8"}
+
+        fake_db = FakeDB(jobs=jobs)
+        fake_db.get = MagicMock(return_value=None)
+        settings = MagicMock()
+        settings.settings.enable_review_mode = False
+
+        with patch("arcade_scanner.server.routes.queue.db", fake_db), \
+             patch("arcade_scanner.server.routes.queue.config", settings), \
+             patch("arcade_scanner.server.routes.queue.verify_media_integrity",
+                   return_value=(False, "decode errors")), \
+             patch("arcade_scanner.server.routes.queue.send_json") as send_json:
+            queue.handle_post(handler)
+
+        assert src.read_bytes() == b"original"
+        assert not list(tmp_path.glob(".*part"))
+        assert send_json.call_args[0][1]["success"] is False
+        assert db_status(fake_db) == [(1, "failed")]
 
 
 class TestDownloadGif:

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -291,6 +291,102 @@ class TestQueueClaimIsExclusive:
 
 
 # ---------------------------------------------------------------------------
+# Job lookup, heartbeats and stale-worker recovery
+#
+# scripts/mac_worker.py can die mid-job (crash, reboot, network loss). Without
+# recovery the row stays 'downloading' forever, which also makes queue_encode
+# refuse that file permanently.
+# ---------------------------------------------------------------------------
+
+class TestQueueRecovery:
+    def _claim(self, store, path="/fake/recover.mp4"):
+        store._conn.execute("DELETE FROM encoding_queue")
+        store.queue_encode(path)
+        return store.get_next_pending(worker_id="dead-worker")["id"]
+
+    def _make_stale(self, store, job_id):
+        store._conn.execute(
+            "UPDATE encoding_queue SET last_seen = 1, started_at = 1 WHERE id = ?",
+            (job_id,))
+
+    def test_a_stale_job_returns_to_the_queue(self, store):
+        job_id = self._claim(store)
+        self._make_stale(store, job_id)
+
+        reclaimed = store.get_next_pending(worker_id="fresh-worker")
+
+        assert reclaimed is not None and reclaimed["id"] == job_id
+        assert store.get_job(job_id)["attempts"] == 1
+
+    def test_a_reclaimed_file_can_be_queued_again(self, store):
+        """The real damage of a hung job: queue_encode blocks that file."""
+        job_id = self._claim(store)
+        self._make_stale(store, job_id)
+
+        store._reclaim_stale_locked()
+
+        assert store.get_job(job_id)["status"] == "pending"
+
+    def test_a_job_that_keeps_dying_is_failed(self, store):
+        job_id = self._claim(store)
+        store._conn.execute("UPDATE encoding_queue SET attempts = 3 WHERE id = ?", (job_id,))
+        self._make_stale(store, job_id)
+
+        store._reclaim_stale_locked()
+
+        assert store.get_job(job_id)["status"] == "failed"
+        assert store.queue_encode("/fake/recover.mp4") is not None
+
+    def test_a_live_heartbeat_prevents_reclaim(self, store):
+        job_id = self._claim(store)
+        self._make_stale(store, job_id)
+        store.update_job_progress(job_id, 50.0, 30, "encode Q=60")
+
+        store._reclaim_stale_locked()
+
+        assert store.get_job(job_id)["status"] == "downloading"
+
+    def test_progress_is_stored_and_clamped(self, store):
+        job_id = self._claim(store)
+
+        store.update_job_progress(job_id, 250.0, 12, "encode Q=55")
+
+        job = store.get_job(job_id)
+        assert job["progress_pct"] == 100.0
+        assert (job["eta_seconds"], job["phase"]) == (12, "encode Q=55")
+
+    def test_progress_on_a_cancelled_job_is_refused(self, store):
+        """The worker learns about the cancellation from this False."""
+        job_id = self._claim(store)
+        store.cancel_job(job_id)
+
+        assert store.update_job_progress(job_id, 10.0, 0, "encode") is False
+
+    def test_a_guarded_status_update_cannot_resurrect_a_cancelled_job(self, store):
+        job_id = self._claim(store)
+        store.cancel_job(job_id)
+
+        applied = store.update_job_status(job_id, "encoding", guard_active=True)
+
+        assert applied is False
+        assert store.get_job(job_id)["status"] == "cancelled"
+
+    def test_get_job_finds_jobs_beyond_the_ui_page(self, store):
+        """Download/upload used to search get_queue_status(limit=100), which
+        lists the *newest* jobs while the worker claims the oldest."""
+        store._conn.execute("DELETE FROM encoding_queue")
+        for i in range(150):
+            store.queue_encode(f"/fake/bulk_{i}.mp4")
+
+        claimed = store.get_next_pending(worker_id="w")
+
+        assert store.get_job(claimed["id"])["file_path"] == "/fake/bulk_0.mp4"
+
+    def test_get_job_returns_none_for_an_unknown_id(self, store):
+        assert store.get_job(999999) is None
+
+
+# ---------------------------------------------------------------------------
 # Concurrent reads on the shared connection
 #
 # One sqlite3.Connection is shared across server threads

--- a/tests/test_unicode_surrogates.py
+++ b/tests/test_unicode_surrogates.py
@@ -98,6 +98,11 @@ def test_encoding_queue_handles_surrogates(store):
     except UnicodeEncodeError as e:
         pytest.fail(f"get_next_pending failed with UnicodeEncodeError: {e}")
 
+    # 3. Lookups by id feed /api/queue/download and /api/queue/upload —
+    #    an escaped path there means os.path.exists() misses the file.
+    assert store.get_job(job_id)["file_path"] == surrogate_path
+    assert store.get_queue_status()[0]["file_path"] == surrogate_path
+
 def test_thumbnail_hashing_handles_surrogates():
     from arcade_scanner.core.video_processor import create_thumbnail
 


### PR DESCRIPTION
## Warum

Der Offloading-Pfad (Server-Queue → `scripts/mac_worker.py` → Recompress → Upload) funktionierte im Prinzip noch, hatte aber drei Bugs, die ihn im Alltag zuverlässig blockieren, plus mehrere Härtungslücken.

## Die drei scharfen Kanten

1. **Kein Re-Login.** `WorkerClient._login()` lief nur im Konstruktor, Sessions liegen rein im RAM (`security/auth.py`). Nach jedem Server-Neustart lief der Worker endlos in `✗ Poll error: 401`. Seit `c1caa24` (`require_auth` auf allen Queue-Endpunkten) war ein Worker ohne `--user` komplett tot — genau so stand das Beispiel aber noch in `dev-docs/video-optimizer.md` und im Settings-Hinweis.
2. **>100 Jobs = deterministischer 404.** Download/Upload suchten die `job_id` in `get_queue_status(limit=100)` (aktiv zuerst, dann `created_at DESC`), während `get_next_pending` den *ältesten* Job claimt. Ein Lookup per ID fehlte im Store.
3. **Surrogat-Pfade.** `get_queue_status` gab `file_path` ohne `_decode_safe_path` zurück — Down-/Upload fanden die Datei nicht (dieselbe Klasse wie in `a3f322b`).

## Weitere Fixes

- **Stale-Reclaim + Heartbeat:** Jobs ohne Lebenszeichen werden nach 15 min neu eingereiht (3 Versuche, dann `failed`). Bisher blockierte ein abgestürzter Worker die Datei dauerhaft, weil `queue_encode` sie als „noch aktiv" ansah.
- **Cancel-Race:** `update_job_status(guard_active=True)` kann `cancelled` nicht mehr überschreiben; `/api/queue/check` meldet auch gelöschte Jobs als abgebrochen; `check_cancelled` unterscheidet „nicht abgebrochen" von „konnte nicht nachfragen".
- **Stale Output:** pro Job ein eigenes `work_dir/job_<id>/`; der Fallback, der eine alte `_opt.mp4` als Erfolg hochlud, ist entfernt.
- **Upload:** Streaming statt `f.read()` (kein Multi-GB-RAM-Peak), serverseitig Größenlimit, Vollständigkeits- und Integritätsprüfung (neues `arcade_scanner/core/media_replace.py`: ffprobe-Dauer + strikter Decode) vor dem `os.replace`, das auch Cross-Filesystem-Moves verweigert.
- **Standard-Mode-Upload** ersetzt das Original jetzt atomar und schreibt dessen DB-Zeile um, statt nur eine `_opt.mp4` danebenzulegen (`.mkv` → `.mp4` inklusive Aufräumen).
- **Tote Duplikate** der Queue-Routen in `api_handler.py` entfernt — unerreichbar, ohne `require_auth`, mit den alten Bugs.
- `saved_bytes` wird bei Zwischenstatus nicht mehr auf 0 gesetzt.

## Neu: Fortschrittsanzeige

`process_file(..., progress_callback=)` feuert aus dem ffmpeg-Reader-Loop in lokalen State; ein Daemon-Thread im Worker POSTet alle 10 s an das neue `POST /api/queue/progress`, das gleichzeitig der Cancel-Kanal ist. Die Queue-Ansicht zeigt Balken, Phase, Restzeit und Worker; Poll-Takt 2 s bei aktiven Jobs, sonst 10 s.

Die Prozentangabe gilt bewusst **pro Encode-Pass** — die Qualitätssuche startet den Balken mehrfach neu, deshalb steht die Phase daneben. Eine über alle Binary-Search-Pässe normalisierte Zahl wäre geraten.

## Verifikation

- `pytest`: **791 grün** (vorher 745), +46 neue Tests. Neu: `tests/test_mac_worker.py` (das Modul hatte bislang null Tests) und `tests/test_media_replace.py`.
- End-to-End gegen die echten Routen und den echten Store mit ffmpeg-Dateien: claim → download (200) → progress → upload → `clip.mkv` ist durch `clip.mp4` ersetzt, DB-Zeile umgeschrieben (`Status=OK`, `codec=hevc`, `optimized_at`), keine `.part`-Reste. Review-Mode ebenso.
- **Nicht automatisiert prüfbar:** der Encode auf echter Mac-Hardware und das reale Heartbeat-Timing. Manuell: Worker starten, Server mitten im Job neu starten (muss sich neu anmelden), `kill -9` auf den Worker (Job fällt nach ~15 min auf `pending`), Cancel während des Encodes.

## Bewusst nicht enthalten

Kein persistenter Session-Store, kein Shared-Mount-Modus (Transfer sparen), kein sha256-Roundtrip-Check, kein Upload-Resume, kein Refactoring von `video_optimizer.py` ins Paket (muss standalone auf dem Mac laufen — die Integritätslogik ist dokumentiert dupliziert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)