### PR TITLE
feat(stream): proxy streaming for clients outside the LAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Proxy Streaming**: Every video may have a smaller copy in its own directory
+  tree, which is excluded from scans. `/stream` decides per request which file to
+  serve — the original on the LAN, the proxy over Tailscale (CGNAT
+  `100.64.0.0/10` and `fd7a:115c:a1e0::/48`), falling back to the original when no
+  proxy exists. The library still shows exactly one entry per video, and originals
+  are never modified. Controlled through `proxy_streaming` / `proxy_root` in the
+  Settings UI; `?proxy=0` and `?proxy=1` override the automatic choice, and the
+  response carries `X-Arcade-Variant`. New: `core/proxy_resolver.py`,
+  `core/master_detect.py` (identifies raw camera material by folder, keyword,
+  camera filename scheme and device name, so proxies are built from edits rather
+  than from source footage) and `scripts/generate_proxies.py` (creates the proxies
+  on a remote NVENC machine, reading originals only).
+
+### Fixed
+- `do_HEAD` split the stream path with `split("path=")`, so any appended query
+  parameter ended up inside the filename. Now uses `parse_qs` like `do_GET`.
+
 ### Changed
 - **Einheitliches Design System**: Die drei Themes (Arcade/Professional/Candy)
   sind durch *ein* dark-first Theme mit genau einem Brand-Accent (Magenta

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -61,6 +61,7 @@ docker run -d \
 | `/media` | Media library | ✅ Yes | Mount your video/image folders here (read-only recommended) |
 | `/config` | Persistent data | ✅ Yes | Databases, settings, user data |
 | `/cache` | Thumbnails/previews | ⚠️ Recommended | Can be regenerated but slow |
+| `/proxies` | Proxy files for remote streaming | ⚪ Optional | Must be writable. Only needed when `proxy_root` is set — see [Proxy Streaming](dev-docs/proxy-streaming.md) |
 
 **Example with multiple media directories:**
 ```yaml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Arcade Media Scanner is a self-hosted media inventory tool that turns your local
 - **Smart Filtering**: Filter by codec (H.264 vs HEVC), bitrate, file size, media type, and image formats.
 - **The Vault**: Mark videos as "Archived" to keep your main lobby clean while maintaining a record of all your media.
 - **GPU-Powered Optimization**: Cross-platform hardware acceleration (NVIDIA, Apple VideoToolbox, Intel/AMD VAAPI) reduces file sizes by 50-80% with minimal quality loss.
+- **Proxy Streaming**: Serves a smaller copy to clients outside your LAN, so high-bitrate camera files stay watchable on the road — originals untouched, no duplicate library entries.
 
 ---
 
@@ -148,6 +149,40 @@ The tool includes a specialized cross-platform video optimizer (`scripts/video_o
 
 ---
 
+## 📡 Proxy Streaming
+
+Camera source files run at 60-600 Mbit/s. No mobile connection plays that, and a small
+server cannot transcode 4K on the fly. Proxy streaming pre-computes a smaller copy and
+serves it **only** to clients outside your LAN:
+
+- **Originals are never modified** — the generator reads them, nothing in the serving path writes.
+- **No duplicate entries**: the proxy directory is excluded from scans automatically.
+- **Invisible to clients**: browser, TV and iOS clients keep requesting the original path.
+- **Fail safe**: no proxy, feature off, or bad config → the original is served as before.
+
+Clients on `10/8`, `172.16/12`, `192.168/16` and loopback count as local; Tailscale
+(`100.64.0.0/10`) and any public address count as remote. Override per request with
+`?proxy=1` / `?proxy=0`; the response carries `X-Arcade-Variant: proxy|original`.
+
+Set `proxy_root` in the Settings UI to switch it on — leaving it empty disables the
+feature entirely. Generate the files on a machine with an NVIDIA GPU:
+
+```bash
+# Preview which files would get a proxy
+python3 scripts/generate_proxies.py --remote gpubox --dry-run
+
+# Scanner in Docker: map each mounted media directory to its host path
+python3 scripts/generate_proxies.py --remote gpubox --mount /media=/srv/media
+```
+
+Camera source files are detected and skipped automatically (folder names, keywords,
+and camera filename schemes like `IMG_1234` / `DSCF0480` / `L1000689`), so proxies are
+built from your edits rather than from raw footage.
+
+📖 **[Full Proxy Streaming Reference →](dev-docs/proxy-streaming.md)**
+
+---
+
 ## ⚙️ Configuration
 
 All settings can be configured through the **Settings UI** (gear icon) or by editing `arcade_data/settings.json`.
@@ -156,6 +191,7 @@ All settings can be configured through the **Settings UI** (gear icon) or by edi
 - **Scan targets**: Directories to scan.
 - **enable_optimizer**: Master toggle for optimization features (true/false).
 - **Custom exclusions**: Paths to skip.
+- **proxy_streaming** / **proxy_root**: Proxy streaming for remote clients. Empty `proxy_root` disables it.
 
 ### Default Exclusions
 | Platform | Excluded Directories |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,13 @@ This document outlines planned features and improvements for the Arcade Media Sc
 
 ## Completed Features
 
+### ✅ Proxy Streaming — the library on the road (2026-08-16)
+- **Per-request switching**: `/stream` serves the original on the LAN and a smaller proxy over Tailscale; without a proxy always the original. `?proxy=0/1` overrides, `X-Arcade-Variant` reports the choice.
+- **One entry per video**: the proxy tree lives outside the library and is excluded from the scan paths automatically — no duplicates, originals stay untouched.
+- **Raw material detection**: `core/master_detect.py` tells camera source files from edited versions using folders, keywords, camera filename schemes and device names.
+- **Generator**: `scripts/generate_proxies.py` encodes on a remote NVENC machine, reads originals only and is resumable.
+- Open: a `--local` mode for a GPU in the same machine; automatic refresh when an original changes.
+
 ### ✅ Embedding Foundation — Ähnlichkeit Teil 1 (2026-08-08)
 - **Vektor-Speicher**: `embedding_meta`/`frame_embeddings` in SQLite, float32-Blobs, L2-normalisiert.
 - **GPU-Indexer**: eigenständiges Skript mit optionalen ML-Deps (`[indexer]`), inkrementell.

--- a/arcade_scanner/config.py
+++ b/arcade_scanner/config.py
@@ -120,6 +120,10 @@ DEFAULT_SETTINGS_JSON = {
     "precompute_thumbnails": True,
     "_comment_review_dir": "Fixed location for review files. If empty, uses the default arcade_data/review.",
     "review_dir": "",
+    "_comment_proxy_streaming": "Serve a smaller proxy file instead of the original when streaming from outside the LAN.",
+    "proxy_streaming": True,
+    "_comment_proxy_root": "Absolute directory holding the proxy files (mirrors the original paths). Empty = feature off. Automatically excluded from scans.",
+    "proxy_root": "",
     "_comment_verbose_scanning": "Show individual file analysis logs during scan. If disabled, only shows progress summary.",
     "verbose_scanning": False,
     "_comment_concurrency": "Performance Limits for small servers.",
@@ -161,6 +165,8 @@ class AppSettings(BaseSettings):
     precompute_thumbnails: bool = Field(True)
     enable_review_mode: bool = Field(False)
     review_dir: str = Field("")
+    proxy_streaming: bool = Field(True)
+    proxy_root: str = Field("")
     verbose_scanning: bool = Field(False)
     max_concurrent_video_scans: int = Field(2)
     max_concurrent_image_scans: int = Field(5)
@@ -296,6 +302,12 @@ class ConfigManager:
         Returns unique exclude paths from ALL users + defaults.
         """
         excludes = set(self.default_exclusions) # Start with defaults!
+
+        # The proxy tree mirrors originals that are already in the library.
+        # Excluding it here (instead of relying on the user to configure it)
+        # is what keeps every video a single entry instead of a duplicate.
+        if self.settings.proxy_root:
+            excludes.add(self.settings.proxy_root)
 
         try:
             from arcade_scanner.database.user_store import user_db

--- a/arcade_scanner/core/master_detect.py
+++ b/arcade_scanner/core/master_detect.py
@@ -1,0 +1,154 @@
+"""Detects raw material (masters) and tells it apart from edited versions.
+
+Why: proxy files are generated for streaming from outside the LAN. Camera source
+files should be skipped there — they are never watched on the road, but they are
+by far the largest material.
+
+A single naming convention cannot be relied upon. Grown libraries contain
+"source_muc_DSCF3041.MOV" next to "IMG_2058.MOV" next to "iphone2.MOV". Hence
+several signals, and raw material is detected POSITIVELY:
+
+    folder        source/, originals/, raw/, src/, master/, source videos/
+    keyword       source, master, untouched (including the typo "ontouched")
+    camera scheme IMG_1234, DSCF0480, L1000689, GX010740, A001_..._C006, UUIDs
+    device name   iphone.MOV, iphone2.MOV, gopro.mp4
+
+Everything else counts as an edit. The reasoning: cameras assign schematic names.
+A descriptive name was typed by a human — and humans name what they exported, not
+what fell out of the camera.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+MASTER = "master"
+EDIT = "edit"
+UNCLEAR = "unclear"
+
+MASTER_DIRS = re.compile(
+    r"^(sources?|originals?|src|raw|master|source videos?|rohmaterial)$", re.I
+)
+
+MASTER_WORDS = re.compile(
+    r"\b(source|src|master|untouched|ontouched|unbearbeitet|unedited|original)\b",
+    re.I,
+)
+
+# Source terms glued to a device name without a separator: "Fujisource.MOV".
+# Deliberately a substring match — a media library contains no "resource" or
+# "outsource", and the error cost is small either way: at worst a proxy is not
+# created, which can be added later at any time.
+CONCAT_MASTER = re.compile(r"(source|master|untouched|unbearbeitet|rohmaterial)", re.I)
+
+# Camera-generated filenames — the strongest signal, because it works without
+# any naming discipline on the user's part.
+CAMERA_PATTERNS: List[Tuple[re.Pattern, str]] = [
+    (re.compile(r"^IMG_\d{3,5}$", re.I), "iPhone/iPad"),
+    (re.compile(r"^DSCF\d{3,5}$", re.I), "Fujifilm"),
+    (re.compile(r"^L\d{6,8}$", re.I), "Leica"),
+    (re.compile(r"^GX\d{6}$", re.I), "GoPro"),
+    (re.compile(r"^A\d{3}_\d{6,10}_C\d{3}$", re.I), "Cine-Cam"),
+    (re.compile(r"^MVI_\d{3,5}$", re.I), "Canon"),
+    (re.compile(r"^DJI_\d{3,5}$", re.I), "DJI"),
+    (re.compile(r"^C\d{4}$", re.I), "Sony/Cine"),
+    (re.compile(
+        r"^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$", re.I
+    ), "iOS export (UUID)"),
+]
+
+# Manually renamed raw material: the name is just the recording device.
+DEVICE_ONLY = re.compile(
+    r"^(iphone|ipad|gopro|fuji|fujifilm|leica|sony|canon|dji|cam|kamera|camera|a7|gh5)"
+    r"[ _-]?\d*$",
+    re.I,
+)
+
+EDIT_WORDS = re.compile(
+    r"\b(final|finalized|cut|graded|grading|timeline|projekt|project|sequenz|sequence|"
+    r"outtakes?|trailer|resized|cropped|export|edit|opt|full ?video|clip)\b",
+    re.I,
+)
+
+# Edit terms without a word boundary, because they are written as one word.
+CONCAT_EDIT = re.compile(
+    r"(firstcut|finalcut|roughcut|precut|4kcut|timeline|fullclip)", re.I
+)
+
+YEAR_FOLDER = re.compile(r"(19|20)\d{2}")
+
+
+def _normalize(text: str) -> str:
+    r"""Turn separators into spaces.
+
+    Necessary because ``\b`` does NOT match between "_" and a letter — "_" counts
+    as a word character. Without this, "05_2025_Session_Final" would score no hit.
+    """
+    return re.sub(r"[_\-.]+", " ", text)
+
+
+def session_of(rel_path: str) -> str:
+    """The dated project folder a file belongs to.
+
+    Everything below it (originals/, hdr final/, sdr/, video/) are variants of the
+    SAME session. Without this grouping a pure originals/ folder would look like a
+    session with no edited version at all.
+    """
+    dirs = rel_path.replace("\\", "/").split("/")[:-1]
+    for i in range(len(dirs) - 1, -1, -1):
+        if YEAR_FOLDER.search(dirs[i]):
+            return "/".join(dirs[: i + 1])
+    while dirs and MASTER_DIRS.match(dirs[-1].strip()):
+        dirs = dirs[:-1]
+    return "/".join(dirs)
+
+
+def classify(rel_path: str) -> Tuple[str, List[str]]:
+    """(verdict, reasons) for a path. Verdict: master | edit | unclear."""
+    parts = rel_path.replace("\\", "/").split("/")
+    dirs, filename = parts[:-1], parts[-1]
+    stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+
+    reasons: List[str] = []
+    # Signals on the FILENAME beat an edit keyword: someone who deliberately
+    # names a file "source_fullclip_4k60.mov" has made a decision.
+    strong = False
+
+    for d in dirs:
+        if MASTER_DIRS.match(d.strip()):
+            reasons.append(f'folder "{d}"')
+
+    if MASTER_WORDS.search(_normalize(stem)) or CONCAT_MASTER.search(stem):
+        reasons.append("source keyword in the name")
+        strong = True
+
+    for pattern, label in CAMERA_PATTERNS:
+        if pattern.match(stem.strip()):
+            reasons.append(f"camera filename ({label})")
+            strong = True
+            break
+
+    if DEVICE_ONLY.match(stem.strip()):
+        reasons.append("name is just the recording device")
+        strong = True
+
+    edited = (
+        bool(EDIT_WORDS.search(_normalize(stem)))
+        or bool(CONCAT_EDIT.search(stem))
+        or any(EDIT_WORDS.search(_normalize(d)) for d in dirs)
+    )
+
+    if reasons and edited and not strong:
+        # Only the folder says "source" while the name says "final" — genuinely
+        # ambiguous, a human has to decide.
+        return UNCLEAR, reasons + ["also carries an edit keyword"]
+    if reasons:
+        return MASTER, reasons
+    if edited:
+        return EDIT, ["edit keyword"]
+    return EDIT, ["named by hand (no camera scheme)"]
+
+
+def is_master(rel_path: str) -> bool:
+    return classify(rel_path)[0] == MASTER

--- a/arcade_scanner/core/proxy_resolver.py
+++ b/arcade_scanner/core/proxy_resolver.py
@@ -1,0 +1,169 @@
+"""Proxy resolution for streaming.
+
+Idea: next to the original file there may be a smaller, streaming-friendly copy
+(a "proxy") — in its own directory tree that is excluded from scans. The library
+therefore still shows exactly one entry per video, and the original is never
+touched.
+
+On each request the server decides which file to send:
+
+    client on the LAN      -> original (full quality at the desk)
+    client via Tailscale   -> proxy, if one exists (on the road)
+    no proxy available     -> original
+
+Clients notice none of this: they always request the original path.
+
+Path mapping — the complete original path is mirrored below the proxy root so
+that files from different mounts cannot collide:
+
+    original:  /media/shoots/2024_01/foo.MOV
+    proxy:     <proxy_root>/media/shoots/2024_01/foo.mp4
+
+Security: the ORIGINAL path from the request is validated by the caller before
+anything here runs. The proxy path is derived from it and never comes from the
+request, so it needs no second whitelist pass.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from typing import Optional, Tuple
+
+# Proxies are always stored as MP4: playable by iOS, Safari and the TV clients
+# without another transcode.
+PROXY_EXTENSION = ".mp4"
+
+# Tailscale hands out addresses from the CGNAT range (IPv4) and from a fixed ULA
+# prefix (IPv6). Either one means: not on the home network.
+_TAILSCALE_NETS = (
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("fd7a:115c:a1e0::/48"),
+)
+
+
+def get_proxy_root() -> str:
+    """Configured proxy root, or "" when the feature is off."""
+    try:
+        from arcade_scanner.config import config
+        return (config.settings.proxy_root or "").strip()
+    except Exception:
+        return ""
+
+
+def is_proxy_streaming_enabled() -> bool:
+    try:
+        from arcade_scanner.config import config
+        return bool(config.settings.proxy_streaming) and bool(get_proxy_root())
+    except Exception:
+        return False
+
+
+def proxy_path_for(original_path: str, proxy_root: Optional[str] = None) -> str:
+    """Path of the proxy file for an original. Does NOT check whether it exists.
+
+    Returns "" when no proxy root is configured, or when the original already
+    lives inside the proxy tree (no proxy of a proxy).
+    """
+    root = proxy_root if proxy_root is not None else get_proxy_root()
+    if not root or not original_path:
+        return ""
+
+    abs_root = os.path.abspath(root)
+    abs_orig = os.path.abspath(original_path)
+
+    if abs_orig == abs_root or abs_orig.startswith(abs_root + os.sep):
+        return ""
+
+    # Strip the drive letter (Windows) and any leading separator, otherwise
+    # os.path.join treats the path as absolute and discards the root.
+    relative = os.path.splitdrive(abs_orig)[1].lstrip("/\\")
+    stem, _ = os.path.splitext(relative)
+    return os.path.join(abs_root, stem + PROXY_EXTENSION)
+
+
+def has_proxy(original_path: str, proxy_root: Optional[str] = None) -> bool:
+    candidate = proxy_path_for(original_path, proxy_root)
+    return bool(candidate) and os.path.isfile(candidate)
+
+
+def is_remote_client(client_ip: str) -> bool:
+    """True when the request does not come from the home network.
+
+    Unknown addresses count as remote on purpose: serving a proxy by mistake
+    costs picture quality, serving a 600 Mbit original by mistake costs playback.
+    """
+    if not client_ip:
+        return True
+
+    try:
+        ip = ipaddress.ip_address(client_ip.strip().strip("[]"))
+    except ValueError:
+        return True
+
+    # Unwrap IPv4-mapped IPv6 addresses (::ffff:192.168.2.10).
+    if getattr(ip, "ipv4_mapped", None):
+        ip = ip.ipv4_mapped
+
+    if any(ip in net for net in _TAILSCALE_NETS):
+        return True
+
+    if ip.is_loopback or ip.is_private or ip.is_link_local:
+        return False
+
+    return True
+
+
+def parse_override(raw: Optional[str]) -> Optional[bool]:
+    """Evaluate the `?proxy=` parameter. None = no preference, decide normally."""
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off"):
+        return False
+    return None
+
+
+def resolve_stream_path(
+    original_path: str,
+    client_ip: str = "",
+    override: Optional[bool] = None,
+) -> Tuple[str, str]:
+    """Decide which file to serve.
+
+    Returns (path to serve, variant) where variant is "proxy" or "original" and
+    ends up in the response as the `X-Arcade-Variant` header.
+    """
+    if override is False:
+        return original_path, "original"
+
+    if not is_proxy_streaming_enabled():
+        return original_path, "original"
+
+    # override is True  -> force the proxy (when one exists)
+    # override is None  -> only switch to the proxy for remote clients
+    if override is not True and not is_remote_client(client_ip):
+        return original_path, "original"
+
+    candidate = proxy_path_for(original_path)
+    if candidate and os.path.isfile(candidate):
+        return candidate, "proxy"
+
+    return original_path, "original"
+
+
+def client_ip_from_handler(handler) -> str:
+    """Extract the client IP from the request (honouring X-Forwarded-For).
+
+    XFF is forgeable — harmless here, because the worst outcome is a different
+    quality tier of a file the caller may already access.
+    """
+    forwarded = (handler.headers.get("X-Forwarded-For") or "").split(",")[0].strip()
+    if forwarded:
+        return forwarded
+    try:
+        return handler.client_address[0]
+    except (AttributeError, IndexError):
+        return ""

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -26,6 +26,11 @@ from arcade_scanner.server.response_helpers import (
     send_json,
     send_not_modified_if_unchanged,
 )
+from arcade_scanner.core.proxy_resolver import (
+    client_ip_from_handler,
+    parse_override,
+    resolve_stream_path,
+)
 from arcade_scanner.server.streaming_util import serve_file_range
 from arcade_scanner.templates.dashboard_template import generate_html_report
 
@@ -656,7 +661,16 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
                         self.send_error(403, error_msg)
                         return
 
-                    serve_file_range(self, file_path, method="GET")
+                    # Proxy selection AFTER the whitelist check: what gets
+                    # validated is always the original path. The proxy path is
+                    # derived from it and never comes from the request.
+                    serve_path, variant = resolve_stream_path(
+                        file_path,
+                        client_ip=client_ip_from_handler(self),
+                        override=parse_override(params.get("proxy", [None])[0]),
+                    )
+                    serve_file_range(self, serve_path, method="GET",
+                                     extra_headers={"X-Arcade-Variant": variant})
                 except SecurityError as e:
                     print(f"🚨 Security violation in stream: {e}")
                     self.send_error(403, "Forbidden")
@@ -850,7 +864,15 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
                     self.send_error(403, "Forbidden")
                     return
 
-                serve_file_range(self, file_path, method="HEAD")
+                # Must reach the same decision as do_GET — otherwise HEAD
+                # reports the original's size while GET serves the proxy.
+                serve_path, variant = resolve_stream_path(
+                    file_path,
+                    client_ip=client_ip_from_handler(self),
+                    override=parse_override(params.get("proxy", [None])[0]),
+                )
+                serve_file_range(self, serve_path, method="HEAD",
+                                 extra_headers={"X-Arcade-Variant": variant})
 
             else:
                 self.send_error(405)

--- a/arcade_scanner/server/api_handler.py
+++ b/arcade_scanner/server/api_handler.py
@@ -836,7 +836,14 @@ class FinderHandler(http.server.SimpleHTTPRequestHandler):
     def do_HEAD(self):
         try:
             if self.path.startswith("/stream?path="):
-                file_path = unquote(self.path.split("path=")[1])
+                # parse_qs instead of split("path="): otherwise any further
+                # query parameter ends up inside the file path.
+                params = parse_qs(urlparse(self.path).query)
+                file_path = params.get("path", [None])[0]
+
+                if not file_path:
+                    self.send_error(400, "Missing path parameter")
+                    return
 
                 # Security: Validate path
                 if not is_path_allowed(file_path):

--- a/arcade_scanner/server/static/settings.js
+++ b/arcade_scanner/server/static/settings.js
@@ -48,6 +48,12 @@ async function openSettings() {
         const precomputeThumbsCheckbox = document.getElementById('settingsPrecomputeThumbs');
         if (precomputeThumbsCheckbox) precomputeThumbsCheckbox.checked = data.precompute_thumbnails !== false;
 
+        const proxyStreamingCheckbox = document.getElementById('settingsProxyStreaming');
+        if (proxyStreamingCheckbox) proxyStreamingCheckbox.checked = data.proxy_streaming !== false;
+
+        const proxyRootInput = document.getElementById('settingsProxyRoot');
+        if (proxyRootInput) proxyRootInput.value = data.proxy_root || '';
+
         const verboseScanningCheckbox = document.getElementById('settingsVerboseScanning');
         if (verboseScanningCheckbox) verboseScanningCheckbox.checked = data.verbose_scanning === true;
 
@@ -141,6 +147,8 @@ async function saveSettings() {
         enable_image_scanning: document.getElementById('settingsScanImages')?.checked || false,
         encoding_preset: document.getElementById('settingsEncodingPreset')?.value || 'balanced',
         precompute_thumbnails: document.getElementById('settingsPrecomputeThumbs')?.checked ?? true,
+        proxy_streaming: document.getElementById('settingsProxyStreaming')?.checked ?? true,
+        proxy_root: (document.getElementById('settingsProxyRoot')?.value ?? '').trim(),
         verbose_scanning: document.getElementById('settingsVerboseScanning')?.checked || false
     };
 

--- a/arcade_scanner/server/streaming_util.py
+++ b/arcade_scanner/server/streaming_util.py
@@ -83,14 +83,21 @@ def _send_file_slice(handler, file_path, start, length):
             remaining -= len(data)
 
 
-def serve_file_range(handler, file_path, method="GET"):
+def serve_file_range(handler, file_path, method="GET", extra_headers=None):
     """
     Standard implementation of HTTP Range Requests (Status 206).
     Allows browsers to seek and buffer videos efficiently.
+
+    extra_headers: optional dict of additional response headers, sent on every
+    response variant (200/206/416) — used to expose which file was served.
     """
     if not os.path.exists(file_path):
         handler.send_error(404)
         return
+
+    def _send_extra():
+        for key, value in (extra_headers or {}).items():
+            handler.send_header(key, value)
 
     stat = os.stat(file_path)
     file_size = stat.st_size
@@ -104,6 +111,7 @@ def serve_file_range(handler, file_path, method="GET"):
         handler.send_response(416)
         handler.send_header("Content-Range", f"bytes */{file_size}")
         handler.send_header("Content-Length", "0")
+        _send_extra()
         handler.end_headers()
         return
 
@@ -119,6 +127,7 @@ def serve_file_range(handler, file_path, method="GET"):
         handler.send_header("Content-Range", f"bytes {start}-{end}/{file_size}")
         handler.send_header("Content-Length", str(length))
         handler.send_header("Last-Modified", handler.date_time_string(stat.st_mtime))
+        _send_extra()
         handler.end_headers()
 
         if method == "GET":
@@ -132,6 +141,7 @@ def serve_file_range(handler, file_path, method="GET"):
     handler.send_header("Content-Length", str(file_size))
     handler.send_header("Accept-Ranges", "bytes")
     handler.send_header("Last-Modified", handler.date_time_string(stat.st_mtime))
+    _send_extra()
     handler.end_headers()
     if method == "GET":
         _send_file_slice(handler, file_path, 0, file_size)

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -1744,6 +1744,33 @@ SETTINGS_MODAL_COMPONENT = """
                     <section class="space-y-4">
                         <div>
                             <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
+                                <span class="material-icons text-lg text-accent">travel_explore</span>
+                                Proxy Streaming
+                            </h3>
+                            <p class="text-[12px] text-text-muted mt-1">Serve a smaller copy when streaming from outside your LAN, so high-bitrate originals stay playable on the road. Originals are never modified.</p>
+                        </div>
+
+                        <div class="ds-settings-card flex items-center justify-between gap-4">
+                            <div class="flex-1">
+                                <div class="text-white font-medium text-sm">Use proxies for remote clients</div>
+                                <div class="text-xs text-gray-500 mt-0.5">Clients on the local network keep getting the original.</div>
+                            </div>
+                            <label class="relative inline-flex items-center cursor-pointer">
+                                <input type="checkbox" id="settingsProxyStreaming" class="sr-only peer" onchange="markSettingsUnsaved()">
+                                <div class="ds-peer-switch"></div>
+                            </label>
+                        </div>
+
+                        <div>
+                            <label class="block text-xs font-medium text-white mb-2">Proxy Directory</label>
+                            <input type="text" id="settingsProxyRoot" placeholder="/proxies" class="w-full bg-surface border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-accent focus:outline-none" oninput="markSettingsUnsaved()">
+                            <p class="text-xs text-gray-500 mt-1">Absolute path. Leave empty to disable proxy streaming entirely. The directory is excluded from scans automatically, so proxies never appear as duplicate entries. Generate the files with <code>scripts/generate_proxies.py</code>.</p>
+                        </div>
+                    </section>
+
+                    <section class="space-y-4">
+                        <div>
+                            <h3 class="text-[16px] font-bold text-text-main flex items-center gap-2">
                                 <span class="material-icons text-lg text-accent">tune</span>
                                 Encoding Quality
                             </h3>

--- a/dev-docs/proxy-streaming.md
+++ b/dev-docs/proxy-streaming.md
@@ -1,0 +1,224 @@
+# Proxy Streaming — Technical Deep-Dive
+
+> `arcade_scanner/core/proxy_resolver.py` · `core/master_detect.py` · `scripts/generate_proxies.py`
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Path Mapping](#path-mapping)
+4. [Location Detection](#location-detection)
+5. [Master Detection](#master-detection)
+6. [Configuration](#configuration)
+7. [CLI Reference — generate_proxies.py](#cli-reference--generate_proxiespy)
+8. [Known Limitations](#known-limitations)
+
+---
+
+## Overview
+
+Camera source files are unstreamable over a mobile link. A 4K clip straight out of a
+Leica or an iPhone runs at 60–600 Mbit/s; no cellular connection plays that, and a
+weak server cannot transcode it on the fly either.
+
+Proxy streaming solves this without touching the library: a smaller copy of a video
+may live in a separate directory tree, and `/stream` decides **per request** which
+file to send.
+
+**Key design goals:**
+
+- **Originals are never modified.** The generator only reads them. Nothing in the
+  serving path writes.
+- **No duplicate entries.** The proxy tree is excluded from scans automatically, so
+  every video stays a single row in the library.
+- **Invisible to clients.** Browser, TV and iOS clients keep requesting the original
+  path. No client change was needed.
+- **Fail safe.** No proxy, unreadable config, feature off → the original is served,
+  exactly as before.
+- **Zero cost when unused.** Leaving `proxy_root` empty short-circuits the resolver
+  before it touches the filesystem.
+
+---
+
+## Architecture
+
+```
+GET /stream?path=/media/shoots/2024_01/clip.MOV
+      │
+      ├─ authentication                       (unchanged)
+      ├─ is_path_allowed(path)                (unchanged — checks the ORIGINAL)
+      │
+      ├─ resolve_stream_path(path, client_ip, override)
+      │     │
+      │     ├─ override is False ──────────────────────────► original
+      │     ├─ feature disabled (no proxy_root) ───────────► original
+      │     ├─ override is not True and client is on LAN ──► original
+      │     ├─ proxy file does not exist ──────────────────► original
+      │     └─ otherwise ──────────────────────────────────► proxy
+      │
+      └─ serve_file_range(chosen, extra_headers={"X-Arcade-Variant": …})
+             HTTP 200 / 206 with byte ranges — seeking works on either file
+```
+
+The security check runs on the path **from the request**. The proxy path is derived
+from that already-validated path and never comes from user input, so it needs no
+second whitelist pass.
+
+`do_GET` and `do_HEAD` must make the identical decision — a HEAD reporting the
+original's size followed by a GET serving the proxy breaks `AVPlayer` and several TV
+media pipelines. Both call the same resolver.
+
+---
+
+## Path Mapping
+
+The **complete** original path is mirrored below the proxy root, so files from
+different mounts cannot collide. The extension always becomes `.mp4`.
+
+| Original | Proxy (`proxy_root` = `/proxies`) |
+|---|---|
+| `/media/shoots/2024_01/clip.MOV` | `/proxies/media/shoots/2024_01/clip.mp4` |
+| `/archive/shoots/2024_01/clip.MOV` | `/proxies/archive/shoots/2024_01/clip.mp4` |
+| `/proxies/media/…/clip.mp4` | *(none — no proxy of a proxy)* |
+
+---
+
+## Location Detection
+
+`is_remote_client()` classifies the requesting address:
+
+| Address range | Verdict | Rationale |
+|---|---|---|
+| `10/8`, `172.16/12`, `192.168/16`, loopback, link-local | **local** | home network — full quality |
+| `100.64.0.0/10` | **remote** | Tailscale CGNAT |
+| `fd7a:115c:a1e0::/48` | **remote** | Tailscale IPv6 |
+| any other public address | **remote** | |
+| empty or unparseable | **remote** | see below |
+
+IPv4-mapped IPv6 addresses (`::ffff:192.168.2.10`) are unwrapped first.
+
+Unknown addresses deliberately fall to **remote**. The error costs are asymmetric: a
+wrongly served proxy costs picture quality, a wrongly served 600 Mbit original costs
+playback entirely.
+
+The address is taken from `X-Forwarded-For` when present, otherwise from the socket.
+XFF is forgeable — harmless here, since the worst outcome is a different quality tier
+of a file the caller may already access.
+
+Manual override per request: `?proxy=1` forces the proxy, `?proxy=0` forces the
+original. `?proxy=0` short-circuits before the configuration is consulted.
+
+---
+
+## Master Detection
+
+`generate_proxies.py` skips camera source files: they are the bulk of the storage and
+are not what you watch on the road. Filenames alone are not reliable in a grown
+library, so `core/master_detect.py` combines several signals and detects raw material
+**positively**:
+
+| Signal | Examples |
+|---|---|
+| Folder name | `source/`, `originals/`, `raw/`, `src/`, `master/`, `source videos/` |
+| Keyword in the name | `source`, `master`, `untouched`, `unbearbeitet` — including concatenations like `Fujisource.MOV` |
+| Camera filename scheme | `IMG_1234`, `DSCF0480`, `L1000689`, `GX010740`, `A001_01021446_C006`, `MVI_`, `DJI_`, `C0012`, iOS UUID names |
+| Device-only name | `iphone.MOV`, `iphone2.MOV`, `gopro.mp4` |
+
+Everything else counts as an edit. The reasoning: cameras assign schematic names, so a
+descriptive name was typed by a human — and humans name what they exported, not what
+fell out of the camera.
+
+Precedence rules:
+
+- A master signal **in the filename** beats an edit keyword. `source_fullclip_4k60.mov`
+  is raw material; the name was chosen deliberately.
+- A master signal from the **folder only**, combined with an edit keyword, yields
+  `unclear` — `source/fullclip_4k60.mov` needs a human decision.
+- Separators are normalised before matching, because `\b` does not match between `_`
+  and a letter. Without that, `05_2025_Session_Final.mov` would look unlabelled.
+
+Sessions are grouped by their dated project folder, so `originals/`, `hdr final/` and
+`sdr/` count as one shoot. That matters for `--no-orphan-masters`: raw material whose
+session contains nothing else playable still gets a proxy by default, otherwise there
+would be nothing to watch from that shoot at all.
+
+---
+
+## Configuration
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `proxy_streaming` | `true` | Master switch for the substitution |
+| `proxy_root` | `""` | Directory holding the proxies. **Empty disables the feature.** |
+
+Both are settable in the UI (Settings → Proxy Streaming), in `settings.json`, or via
+the environment (`ARCADE_PROXY_STREAMING`, `ARCADE_PROXY_ROOT`).
+
+`proxy_root` is added to the scan exclusions automatically in
+`config.active_exclude_paths`, so the proxies never enter the library.
+
+Response header `X-Arcade-Variant: proxy|original` reports what was served — useful
+for verifying the behaviour from a phone.
+
+---
+
+## CLI Reference — `generate_proxies.py`
+
+Runs on the scanner host, encodes on a remote machine with an NVIDIA GPU:
+
+```
+Original --rsync--> remote --ffmpeg/NVENC--> remote --rsync--> proxy tree
+```
+
+Originals are only read. Writes happen below `--proxy-root` and only after a complete
+transfer (download to `.part`, then rename), so an abort never leaves a truncated file
+that the server would then serve.
+
+The run is resumable — existing proxies are skipped.
+
+```bash
+# Scanner without Docker: database paths are already host paths
+python3 scripts/generate_proxies.py --remote gpubox --dry-run
+
+# Scanner in Docker: map each mounted media directory
+python3 scripts/generate_proxies.py --remote gpubox \
+    --mount /media=/srv/media --mount /photos=/srv/photos \
+    --tree /media/clips/ --limit 3
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--remote` | *required* | SSH target of the GPU machine |
+| `--remote-dir` | `~/arcade-proxy-work` | Work directory there; needs room for the largest file |
+| `--mount CONTAINER=HOST` | *(none)* | Path translation, repeatable. Without it paths are assumed identical. |
+| `--proxy-root` | from settings | Destination tree |
+| `--tree` | `/` | Only files below this container path |
+| `--min-mbps` / `--max-mbps` | `20` / `100` | Bitrate window of the candidates |
+| `--height` | `1920` | Longest edge; landscape becomes 1920×1080, portrait 1080×1920 |
+| `--bitrate` | `6` | Target bitrate in Mbit/s |
+| `--exclude-file` | `arcade_data/proxy_exclude.txt` | Container paths that never get a proxy |
+| `--no-orphan-masters` | off | Skip raw material even when its session has no alternative |
+| `--limit` / `--force` / `--dry-run` | | Partial runs, re-encode, preview |
+
+Encoding: `hevc_nvenc`, preset `p5`, VBR with `-cq 28`, CUDA decode, AAC 128k stereo,
+`+faststart`. 10-bit sources stay 10-bit (`main10`/`p010le`) so HDR survives.
+
+---
+
+## Known Limitations
+
+1. **"LAN means home"** — on a VPS there is no private network, so every request
+   would be classified remote and get the proxy.
+2. **Unreadable addresses downgrade silently.** A malformed `X-Forwarded-For` yields a
+   proxy without any warning. Deliberate (see above), but worth knowing when the
+   server sits behind a reverse proxy.
+3. **`generate_proxies.py` requires a *remote* GPU.** A local GPU has no code path yet;
+   a `--local` mode would be the obvious addition.
+4. **No automatic invalidation.** Replacing an original does not refresh its proxy —
+   re-run with `--force` for those files.
+
+---
+
+*Last updated: proxy streaming v1 — resolver, master detection, remote NVENC generator.*

--- a/scripts/generate_proxies.py
+++ b/scripts/generate_proxies.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Generates proxy files for streaming from outside the LAN.
+
+RUNS ON: the scanner host (database, originals and proxy destination live there).
+ENCODES ON: the machine reachable via --remote that has an NVIDIA GPU.
+
+Per file:
+
+    original --rsync--> remote --ffmpeg/NVENC--> remote --rsync--> proxy tree
+
+Originals are READ ONLY. Writes happen exclusively below --proxy-root, and only
+after a complete transfer back (written under a temporary name, then renamed) —
+so an abort never leaves a half file behind that the server would then serve.
+
+The run is resumable: existing proxies are skipped.
+
+Scanner without Docker (database paths are already host paths):
+
+    python3 scripts/generate_proxies.py --remote gpubox --dry-run
+
+Scanner in Docker — the database only knows container paths, so supply one
+mapping per mounted media directory:
+
+    python3 scripts/generate_proxies.py --remote gpubox \\
+        --mount /media=/srv/media --mount /photos=/srv/photos \\
+        --tree /media/clips/ --limit 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from arcade_scanner.core.master_detect import MASTER, classify, session_of  # noqa: E402
+
+DEFAULT_DB = str(SCRIPT_DIR.parent / "arcade_data" / "media_library.db")
+
+G = "\033[92m"; Y = "\033[93m"; R = "\033[91m"; C = "\033[96m"; B = "\033[1m"; N = "\033[0m"
+
+
+def log(msg: str = "") -> None:
+    print(msg, flush=True)
+
+
+def human(num_bytes: float) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(num_bytes) < 1024:
+            return f"{num_bytes:.1f} {unit}"
+        num_bytes /= 1024
+    return f"{num_bytes:.1f} TB"
+
+
+def parse_mount(spec: str) -> tuple:
+    """--mount /in/container=/on/the/host"""
+    if "=" not in spec:
+        raise argparse.ArgumentTypeError(
+            f"--mount expects CONTAINER=HOST, got: {spec!r}")
+    container, host = spec.split("=", 1)
+    return container.rstrip("/"), host.rstrip("/")
+
+
+def to_host(container_path: str, mounts: dict) -> str | None:
+    """Translate a container path into the host path.
+
+    Without --mount (scanner not running in Docker) both paths are identical.
+    """
+    if not mounts:
+        return container_path
+    for prefix in sorted(mounts, key=len, reverse=True):
+        if container_path == prefix or container_path.startswith(prefix + "/"):
+            return mounts[prefix] + container_path[len(prefix):]
+    return None
+
+
+def configured_proxy_root() -> str:
+    """proxy_root from the scanner settings — the source of truth for it.
+
+    This is a CONTAINER path when the server runs in Docker, so it is translated
+    through --mount below.
+    """
+    try:
+        from arcade_scanner.config import config
+        return (config.settings.proxy_root or "").strip()
+    except Exception:
+        return ""
+
+
+def proxy_host_path(container_path: str, proxy_root: str) -> str:
+    """Zielpfad im Proxy-Baum — gleiche Abbildung wie core/proxy_resolver.py.
+
+    Der komplette Original-Pfad wird gespiegelt, damit Dateien aus
+    verschiedenen Mounts nicht kollidieren.
+    """
+    relative = container_path.lstrip("/")
+    stem, _ = os.path.splitext(relative)
+    return os.path.join(proxy_root, stem + ".mp4")
+
+
+# ── Candidate selection ─────────────────────────────────────────────────────
+
+def select_candidates(db_path, min_mbps, max_mbps, tree, include_orphans, excludes):
+    """Yields (container_path, bitrate, size_mb, duration, reason)."""
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(
+            "select file_path, bitrate_mbps, size_mb, duration_sec from media "
+            "where file_path like ? and media_type = 'video'",
+            (tree + "%",),
+        ).fetchall()
+    finally:
+        con.close()
+
+    prefix_len = len(tree.rstrip("/")) + 1
+
+    # Sessions that contain anything playable on the road at all.
+    playable_sessions = set()
+    for path, br, _size, _dur in rows:
+        rel = path[prefix_len:]
+        if classify(rel)[0] != MASTER or br < min_mbps:
+            playable_sessions.add(session_of(rel))
+
+    selected = []
+    for path, br, size, dur in rows:
+        if path in excludes:
+            continue
+        if not (min_mbps <= br < max_mbps):
+            continue
+
+        rel = path[prefix_len:]
+        verdict, _reasons = classify(rel)
+
+        if verdict != MASTER:
+            selected.append((path, br, size, dur, "edited version"))
+        elif include_orphans and session_of(rel) not in playable_sessions:
+            # Raw material, but its session has nothing else playable — without
+            # a proxy there would be nothing at all to watch from that shoot.
+            selected.append((path, br, size, dur, "raw material, no alternative"))
+
+    selected.sort(key=lambda r: r[2])  # smallest first: visible progress early on
+    return selected
+
+
+# ── Encoding ────────────────────────────────────────────────────────────────
+
+def build_ffmpeg_command(remote_in, remote_out, height, bitrate, ten_bit):
+    """ffmpeg invocation for the remote side (as a single shell line)."""
+    # Fits the image into a height x height box: landscape becomes 1920x1080,
+    # portrait becomes 1080x1920. force_divisible_by=2 because of 4:2:0.
+    scale = (f"scale=w={height}:h={height}"
+             ":force_original_aspect_ratio=decrease:force_divisible_by=2")
+
+    args = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-hwaccel", "cuda",              # decode on the GPU
+        "-i", remote_in,
+        "-vf", scale,
+        "-c:v", "hevc_nvenc",
+        "-preset", "p5",
+        "-tune", "hq",
+        "-rc", "vbr",
+        "-cq", "28",
+        "-b:v", f"{bitrate}M",
+        "-maxrate", f"{int(bitrate * 1.5)}M",
+        "-bufsize", f"{bitrate * 2}M",
+        # 10-bit sources stay 10-bit so that HDR is not destroyed.
+        "-profile:v", "main10" if ten_bit else "main",
+        "-pix_fmt", "p010le" if ten_bit else "yuv420p",
+        "-c:a", "aac", "-b:a", "128k", "-ac", "2",
+        "-movflags", "+faststart",       # starts without buffering the whole file
+        remote_out,
+    ]
+    return " ".join(shlex.quote(a) for a in args)
+
+
+def probe_is_ten_bit(path: str) -> bool:
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=pix_fmt", "-of", "csv=p=0", path],
+            capture_output=True, text=True, timeout=60,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    return any(tag in out for tag in ("p010", "10le", "10be", "yuv420p10"))
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, **kwargs)
+
+
+def process_one(item, args, index, total):
+    container_path, br, size_mb, dur, reason = item
+    host_src = to_host(container_path, args.mounts)
+    name = os.path.basename(container_path)
+
+    log(f"\n{B}[{index}/{total}]{N} {name}")
+    log(f"    {size_mb/1024:.2f} GB · {br:.0f} Mbit · {dur/60:.1f} min · {reason}")
+
+    if host_src is None:
+        log(f"    {R}✗ no host path for {container_path}{N}")
+        return "error"
+    if not os.path.isfile(host_src):
+        log(f"    {Y}⚠ original missing (renamed? rescan needed) — skipped{N}")
+        return "missing"
+
+    target = proxy_host_path(container_path, args.proxy_root)
+    if os.path.isfile(target) and not args.force:
+        log(f"    {C}→ proxy already exists, skipped{N}")
+        return "skipped"
+
+    if args.dry_run:
+        log(f"    {C}would create: {target}{N}")
+        return "dry"
+
+    remote_in = f"{args.remote_dir}/in_{index}{Path(name).suffix}"
+    remote_out = f"{args.remote_dir}/out_{index}.mp4"
+    started = time.time()
+
+    try:
+        run(["ssh", args.remote, f"mkdir -p {shlex.quote(args.remote_dir)}"], check=True)
+
+        log("    ↑ transferring to the GPU machine")
+        run(["rsync", "-a", "--partial", host_src, f"{args.remote}:{remote_in}"], check=True)
+
+        log("    ⚙ encoding (NVENC)")
+        cmd = build_ffmpeg_command(remote_in, remote_out, args.height, args.bitrate,
+                                   probe_is_ten_bit(host_src))
+        result = run(["ssh", args.remote, cmd], capture_output=True, text=True)
+        if result.returncode != 0:
+            log(f"    {R}✗ ffmpeg failed:{N}")
+            for line in (result.stderr or "").splitlines()[:6]:
+                log(f"      {line}")
+            return "error"
+
+        # Download in full first, then rename into the final place — otherwise
+        # the server could serve a half-written file.
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        tmp_target = target + ".part"
+        log("    ↓ transferring back")
+        run(["rsync", "-a", "--partial", f"{args.remote}:{remote_out}", tmp_target], check=True)
+
+        new_size = os.path.getsize(tmp_target)
+        if new_size < 1024:
+            os.remove(tmp_target)
+            log(f"    {R}✗ result is essentially empty — discarded{N}")
+            return "error"
+
+        os.replace(tmp_target, target)
+
+    except subprocess.CalledProcessError as exc:
+        log(f"    {R}✗ transfer failed: {exc}{N}")
+        return "error"
+    finally:
+        run(["ssh", args.remote, f"rm -f {shlex.quote(remote_in)} {shlex.quote(remote_out)}"],
+            capture_output=True)
+
+    elapsed = time.time() - started
+    saved = size_mb * 1024 * 1024 - new_size
+    log(f"    {G}✓ {human(new_size)} instead of {human(size_mb*1024*1024)} "
+        f"({saved/(size_mb*1024*1024)*100:.0f}% smaller, {elapsed/60:.1f} min){N}")
+    return "done"
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Generates proxy files on a remote GPU machine.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--remote", required=True,
+                   help="SSH target of the GPU machine, e.g. user@host or a ~/.ssh/config alias")
+    p.add_argument("--remote-dir", default="~/arcade-proxy-work",
+                   help="Work directory there (needs room for the largest single file)")
+    p.add_argument("--mount", action="append", type=parse_mount, default=[],
+                   metavar="CONTAINER=HOST",
+                   help="Path mapping when the scanner runs in Docker. "
+                        "Repeatable. Without it paths are assumed identical.")
+    p.add_argument("--proxy-root", default="",
+                   help="Destination for the proxies. Taken from the scanner settings if omitted.")
+    p.add_argument("--db", default=DEFAULT_DB)
+    p.add_argument("--tree", default="/",
+                   help="Only files below this container path")
+    p.add_argument("--min-mbps", type=float, default=20.0)
+    p.add_argument("--max-mbps", type=float, default=100.0)
+    p.add_argument("--height", type=int, default=1920,
+                   help="Longest edge of the proxy (1920 = 1080p both landscape and portrait)")
+    p.add_argument("--bitrate", type=int, default=6, help="Target bitrate in Mbit/s")
+    p.add_argument("--exclude-file", default=str(SCRIPT_DIR.parent / "arcade_data"
+                                                 / "proxy_exclude.txt"),
+                   help="File of container paths (one per line) that never get a proxy")
+    p.add_argument("--no-orphan-masters", action="store_true",
+                   help="Skip raw material even when its session has nothing else")
+    p.add_argument("--limit", type=int, default=0, help="Only the first N files (0 = all)")
+    p.add_argument("--force", action="store_true", help="Re-create existing proxies")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+    args.mounts = dict(args.mount)
+
+    proxy_root = args.proxy_root or configured_proxy_root()
+    if not proxy_root:
+        p.error("No proxy destination: neither --proxy-root nor 'proxy_root' in the "
+                "scanner settings is set.")
+    # The value from the settings is a container path; here we need the host
+    # path, otherwise the script writes into nowhere.
+    args.proxy_root = to_host(proxy_root, args.mounts) or proxy_root
+
+    excludes = set()
+    if os.path.isfile(args.exclude_file):
+        with open(args.exclude_file, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    excludes.add(line)
+
+    items = select_candidates(args.db, args.min_mbps, args.max_mbps, args.tree,
+                              not args.no_orphan_masters, excludes)
+    if args.limit:
+        items = items[: args.limit]
+
+    total_gb = sum(i[2] for i in items) / 1024
+    total_h = sum(i[3] for i in items) / 3600
+    log(f"{B}{C}Proxy generator{N}")
+    log(f"  source:   {args.tree} ({args.min_mbps:.0f}-{args.max_mbps:.0f} Mbit)")
+    log(f"  target:   {args.proxy_root}")
+    log(f"  gpu:      {args.remote}")
+    log(f"  selected: {len(items)} files, {total_gb:.1f} GB, {total_h:.1f} h of material")
+    if excludes:
+        log(f"  excluded: {len(excludes)} path(s) from {os.path.basename(args.exclude_file)}")
+    if args.dry_run:
+        log(f"  {Y}dry run — nothing will be written{N}")
+
+    if not items:
+        log("\nNothing to do.")
+        return 0
+
+    tally = {}
+    for i, item in enumerate(items, 1):
+        outcome = process_one(item, args, i, len(items))
+        tally[outcome] = tally.get(outcome, 0) + 1
+
+    log(f"\n{B}Done.{N} " + ", ".join(f"{k}: {v}" for k, v in sorted(tally.items())))
+    return 1 if tally.get("error") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_master_detect.py
+++ b/tests/test_master_detect.py
@@ -1,0 +1,161 @@
+"""Tests for arcade_scanner/core/master_detect.py.
+
+The paths are invented but reproduce the patterns of real, grown libraries:
+source subfolders next to edited versions, camera-generated filenames,
+hand-picked names, underscores instead of spaces, concatenated terms and typos.
+"""
+
+import pytest
+
+from arcade_scanner.core.master_detect import (
+    EDIT,
+    MASTER,
+    UNCLEAR,
+    classify,
+    is_master,
+    session_of,
+)
+
+
+# ── Raw material via the folder ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [
+    "shoots/2019_09 Berlin/source/source.mov",
+    "shoots/2024_04 Hamburg/Source/IMG_8288.MOV",
+    "shoots/2020_08 Rom/source videos/iPhone Source.MOV",
+    "shoots/2021_03 Wien/originals/IMG_2058.MOV",
+    "shoots/2021_03 Wien/raw/x.mov",
+    "shoots/2021_03 Wien/src/x.mov",
+    "shoots/2021_03 Wien/Rohmaterial/x.mov",
+])
+def test_master_folders(path):
+    assert is_master(path), path
+
+
+# ── Raw material via the keyword ────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [
+    "shoots/2022_11 Prag/source_prg_DSCF3041.MOV",
+    "shoots/2026_07 Lissabon/source_file_shoot_07_26.MOV",
+    "shoots/x/05_2025_Session_Source.MOV",
+    "shoots/x/Fujisource .MOV",          # "source" glued to the device name
+    "shoots/x/Session Nov 21_ontouched source file.MOV",   # typo
+    "shoots/x/clip_unbearbeitet.mov",
+])
+def test_master_keywords(path):
+    assert is_master(path), path
+
+
+def test_concatenated_source_keyword():
+    """Without a separator the word boundary fails — must still be detected."""
+    verdict, reasons = classify("shoots/x/Fujisource.MOV")
+    assert verdict == MASTER
+    assert any("source keyword" in r for r in reasons)
+
+
+# ── Raw material via the camera scheme ──────────────────────────────────────
+
+@pytest.mark.parametrize("path,expected_label", [
+    ("shoots/x/IMG_5605.mp4", "iPhone/iPad"),
+    ("shoots/x/DSCF3041.MOV", "Fujifilm"),
+    ("shoots/x/L1000689.MP4", "Leica"),
+    ("shoots/x/GX010740.MP4", "GoPro"),
+    ("shoots/x/A001_01021446_C006.MOV", "Cine-Cam"),
+    ("shoots/x/MVI_1234.MOV", "Canon"),
+    ("shoots/x/DJI_0042.MP4", "DJI"),
+    ("shoots/x/C0012.MP4", "Sony/Cine"),
+    ("shoots/x/68D18503-48DC-4F8E-87C7-29B160A318AB.MP4", "iOS export (UUID)"),
+])
+def test_camera_filenames(path, expected_label):
+    verdict, reasons = classify(path)
+    assert verdict == MASTER
+    assert any(expected_label in r for r in reasons)
+
+
+@pytest.mark.parametrize("path", [
+    "shoots/x/iphone.MOV", "shoots/x/iphone1.MOV", "shoots/x/iphone2.MOV",
+    "shoots/x/gopro.mp4", "shoots/x/leica.mov",
+])
+def test_device_only_names(path):
+    assert is_master(path), path
+
+
+# ── Edited versions ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [
+    "shoots/2025_05 Session/05_2025_Session_Final.mov",   # "_Final" — word boundary!
+    "shoots/2025_04 Session/firstcut.mp4",                # concatenated
+    "shoots/2025_04 Session/timelinezoomed.mov",          # concatenated
+    "shoots/2024_12 Session/Sequenz 01_opt.mp4",
+    "shoots/2020_08 Session/final videos/slow motion 30fps.mp4",  # folder carries it
+    "shoots/2021_03 Session/hdr final/wide shot 4k60 hdr.mp4",
+    "shoots/2026_04 Session/April_2026_Session_outtakes.mp4",
+    "shoots/2026_06 Session/4KCut.mp4",
+    "shoots/2015_05 Session/finalized videos/take2.mp4",
+])
+def test_edits(path):
+    verdict, _ = classify(path)
+    assert verdict == EDIT, path
+
+
+def test_handwritten_name_defaults_to_edit():
+    """No camera scheme and no source signal -> named by hand -> an export."""
+    verdict, reasons = classify("shoots/2021_11 Session/Session Nov 21 Video.mov")
+    assert verdict == EDIT
+    assert "named by hand" in reasons[0]
+
+
+# ── Precedence rules ────────────────────────────────────────────────────────
+
+def test_filename_master_signal_beats_edit_keyword():
+    """A deliberately chosen name wins: 'source_fullclip' is raw material."""
+    verdict, _ = classify("shoots/2022_06 Session/source/source_fullclip_4k60.mov")
+    assert verdict == MASTER
+
+
+def test_folder_only_master_signal_with_edit_keyword_is_unclear():
+    """Folder says source, name says fullclip — a human has to decide."""
+    verdict, reasons = classify("shoots/2022_06 Session/source/fullclip_4k60.mov")
+    assert verdict == UNCLEAR
+    assert any("edit keyword" in r for r in reasons)
+
+
+def test_camera_name_in_edit_folder_stays_master():
+    """IMG_2058 stays raw material even inside a 'final' folder."""
+    assert is_master("shoots/2021_03 Session/hdr final/IMG_2058.MOV")
+
+
+# ── Session grouping ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path,expected", [
+    ("shoots/2021_03 Session/originals/IMG_2058.MOV", "shoots/2021_03 Session"),
+    ("shoots/2021_03 Session/hdr final/a.mp4", "shoots/2021_03 Session"),
+    ("shoots/2021_03 Session/sdr/b.mp4", "shoots/2021_03 Session"),
+    ("shoots/2021_03 Session/c.mp4", "shoots/2021_03 Session"),
+])
+def test_session_groups_variants_together(path, expected):
+    assert session_of(path) == expected
+
+
+def test_session_without_year_folder_strips_master_dir():
+    assert session_of("clips/misc/source/x.mov") == "clips/misc"
+
+
+def test_session_of_file_at_root():
+    assert session_of("x.mov") == ""
+
+
+# ── Robustness ──────────────────────────────────────────────────────────────
+
+def test_file_without_extension():
+    verdict, _ = classify("shoots/x/IMG_5605")
+    assert verdict == MASTER
+
+
+def test_windows_separators():
+    assert is_master(r"shoots\originals\IMG_2058.MOV")
+
+
+def test_umlauts_and_spaces_survive():
+    verdict, _ = classify("clips/Aufnahme am Boden_11-20.mp4")
+    assert verdict == EDIT

--- a/tests/test_proxy_resolver.py
+++ b/tests/test_proxy_resolver.py
@@ -1,0 +1,147 @@
+"""Tests for arcade_scanner/core/proxy_resolver.py — proxy selection on stream."""
+
+import os
+
+import pytest
+
+from arcade_scanner.core import proxy_resolver as pr
+
+
+# ── Path mapping ────────────────────────────────────────────────────────────
+
+def test_proxy_path_mirrors_full_original_path():
+    got = pr.proxy_path_for("/library/shoots/2024_01/foo.MOV", proxy_root="/proxies")
+    assert got == "/proxies/library/shoots/2024_01/foo.mp4"
+
+
+def test_proxy_path_always_uses_mp4_extension():
+    for src in ("a.MOV", "a.mkv", "a.avi", "a.mp4"):
+        got = pr.proxy_path_for(f"/media/{src}", proxy_root="/proxies")
+        assert got.endswith(".mp4"), src
+
+
+def test_files_from_different_mounts_do_not_collide():
+    a = pr.proxy_path_for("/library/a/foo.MOV", proxy_root="/proxies")
+    b = pr.proxy_path_for("/archive/a/foo.MOV", proxy_root="/proxies")
+    assert a != b
+
+
+def test_no_proxy_of_a_proxy():
+    """An original already inside the proxy tree gets no proxy of its own."""
+    assert pr.proxy_path_for("/proxies/library/a/foo.mp4", proxy_root="/proxies") == ""
+
+
+def test_empty_root_disables_mapping():
+    assert pr.proxy_path_for("/library/a/foo.MOV", proxy_root="") == ""
+
+
+def test_empty_original_is_handled():
+    assert pr.proxy_path_for("", proxy_root="/proxies") == ""
+
+
+# ── Location detection ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("ip", [
+    "192.168.2.10",     # home network
+    "10.0.0.5",
+    "172.16.0.9",
+    "127.0.0.1",        # loopback
+    "::1",
+    "::ffff:192.168.2.10",  # IPv4-mapped
+    "169.254.1.1",      # link-local
+])
+def test_lan_clients_are_not_remote(ip):
+    assert pr.is_remote_client(ip) is False
+
+
+@pytest.mark.parametrize("ip", [
+    "100.121.203.26",   # Tailscale (CGNAT)
+    "100.64.0.1",
+    "100.127.255.254",
+    "fd7a:115c:a1e0::1",  # Tailscale IPv6
+    "8.8.8.8",          # public internet
+])
+def test_remote_clients_are_remote(ip):
+    assert pr.is_remote_client(ip) is True
+
+
+@pytest.mark.parametrize("ip", ["", "not-an-ip", "999.999.999.999"])
+def test_unknown_ip_defaults_to_remote(ip):
+    """When in doubt, proxy: a 600 Mbit original breaks playback outright."""
+    assert pr.is_remote_client(ip) is True
+
+
+# ── Override parameter ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw,expected", [
+    ("1", True), ("true", True), ("YES", True), ("on", True),
+    ("0", False), ("false", False), ("no", False), ("OFF", False),
+    (None, None), ("", None), ("maybe", None),
+])
+def test_parse_override(raw, expected):
+    assert pr.parse_override(raw) is expected
+
+
+# ── Resolution ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def library(tmp_path, monkeypatch):
+    """An original with an existing proxy; feature enabled."""
+    original = tmp_path / "media" / "OD" / "clip.MOV"
+    original.parent.mkdir(parents=True)
+    original.write_bytes(b"x" * 1000)
+
+    root = tmp_path / "Proxies"
+    proxy = root / str(original).lstrip("/").replace(".MOV", ".mp4")
+    proxy.parent.mkdir(parents=True)
+    proxy.write_bytes(b"x" * 10)
+
+    monkeypatch.setattr(pr, "get_proxy_root", lambda: str(root))
+    monkeypatch.setattr(pr, "is_proxy_streaming_enabled", lambda: True)
+    return str(original), str(proxy)
+
+
+def test_remote_client_gets_proxy(library):
+    original, proxy = library
+    path, variant = pr.resolve_stream_path(original, client_ip="100.121.203.26")
+    assert (path, variant) == (proxy, "proxy")
+
+
+def test_lan_client_gets_original(library):
+    original, _ = library
+    path, variant = pr.resolve_stream_path(original, client_ip="192.168.2.10")
+    assert (path, variant) == (original, "original")
+
+
+def test_override_true_forces_proxy_even_in_lan(library):
+    original, proxy = library
+    path, variant = pr.resolve_stream_path(original, client_ip="192.168.2.10", override=True)
+    assert (path, variant) == (proxy, "proxy")
+
+
+def test_override_false_forces_original_even_remote(library):
+    original, _ = library
+    path, variant = pr.resolve_stream_path(original, client_ip="100.121.203.26", override=False)
+    assert (path, variant) == (original, "original")
+
+
+def test_missing_proxy_falls_back_to_original(library, tmp_path, monkeypatch):
+    original, proxy = library
+    os.remove(proxy)
+    path, variant = pr.resolve_stream_path(original, client_ip="100.121.203.26")
+    assert (path, variant) == (original, "original")
+
+
+def test_disabled_feature_always_serves_original(library, monkeypatch):
+    original, _ = library
+    monkeypatch.setattr(pr, "is_proxy_streaming_enabled", lambda: False)
+    path, variant = pr.resolve_stream_path(original, client_ip="100.121.203.26")
+    assert (path, variant) == (original, "original")
+
+
+def test_override_false_short_circuits_before_config(monkeypatch):
+    """?proxy=0 must not depend on the configuration."""
+    def boom():
+        raise AssertionError("config should not be consulted")
+    monkeypatch.setattr(pr, "is_proxy_streaming_enabled", boom)
+    assert pr.resolve_stream_path("/a/b.MOV", client_ip="", override=False) == ("/a/b.MOV", "original")


### PR DESCRIPTION
## Why

Camera source files run at 20–600 Mbit/s. No mobile connection plays that, and
transcoding 4K on the fly needs hardware a small server does not have. This adds
a third option: pre-compute a smaller copy and serve it only to clients that are
not on the LAN.

## What it does

A video may have a proxy copy in its own directory tree. `/stream` decides per
request which file to send:

| Client | Served |
|---|---|
| LAN (`10/8`, `172.16/12`, `192.168/16`, loopback) | original |
| Tailscale (`100.64.0.0/10`, `fd7a:115c:a1e0::/48`) or public | proxy, if one exists |
| no proxy present | original |

`?proxy=0` / `?proxy=1` override the automatic choice; the response carries
`X-Arcade-Variant: proxy|original`.

## Properties worth checking in review

- **The library is unaffected.** `proxy_root` is added to the scan exclusions
  automatically, so a video stays a single entry instead of appearing twice.
- **Originals are never written to.** The generator reads them; nothing in the
  serving path writes.
- **Clients need no change.** Browser, TV and iOS clients keep requesting the
  original path.
- **Security is unchanged.** `is_path_allowed` still validates the path from the
  request. The proxy path is derived from that already-validated path and never
  comes from user input, so it needs no second whitelist pass.
- **`do_GET` and `do_HEAD` share the resolver.** A HEAD reporting the original's
  size followed by a GET serving the proxy breaks `AVPlayer` and several TV media
  pipelines.
- **Off by default.** With `proxy_root` empty the resolver short-circuits before
  touching the filesystem.

## Raw material detection

`core/master_detect.py` keeps camera source files out of the generator: by folder
(`source/`, `originals/`, `raw/`), by keyword (including concatenations like
`Fujisource.MOV`), by camera filename scheme (`IMG_1234`, `DSCF0480`, `L1000689`,
`A001_..._C006`, iOS UUIDs) and by device-only names (`iphone2.MOV`).

Everything else counts as an edit — cameras assign schematic names, so a
descriptive name was typed by a human, and humans name what they exported rather
than what fell out of the camera.

## Generator

`scripts/generate_proxies.py` runs on the scanner host and delegates the encode:

```
original --rsync--> remote --ffmpeg/NVENC--> remote --rsync--> proxy tree
```

Results are downloaded under a temporary name and renamed into place, so an abort
never leaves a truncated file that would then be served. Existing proxies are
skipped, so a run is resumable.

## Known limitations (documented, not hidden)

1. "LAN means home" is wrong on a VPS — every request would be classified remote.
2. An unreadable `X-Forwarded-For` silently downgrades quality. Deliberate: a
   wrongly served proxy costs picture quality, a wrongly served 600 Mbit original
   costs playback.
3. The generator needs a *remote* GPU; a local one has no code path yet.
4. Replacing an original does not refresh its proxy — re-run with `--force`.

## Also in here

`do_HEAD` extracted the stream path with `split("path=")[1]`, so any appended
query parameter ended up inside the filename. Pre-existing bug, fixed separately
in the first commit so it can be cherry-picked on its own.

## Tests

89 new tests (`test_proxy_resolver.py`, `test_master_detect.py`), suite at
880 passed. Each of the five commits was checked out individually and the suite
run against it, so no commit leaves a broken intermediate state.