### PR TITLE
fix(web): Light-Mode-Kontraste über alle Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ All notable changes to this project will be documented in this file.
   on a remote NVENC machine, reading originals only).
 
 ### Fixed
+- **Ordner-Browser: echte Hierarchie statt flacher Liste**. `getSubfoldersAt(null)`
+  hielt jeden Pfad für eine oberste Ebene, zu dem es keinen *anderen Ordner mit
+  Dateien* als Präfix gab. Da Mount-Verzeichnisse wie `/media_ralf` selbst keine
+  Dateien enthalten, landete jeder tiefe Blattordner auf der Startebene — bei einer
+  Bibliothek mit 8776 Dateien 153 flache Einträge statt 3 Mounts. Root- und
+  Kind-Ebene laufen jetzt über denselben Code und leiten die nächste Ebene aus den
+  Pfadsegmenten ab, so dass auch Zwischenordner ohne eigene Dateien eine Ebene
+  bilden (`/media_ralf` → `OD`/`korea`/`Reface` → …). Breadcrumbs und die
+  Zurück-Navigation folgen derselben Logik und springen keine Ebene mehr über.
+- **Browser-Zurück im Ordner-Browser**: Es liefen zwei konkurrierende
+  Popstate-Handler (`addEventListener('popstate')` und `window.onpopstate`); der
+  zweite überschrieb den gerade wiederhergestellten State. Der zweite Handler
+  entfällt, und `loadFromURL()` setzt den Ordnerpfad jetzt aktiv zurück, wenn die
+  URL keinen `folderPath` enthält — vorher blieb beim Zurücknavigieren der alte
+  Pfad stehen.
+
 - **Light-Mode-Kontraste**: Die Views trugen noch flächendeckend Hardcodes aus
   der dark-only Zeit (`text-white`, `text-gray-400/500/600`, `bg-white/10`,
   `bg-black/40`, `rgba(255,255,255,…)` in `styles.css`), die im hellen Design
@@ -36,6 +52,17 @@ All notable changes to this project will be documented in this file.
   parameter ended up inside the filename. Now uses `parse_qs` like `do_GET`.
 
 ### Changed
+- **Mobile-Navigation**: Neuer Eintrag **Ordner** in der Bottom-Nav, der direkt in
+  den Ordner-Browser springt — der war auf dem Handy bisher gar nicht erreichbar
+  (die View-Toggles sind `hidden md:flex`, nur per Deep-Link zugänglich). Dafür ist
+  **Vault** aus der Bottom-Nav entfernt; der Workspace bleibt über `/vault` und den
+  Desktop erreichbar.
+- **Ordnerliste auf schmalen Viewports**: unterhalb von 768px kompakte Zeilen
+  (56px-Thumbnail, Name, Anzahl + Größe, Chevron, ≥64px Tap-Ziel) statt der
+  bildschirmfüllenden Karten mit 2×2-Mosaik — damit sind mehrere Ordner gleichzeitig
+  sichtbar und Durchklicken fühlt sich wie ein Dateimanager an. Beim Wechsel über den
+  Breakpoint (Rotation) wird neu gerendert; die Breadcrumb-Leiste scrollt horizontal
+  und springt ans Ende des Pfads.
 - **Einheitliches Design System**: Die drei Themes (Arcade/Professional/Candy)
   sind durch *ein* dark-first Theme mit genau einem Brand-Accent (Magenta
   `#c4179f`) ersetzt. Semantische Farben (HEVC-Türkis, AV1-Violett,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ All notable changes to this project will be documented in this file.
   on a remote NVENC machine, reading originals only).
 
 ### Fixed
+- **Light-Mode-Kontraste**: Die Views trugen noch flächendeckend Hardcodes aus
+  der dark-only Zeit (`text-white`, `text-gray-400/500/600`, `bg-white/10`,
+  `bg-black/40`, `rgba(255,255,255,…)` in `styles.css`), die im hellen Design
+  weiß auf weiß bzw. ~2:1 landeten — am deutlichsten in den Settings. Diese
+  Utilities zeigen jetzt auf mode-aware Tokens: neue Tailwind-Farbe `ink`
+  (Vordergrund als Flächen-/Linienquelle) statt `*-white/N`, die Graustufen
+  200–900 auf die semantische Textskala, und die semantischen Farben (HEVC,
+  AV1, Bitrate, Optimized, Danger, Info) haben eigene Light-Werte mit ≥4.5:1
+  auf Weiß. Gefüllte Buttons/Badges beziehen ihre Textfarbe aus `--ds-on-*`
+  (automatisch schwarz/weiß nach Luminanz), Badges auf Thumbnails behalten über
+  `--ds-*-media-rgb` den hellen Ton plus dunklen Scrim. `--ds-text-muted` im
+  Dark-Mode von `#6b6b76` auf `#7e7e8a` angehoben (3.4:1 → 4.5:1). Der alte
+  Block aus `!important`-Overrides in `styles.css` ist damit entfallen.
 - `do_HEAD` split the stream path with `split("path=")`, so any appended query
   parameter ended up inside the filename. Now uses `parse_qs` like `do_GET`.
 

--- a/arcade_scanner/server/static/autotag.js
+++ b/arcade_scanner/server/static/autotag.js
@@ -48,7 +48,7 @@ function renderAutoTagRules() {
                 return;
             }
             list.innerHTML = rules.map(r => `
-                <div id="atrule-${r.id}" class="flex items-center gap-3 p-2 rounded-lg bg-black/5 dark:bg-white/5">
+                <div id="atrule-${r.id}" class="flex items-center gap-3 p-2 rounded-lg bg-black/5 dark:bg-ink/5">
                     <input type="checkbox" ${r.enabled ? 'checked' : ''}
                            onchange="toggleAutoTagRule('${r.id}', this.checked)">
                     <div class="min-w-0 flex-1">

--- a/arcade_scanner/server/static/candidates.js
+++ b/arcade_scanner/server/static/candidates.js
@@ -45,10 +45,10 @@ function _candHeader() {
     const codecBtn = (c, label) => `
         <button onclick="setCandidatesCodec('${c}')"
                 class="px-3 py-1 rounded text-xs font-bold ${candState.codec === c
-                    ? 'bg-arcade-cyan text-black'
-                    : 'bg-white/10 text-gray-300 hover:bg-white/20'}">${label}</button>`;
+                    ? 'bg-arcade-cyan text-white'
+                    : 'bg-ink/10 text-gray-300 hover:bg-ink/20'}">${label}</button>`;
     return `
-    <div id="candidatesHeader" class="col-span-full p-4 rounded-xl bg-white/5 mb-2">
+    <div id="candidatesHeader" class="col-span-full p-4 rounded-xl bg-ink/5 mb-2">
         <div class="flex flex-wrap items-center gap-4">
             <div>
                 <div class="text-2xl font-bold text-arcade-cyan">~${_fmtGB(s.total_estimated_saved_mb)}</div>
@@ -72,9 +72,9 @@ function _candRow(r, idx) {
     const confColors = { high: 'text-green-400', medium: 'text-yellow-400', low: 'text-gray-400' };
     const confLabel = r.source === 'history' ? 'Historie' : 'Schätzung';
     const thumb = r.thumb ? `<img src="/thumbnails/${r.thumb}" class="w-24 h-14 object-cover rounded" loading="lazy">`
-                          : '<div class="w-24 h-14 rounded bg-white/10"></div>';
+                          : '<div class="w-24 h-14 rounded bg-ink/10"></div>';
     return `
-    <div id="cand-${idx}" class="col-span-full flex items-center gap-3 p-2 rounded-lg bg-white/5 hover:bg-white/10">
+    <div id="cand-${idx}" class="col-span-full flex items-center gap-3 p-2 rounded-lg bg-ink/5 hover:bg-ink/10">
         <input type="checkbox" ${checked} onclick="toggleCandidateSelect(${idx})">
         <div class="cursor-pointer" onclick="openCinema(this)" data-path="${escapeHtml(r.file_path)}">${thumb}</div>
         <div class="min-w-0 flex-1">
@@ -87,7 +87,7 @@ function _candRow(r, idx) {
             <div class="text-[11px] ${confColors[r.confidence] || ''}">${r.estimated_saved_pct}% · ${confLabel}</div>
         </div>
         <button onclick="queueCandidate(${idx})"
-                class="shrink-0 px-3 py-1.5 rounded text-xs font-bold bg-white/10 hover:bg-arcade-cyan/30">
+                class="shrink-0 px-3 py-1.5 rounded text-xs font-bold bg-ink/10 hover:bg-arcade-cyan/30">
             In Queue
         </button>
     </div>`;

--- a/arcade_scanner/server/static/cinema.js
+++ b/arcade_scanner/server/static/cinema.js
@@ -549,7 +549,7 @@ function updateCinemaInfo() {
             </div>
             <div class="info-row">
                 <span class="info-label">Status</span>
-                <span class="info-value" style="color: ${v.Status === 'SOURCE' ? '#A855F7' : (v.Status === 'HIGH' ? '#E3A857' : '#568203')}">${v.Status}</span>
+                <span class="info-value" style="color: ${v.Status === 'SOURCE' ? 'var(--ds-av1)' : (v.Status === 'HIGH' ? 'var(--ds-bitrate)' : 'var(--ds-optimized)')}">${v.Status}</span>
             </div>
         `;
     } else {
@@ -596,7 +596,7 @@ function updateCinemaInfo() {
             </div>
             <div class="info-row">
                 <span class="info-label">Status</span>
-                <span class="info-value" style="color: ${v.Status === 'SOURCE' ? '#A855F7' : (v.Status === 'HIGH' ? '#E3A857' : '#568203')}">${v.Status}</span>
+                <span class="info-value" style="color: ${v.Status === 'SOURCE' ? 'var(--ds-av1)' : (v.Status === 'HIGH' ? 'var(--ds-bitrate)' : 'var(--ds-optimized)')}">${v.Status}</span>
             </div>
         `;
     }
@@ -644,10 +644,10 @@ function updateCinemaTags() {
                 const tagData = availableTags.find(t => t.name === tagName);
                 const color = tagData?.color || '#888';
                 return `
-                 <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/60 border border-white/20 backdrop-blur-sm shadow-xl transition-all hover:scale-105 group/chip select-none">
+                 <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/60 border border-ink/20 backdrop-blur-sm shadow-xl transition-all hover:scale-105 group/chip select-none">
                      <span class="w-2 h-2 rounded-full shadow-[0_0_8px_var(--color)]" style="background-color: ${color}; --color: ${color}"></span>
                      <span class="text-xs text-white font-semibold tracking-wide drop-shadow-md">${tagName}</span>
-                     <button onclick="event.stopPropagation(); toggleCinemaTag('${tagName}')" class="ml-1 text-white/40 hover:text-red-400 hover:bg-white/10 rounded-full p-0.5 transition-colors" title="Remove Tag">
+                     <button onclick="event.stopPropagation(); toggleCinemaTag('${tagName}')" class="ml-1 text-white/40 hover:text-red-400 hover:bg-ink/10 rounded-full p-0.5 transition-colors" title="Remove Tag">
                          <span class="material-icons text-[14px] font-bold">close</span>
                      </button>
                  </div>
@@ -657,7 +657,7 @@ function updateCinemaTags() {
     }
 
     if (availableTags.length === 0) {
-        container.innerHTML = '<span class="text-xs text-gray-600 italic">No tags available</span>';
+        container.innerHTML = '<span class="text-xs text-white/60 italic">No tags available</span>';
         return;
     }
 
@@ -731,7 +731,7 @@ function showCinemaToast(message) {
 
     toast = document.createElement('div');
     toast.id = 'cinemaToast';
-    toast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 px-4 py-2 bg-black/80 text-white rounded-lg backdrop-blur border border-white/20 text-sm font-medium z-[10001] animate-fade-in';
+    toast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 px-4 py-2 bg-black/80 text-white rounded-lg backdrop-blur border border-ink/20 text-sm font-medium z-[10001] animate-fade-in';
     toast.textContent = message;
     document.body.appendChild(toast);
 

--- a/arcade_scanner/server/static/collections.js
+++ b/arcade_scanner/server/static/collections.js
@@ -253,7 +253,7 @@ function renderCollectionTagsList() {
     container.innerHTML = availableTags.map(tag => `
         <button class="collection-filter-chip ${collectionCriteria.tags.includes(tag.name) ? 'active' : ''}"
                 onclick="toggleCollectionTag('${tag.name}')"
-                style="border-color: ${collectionCriteria.tags.includes(tag.name) ? tag.color : 'rgba(255,255,255,0.1)'}">
+                style="border-color: ${collectionCriteria.tags.includes(tag.name) ? tag.color : 'rgb(var(--ds-text-rgb) / 0.12)'}">
             <span class="tag-dot" style="background-color: ${tag.color}; width: 6px; height: 6px; border-radius: 50%; display: inline-block;"></span>
             ${tag.name}
         </button>
@@ -1012,7 +1012,7 @@ function renderCollections() {
         html += `
             <div class="category-group mb-1">
                 <button onclick="toggleCategoryCollapse('${category}')"
-                        class="w-full flex items-center gap-1.5 px-2 py-1.5 text-[10px] font-bold text-gray-500 uppercase tracking-widest hover:text-gray-300 transition-colors rounded hover:bg-white/5">
+                        class="w-full flex items-center gap-1.5 px-2 py-1.5 text-[10px] font-bold text-gray-500 uppercase tracking-widest hover:text-gray-300 transition-colors rounded hover:bg-ink/5">
                     <span class="material-icons text-[14px] transition-transform duration-200 ${isCollapsed ? '-rotate-90' : ''}"
                           id="cat-arrow-${safeKey}">expand_more</span>
                     <span class="flex-1 text-left">${category}</span>
@@ -1039,7 +1039,7 @@ function renderCollectionItem(col) {
     const isActive = col.id === activeCollectionId;
 
     return `
-        <div class="collection-nav-item group flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all w-full cursor-pointer ${isActive ? 'bg-arcade-cyan/25 text-arcade-cyan border border-arcade-cyan/50 shadow-lg shadow-arcade-cyan/10 font-bold' : 'text-gray-600 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/5 border border-transparent'}"
+        <div class="collection-nav-item group flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all w-full cursor-pointer ${isActive ? 'bg-arcade-cyan/25 text-arcade-cyan border border-arcade-cyan/50 shadow-lg shadow-arcade-cyan/10 font-bold' : 'text-gray-600 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-ink/5 border border-transparent'}"
                 onclick="applyCollection('${col.id}')"
                 ondblclick="openCollectionModal('${col.id}')">
             <span class="material-icons text-[18px]" style="color: ${col.color}">${col.icon}</span>
@@ -1051,7 +1051,7 @@ function renderCollectionItem(col) {
                 <span class="material-icons text-[14px]">edit</span>
             </button>
 
-            <span class="text-[10px] px-1.5 py-0.5 rounded-full ${isActive ? 'bg-black/40 text-arcade-cyan border border-arcade-cyan/30' : 'bg-black/5 dark:bg-white/5 text-gray-400 dark:text-gray-500'} font-mono">${count}</span>
+            <span class="text-[10px] px-1.5 py-0.5 rounded-full ${isActive ? 'bg-ink/5 text-arcade-cyan border border-arcade-cyan/30' : 'bg-ink/[0.03] dark:bg-ink/5 text-gray-400 dark:text-gray-500'} font-mono">${count}</span>
         </div>
     `;
 }

--- a/arcade_scanner/server/static/context_menu.js
+++ b/arcade_scanner/server/static/context_menu.js
@@ -17,26 +17,26 @@ function _buildContextMenu() {
     _cmEl.innerHTML = `
         <div id="arcadeContextMenuInner" class="
             fixed z-[9900] min-w-[200px] py-1.5 rounded-xl
-            bg-[#12012a]/95 border border-white/10
+            bg-[#12012a]/95 border border-ink/10
             backdrop-blur-xl shadow-2xl shadow-black/60
             text-sm font-medium
             transition-all duration-150
             opacity-0 scale-95 pointer-events-none
         ">
-            <div class="px-3 py-1 text-[10px] uppercase tracking-widest text-gray-500 font-bold border-b border-white/5 mb-1" id="ctxFileName">—</div>
-            <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-gray-200 hover:bg-white/8 hover:text-white transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-cinema">
+            <div class="px-3 py-1 text-[10px] uppercase tracking-widest text-gray-500 font-bold border-b border-ink/5 mb-1" id="ctxFileName">—</div>
+            <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-gray-200 hover:bg-ink/8 hover:text-text-main transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-cinema">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
                 In Cinema öffnen
             </button>
-            <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-gray-200 hover:bg-white/8 hover:text-white transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-favorite">
+            <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-gray-200 hover:bg-ink/8 hover:text-text-main transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-favorite">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
                 <span id="ctx-fav-label">Favorit</span>
             </button>
-            <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-gray-200 hover:bg-white/8 hover:text-white transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-locate">
+            <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-gray-200 hover:bg-ink/8 hover:text-text-main transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-locate">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
                 In Finder zeigen
             </button>
-            <div class="border-t border-white/5 my-1"></div>
+            <div class="border-t border-ink/5 my-1"></div>
             <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-arcade-cyan hover:bg-arcade-cyan/10 transition-colors cursor-pointer rounded-lg mx-1 cinema-action-btn-ctx" style="width:calc(100% - 8px)" id="ctx-optimize">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" fill="currentColor" fill-opacity="0.2"/><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
                 Optimieren
@@ -45,7 +45,7 @@ function _buildContextMenu() {
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="3"/><path d="M9 12h3v2.5a2.5 2.5 0 0 1-5 0v-5a2.5 2.5 0 0 1 5 0"/><line x1="14" y1="8" x2="14" y2="16"/><line x1="17" y1="8" x2="19" y2="8"/><line x1="17" y1="12" x2="19" y2="12"/></svg>
                 Als GIF exportieren
             </button>
-            <div class="border-t border-white/5 my-1"></div>
+            <div class="border-t border-ink/5 my-1"></div>
             <button class="ctx-item w-full flex items-center gap-2.5 px-3 py-2 text-red-400 hover:bg-red-400/10 transition-colors cursor-pointer rounded-lg mx-1" style="width:calc(100% - 8px)" id="ctx-vault">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1" fill="currentColor"/></svg>
                 Vault
@@ -156,29 +156,29 @@ function _buildCommandPalette() {
             bg-black/60 backdrop-blur-sm opacity-0 pointer-events-none transition-opacity duration-200">
             <div id="cmdPanel" class="
                 w-full max-w-xl mx-4
-                bg-[#0d0120]/95 border border-white/10
+                bg-[#0d0120]/95 border border-ink/10
                 rounded-2xl shadow-2xl shadow-black/80
                 backdrop-blur-2xl
                 overflow-hidden
                 transform scale-95 transition-transform duration-200
             ">
                 <!-- Search input -->
-                <div class="flex items-center gap-3 px-4 py-3.5 border-b border-white/8">
+                <div class="flex items-center gap-3 px-4 py-3.5 border-b border-ink/8">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-gray-500 shrink-0">
                         <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
                     </svg>
                     <input id="cmdInput" type="text" placeholder="Suchen oder Aktion eingeben…"
-                        class="flex-1 bg-transparent border-0 outline-none text-white text-base placeholder-gray-600 font-medium"
+                        class="flex-1 bg-transparent border-0 outline-none text-text-main text-base placeholder-gray-600 font-medium"
                         autocomplete="off" spellcheck="false">
-                    <kbd class="text-[10px] text-gray-600 border border-white/10 rounded px-1.5 py-0.5 font-mono">ESC</kbd>
+                    <kbd class="text-[10px] text-gray-600 border border-ink/10 rounded px-1.5 py-0.5 font-mono">ESC</kbd>
                 </div>
                 <!-- Results -->
                 <div id="cmdResults" class="max-h-[380px] overflow-y-auto py-2"></div>
                 <!-- Footer -->
-                <div class="flex items-center gap-4 px-4 py-2.5 border-t border-white/5 text-[11px] text-gray-600">
-                    <span><kbd class="border border-white/10 rounded px-1 py-0.5 font-mono">↑↓</kbd> Navigieren</span>
-                    <span><kbd class="border border-white/10 rounded px-1 py-0.5 font-mono">↵</kbd> Auswählen</span>
-                    <span><kbd class="border border-white/10 rounded px-1 py-0.5 font-mono">ESC</kbd> Schließen</span>
+                <div class="flex items-center gap-4 px-4 py-2.5 border-t border-ink/5 text-[11px] text-gray-600">
+                    <span><kbd class="border border-ink/10 rounded px-1 py-0.5 font-mono">↑↓</kbd> Navigieren</span>
+                    <span><kbd class="border border-ink/10 rounded px-1 py-0.5 font-mono">↵</kbd> Auswählen</span>
+                    <span><kbd class="border border-ink/10 rounded px-1 py-0.5 font-mono">ESC</kbd> Schließen</span>
                 </div>
             </div>
         </div>
@@ -229,12 +229,12 @@ function _renderCmdResults() {
             const name = v.FileName || '—';
             const size = v.Size_MB ? `${v.Size_MB.toFixed(0)} MB` : '';
             html += `
-            <button class="cmd-result w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-white/6 transition-colors cursor-pointer group" data-idx="${i}" data-type="video" data-id="${v.id || v.FilePath}">
+            <button class="cmd-result w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-ink/6 transition-colors cursor-pointer group" data-idx="${i}" data-type="video" data-id="${v.id || v.FilePath}">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-gray-500 shrink-0 group-hover:text-arcade-cyan transition-colors">
                     <polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/>
                 </svg>
                 <div class="flex-1 min-w-0">
-                    <div class="text-gray-200 text-sm font-medium truncate group-hover:text-white">${name}</div>
+                    <div class="text-gray-200 text-sm font-medium truncate group-hover:text-text-main">${name}</div>
                     <div class="text-gray-600 text-[11px] truncate">${v.DirectoryPath || ''}</div>
                 </div>
                 <span class="text-[11px] text-gray-600 shrink-0">${size}</span>
@@ -243,12 +243,12 @@ function _renderCmdResults() {
     }
 
     if (actions.length) {
-        html += `<div class="px-3 py-1 text-[10px] uppercase tracking-widest text-gray-600 font-bold ${videos.length ? 'mt-1 border-t border-white/5 pt-2' : ''}">Aktionen</div>`;
+        html += `<div class="px-3 py-1 text-[10px] uppercase tracking-widest text-gray-600 font-bold ${videos.length ? 'mt-1 border-t border-ink/5 pt-2' : ''}">Aktionen</div>`;
         actions.forEach((a, i) => {
             html += `
-            <button class="cmd-result w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-white/6 transition-colors cursor-pointer group" data-idx="${videos.length + i}" data-type="action" data-action-idx="${CMD_ACTIONS.indexOf(a)}">
+            <button class="cmd-result w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-ink/6 transition-colors cursor-pointer group" data-idx="${videos.length + i}" data-type="action" data-action-idx="${CMD_ACTIONS.indexOf(a)}">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-gray-500 shrink-0 group-hover:text-arcade-cyan transition-colors">${a.icon}</svg>
-                <span class="text-gray-200 text-sm font-medium group-hover:text-white">${a.label}</span>
+                <span class="text-gray-200 text-sm font-medium group-hover:text-text-main">${a.label}</span>
             </button>`;
         });
     }
@@ -292,7 +292,7 @@ function _cmdKeyNav(e) {
         if (_cmdSelectedIdx >= 0) _executeCmdResult(results[_cmdSelectedIdx]);
         return;
     }
-    results.forEach((r, i) => r.classList.toggle('bg-white/6', i === _cmdSelectedIdx));
+    results.forEach((r, i) => r.classList.toggle('bg-ink/6', i === _cmdSelectedIdx));
     if (_cmdSelectedIdx >= 0) results[_cmdSelectedIdx].scrollIntoView({ block: 'nearest' });
 }
 

--- a/arcade_scanner/server/static/duplicates.js
+++ b/arcade_scanner/server/static/duplicates.js
@@ -146,7 +146,7 @@ function renderDuplicatesView() {
                 
                 <!-- Title & Description -->
                 <div class="text-center max-w-md">
-                    <h2 class="text-2xl font-bold text-white mb-3">Duplicate Finder</h2>
+                    <h2 class="text-2xl font-bold text-text-main mb-3">Duplicate Finder</h2>
                     <p class="text-gray-400 leading-relaxed">
                         Scan your library to find visually similar or duplicate media files. 
                         This uses perceptual hashing to detect duplicates even with different file sizes or resolutions.
@@ -155,15 +155,15 @@ function renderDuplicatesView() {
                 
                 <!-- Feature Pills -->
                 <div class="flex flex-wrap justify-center gap-3">
-                    <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-xs text-gray-400">
+                    <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-ink/5 border border-ink/10 text-xs text-gray-400">
                         <span class="material-icons text-sm text-cyan-400">movie</span>
                         Videos
                     </div>
-                    <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-xs text-gray-400">
+                    <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-ink/5 border border-ink/10 text-xs text-gray-400">
                         <span class="material-icons text-sm text-pink-400">image</span>
                         Images
                     </div>
-                    <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-xs text-gray-400">
+                    <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-ink/5 border border-ink/10 text-xs text-gray-400">
                         <span class="material-icons text-sm text-purple-400">fingerprint</span>
                         Perceptual Hashing
                     </div>
@@ -193,7 +193,7 @@ function renderDuplicatesView() {
                 <span class="material-icons text-6xl text-gray-600 mb-4">check_circle</span>
                 <h3 class="text-xl font-bold text-gray-400 mb-2">No Duplicates Found</h3>
                 <p class="text-sm text-gray-500 mb-6">Your library is clean! No duplicate media detected.</p>
-                <button onclick="rescanDuplicates()" class="px-5 py-2.5 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border border-purple-500/40 text-white text-sm font-medium transition-colors flex items-center gap-2">
+                <button onclick="rescanDuplicates()" class="px-5 py-2.5 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border border-purple-500/40 text-text-main text-sm font-medium transition-colors flex items-center gap-2">
                     <span class="material-icons text-[18px]">refresh</span>
                     Rescan for Duplicates
                 </button>
@@ -222,7 +222,7 @@ function renderDuplicatesView() {
                             <span class="material-icons text-3xl text-purple-700 dark:text-purple-400">content_copy</span>
                         </div>
                         <div>
-                            <h2 class="text-xl font-bold text-gray-900 dark:text-white">Duplicate Media</h2>
+                            <h2 class="text-xl font-bold text-gray-900 dark:text-text-main">Duplicate Media</h2>
                             <p class="text-sm text-gray-700 dark:text-gray-400">
                                 Found <span class="text-purple-700 dark:text-purple-400 font-bold">${duplicateData.summary.total_groups}</span> groups
                                 (<span class="text-cyan-700 dark:text-cyan-400">${duplicateData.summary.video_groups}</span> videos,
@@ -237,15 +237,15 @@ function renderDuplicatesView() {
                             <div class="text-xs text-gray-600 dark:text-gray-500 uppercase tracking-wider">Potential Savings</div>
                         </div>
                         ${nextBatchButton}
-                        <button onclick="deleteAllDuplicates()" class="px-4 py-2 rounded-lg bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 text-red-400 hover:text-white text-sm font-medium transition-colors flex items-center gap-2">
+                        <button onclick="deleteAllDuplicates()" class="px-4 py-2 rounded-lg bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 text-red-400 hover:text-text-main text-sm font-medium transition-colors flex items-center gap-2">
                             <span class="material-icons text-[18px]">delete_sweep</span>
                             Delete All Duplicates
                         </button>
-                        <button onclick="openDuplicateChecker()" class="px-4 py-2 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border border-purple-500/40 text-purple-400 hover:text-white text-sm font-medium transition-colors flex items-center gap-2">
+                        <button onclick="openDuplicateChecker()" class="px-4 py-2 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 border border-purple-500/40 text-purple-400 hover:text-text-main text-sm font-medium transition-colors flex items-center gap-2">
                             <span class="material-icons text-[18px]">fullscreen</span>
                             Fullscreen Mode
                         </button>
-                        <button onclick="rescanDuplicates()" class="px-4 py-2 rounded-lg bg-purple-300 dark:bg-purple-500/20 hover:bg-purple-400 dark:hover:bg-purple-500/30 border border-purple-400 dark:border-purple-500/40 text-purple-900 dark:text-white text-sm font-medium transition-colors flex items-center gap-2">
+                        <button onclick="rescanDuplicates()" class="px-4 py-2 rounded-lg bg-purple-300 dark:bg-purple-500/20 hover:bg-purple-400 dark:hover:bg-purple-500/30 border border-purple-400 dark:border-purple-500/40 text-purple-900 dark:text-text-main text-sm font-medium transition-colors flex items-center gap-2">
                             <span class="material-icons text-[18px]">refresh</span>
                             Rescan
                         </button>
@@ -261,9 +261,9 @@ function renderDuplicatesView() {
         const color = isVideo ? 'cyan' : 'pink';
 
         html += `
-                <div class="col-span-full bg-arcade-bg dark:bg-[#14141c] rounded-xl border border-black/8 dark:border-white/5 hover:border-${color}-500/30 overflow-hidden mb-4 transition-all">
+                <div class="col-span-full bg-arcade-bg dark:bg-[#14141c] rounded-xl border border-black/8 dark:border-ink/5 hover:border-${color}-500/30 overflow-hidden mb-4 transition-all">
                     <!-- Group Header -->
-                    <div class="p-4 border-b border-black/8 dark:border-white/5 flex items-center justify-between flex-wrap gap-2 bg-black/[0.02] dark:bg-white/[0.02]">
+                    <div class="p-4 border-b border-black/8 dark:border-ink/5 flex items-center justify-between flex-wrap gap-2 bg-black/[0.02] dark:bg-ink/[0.02]">
                         <div class="flex items-center gap-3">
                             <span class="material-icons text-${color}-400">${icon}</span>
                             <span class="text-xs font-bold text-gray-400 uppercase tracking-wide">
@@ -274,7 +274,7 @@ function renderDuplicatesView() {
                             <span class="text-sm font-mono text-green-400">
                                 +${group.potential_savings_mb.toFixed(0)} MB
                             </span>
-                            <span class="text-xs text-gray-500 px-2 py-1 rounded bg-white/5">
+                            <span class="text-xs text-gray-500 px-2 py-1 rounded bg-ink/5">
                                 ${Math.round(group.confidence * 100)}% match
                             </span>
                         </div>
@@ -286,7 +286,7 @@ function renderDuplicatesView() {
             const isKeep = file.path === group.recommended_keep;
             const thumbSrc = file.thumb ? `/thumbnails/${file.thumb}` : '/static/placeholder.png';
             return `
-                                <div class="relative rounded-lg border ${isKeep ? 'border-green-500/50 bg-green-500/5' : 'border-white/10 bg-white/[0.02]'} overflow-hidden flex flex-col">
+                                <div class="relative rounded-lg border ${isKeep ? 'border-green-500/50 bg-green-500/5' : 'border-ink/10 bg-ink/[0.02]'} overflow-hidden flex flex-col">
                                     ${isKeep ? `
                                         <div class="absolute top-2 right-2 z-10 px-2 py-0.5 rounded text-[10px] font-bold bg-green-500 text-black uppercase tracking-wider">
                                             Keep
@@ -311,16 +311,16 @@ function renderDuplicatesView() {
                                         </div>
                                         
                                         <div class="flex items-center gap-2 text-[10px] text-gray-400 font-mono flex-wrap">
-                                            <span class="bg-white/5 px-1.5 py-0.5 rounded">${file.size_mb.toFixed(0)} MB</span>
-                                            ${file.width && file.height ? `<span class="bg-white/5 px-1.5 py-0.5 rounded">${file.width}×${file.height}</span>` : ''}
-                                            ${file.bitrate_mbps ? `<span class="bg-white/5 px-1.5 py-0.5 rounded">${file.bitrate_mbps.toFixed(1)} Mbps</span>` : ''}
+                                            <span class="bg-ink/5 px-1.5 py-0.5 rounded">${file.size_mb.toFixed(0)} MB</span>
+                                            ${file.width && file.height ? `<span class="bg-ink/5 px-1.5 py-0.5 rounded">${file.width}×${file.height}</span>` : ''}
+                                            ${file.bitrate_mbps ? `<span class="bg-ink/5 px-1.5 py-0.5 rounded">${file.bitrate_mbps.toFixed(1)} Mbps</span>` : ''}
                                             <span class="ml-auto bg-purple-500/20 text-purple-300 px-1.5 py-0.5 rounded">Q: ${file.quality_score.toFixed(0)}</span>
                                         </div>
                                         
                                         ${window.IS_LOCAL_ACCESS ? `
                                         <!-- Reveal in Finder Button (only on local access) -->
                                         <button onclick="revealInFinder('${escapeHtml(file.path.replace(/'/g, "\\'"))}')"
-                                                class="w-full py-1.5 rounded-lg bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white border border-white/10 text-xs transition-all flex items-center justify-center gap-1">
+                                                class="w-full py-1.5 rounded-lg bg-ink/5 text-gray-400 hover:bg-ink/10 hover:text-text-main border border-ink/10 text-xs transition-all flex items-center justify-center gap-1">
                                             <span class="material-icons text-sm">folder_open</span>
                                             Reveal in Finder
                                         </button>
@@ -584,12 +584,12 @@ function showDuplicateScanningUI() {
             
             <!-- Status Text -->
             <div class="text-center">
-                <h3 class="text-xl font-bold text-white mb-2" id="scan-status-text">Starting visual analysis...</h3>
+                <h3 class="text-xl font-bold text-text-main mb-2" id="scan-status-text">Starting visual analysis...</h3>
                 <p class="text-sm text-gray-400">This may take a minute for large libraries.</p>
             </div>
             
             <!-- Progress Bar -->
-            <div class="w-full max-w-md bg-white/5 rounded-full h-4 overflow-hidden relative border border-white/5">
+            <div class="w-full max-w-md bg-ink/5 rounded-full h-4 overflow-hidden relative border border-ink/5">
                 <div id="scan-progress-bar" class="h-full bg-gradient-to-r from-purple-500 to-pink-500 transition-all duration-300" style="width: 0%"></div>
             </div>
             <div class="text-xs text-gray-500 font-mono" id="scan-progress-text">0%</div>

--- a/arcade_scanner/server/static/engine.js
+++ b/arcade_scanner/server/static/engine.js
@@ -898,10 +898,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         loadAvailableTags();
     }
 
-    // Handle URL Back/Forward
-    window.onpopstate = (event) => {
-        loadFromURL();
-    };
+    // Back/Forward wird von genau EINEM Handler bedient — dem
+    // addEventListener('popstate', ...) weiter oben in dieser Datei. Ein zweiter
+    // Handler hier hat den wiederhergestellten State direkt wieder überschrieben.
 
     // --- CATEGORY MANAGEMENT FUNCTIONS ---
     function getAvailableCategories() {

--- a/arcade_scanner/server/static/engine.js
+++ b/arcade_scanner/server/static/engine.js
@@ -169,21 +169,21 @@ function createComparisonCard(pair) {
                 <span>${orig.Bitrate_Mbps.toFixed(1)} Mb/s</span>
             </div>
             ${window.IS_LOCAL_ACCESS ? `
-            <button class="text-xs text-gray-500 hover:text-white flex items-center gap-1 px-1 transition-colors" onclick="revealInFinder('${orig.FilePath.replace(/'/g, "\\'")}')">
+            <button class="text-xs text-gray-500 hover:text-text-main flex items-center gap-1 px-1 transition-colors" onclick="revealInFinder('${orig.FilePath.replace(/'/g, "\\'")}')">
                 <span class="material-icons text-[12px]">folder_open</span> Reveal
             </button>
             ` : ''}
         </div>
 
         <!-- Stats Center -->
-        <div class="w-full md:w-32 flex flex-col items-center justify-center gap-1 border-y md:border-y-0 md:border-x border-white/5 py-4 md:py-0 bg-white/[0.02] rounded-lg md:bg-transparent">
+        <div class="w-full md:w-32 flex flex-col items-center justify-center gap-1 border-y md:border-y-0 md:border-x border-ink/5 py-4 md:py-0 bg-ink/[0.02] rounded-lg md:bg-transparent">
              <div class="text-2xl font-bold ${isSmaller ? 'text-green-400 drop-shadow-[0_0_8px_rgba(76,217,100,0.4)]' : 'text-red-500'} font-mono tracking-tighter">${diffPct.toFixed(1)}%</div>
              <div class="text-xs text-gray-500 font-mono mb-2">${diffMB.toFixed(1)} MB</div>
              
              <button class="ds-btn ds-btn-primary w-full mt-1" onclick="keepOptimized('${encodeURIComponent(orig.FilePath)}', '${encodeURIComponent(opt.FilePath)}')">
                 <span class="material-icons text-[14px]">check</span> KEEP
              </button>
-             <button class="w-full py-2 rounded-lg bg-[var(--ds-fill-soft)] text-gray-400 hover:bg-[var(--ds-fill)] hover:text-white border border-white/5 text-xs font-bold transition-all flex items-center justify-center gap-1" onclick="discardOptimized('${encodeURIComponent(opt.FilePath)}')">
+             <button class="w-full py-2 rounded-lg bg-[var(--ds-fill-soft)] text-gray-400 hover:bg-[var(--ds-fill)] hover:text-text-main border border-ink/5 text-xs font-bold transition-all flex items-center justify-center gap-1" onclick="discardOptimized('${encodeURIComponent(opt.FilePath)}')">
                 <span class="material-icons text-[14px]">delete</span> DISCARD
              </button>
         </div>
@@ -208,7 +208,7 @@ function createComparisonCard(pair) {
                 <span>${opt.Bitrate_Mbps.toFixed(1)} Mb/s</span>
             </div>
              ${window.IS_LOCAL_ACCESS ? `
-             <button class="text-xs text-gray-500 hover:text-white flex items-center gap-1 px-1 transition-colors" onclick="revealInFinder('${opt.FilePath.replace(/'/g, "\\'")}')">
+             <button class="text-xs text-gray-500 hover:text-text-main flex items-center gap-1 px-1 transition-colors" onclick="revealInFinder('${opt.FilePath.replace(/'/g, "\\'")}')">
                 <span class="material-icons text-[12px]">folder_open</span> Reveal
             </button>
             ` : ''}
@@ -281,7 +281,7 @@ function discardOptimized(opt) {
  * @returns {string} HTML für den Button
  */
 function _optimizeButton(v) {
-    const cls = 'w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 flex items-center ' +
+    const cls = 'w-10 h-10 rounded-full bg-ink/10 hover:bg-ink/20 flex items-center ' +
                 'justify-center backdrop-blur text-white transition-all transform hover:scale-110';
 
     if (window.IS_DOCKER) {
@@ -352,7 +352,7 @@ function createVideoCard(v) {
              
              <!-- Corner Checkbox -->
              <div class="absolute top-1.5 left-1.5 z-20 opacity-0 group-hover:opacity-100 transition-opacity">
-                <input type="checkbox" class="w-4 h-4 rounded-[4px] border-white/30 bg-black/50 text-accent focus:ring-0 cursor-pointer" aria-label="Select" onclick="event.stopPropagation(); toggleSelection(this, event, '${v.FilePath.replace(/'/g, "\\'")}')">
+                <input type="checkbox" class="w-4 h-4 rounded-[4px] border-ink/30 bg-black/50 text-accent focus:ring-0 cursor-pointer" aria-label="Select" onclick="event.stopPropagation(); toggleSelection(this, event, '${v.FilePath.replace(/'/g, "\\'")}')">
              </div>
 
              <button class="favorite-btn absolute top-1.5 right-1.5 z-20 w-7 h-7 rounded-full bg-black/45 flex items-center justify-center transition-all ${v.favorite ? 'text-bitrate active' : 'text-white/70 opacity-0 group-hover:opacity-100'}"
@@ -374,14 +374,14 @@ function createVideoCard(v) {
              <!-- Quick Actions Overlay -->
              <div class="hidden md:flex absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity items-center justify-center gap-3">
                  ${window.IS_LOCAL_ACCESS ? `
-                 <button class="w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center backdrop-blur text-white transition-all transform hover:scale-110" title="Reveal" onclick="event.stopPropagation(); revealInFinder('${v.FilePath.replace(/'/g, "\\'")}')">
+                 <button class="w-10 h-10 rounded-full bg-ink/10 hover:bg-ink/20 flex items-center justify-center backdrop-blur text-white transition-all transform hover:scale-110" title="Reveal" onclick="event.stopPropagation(); revealInFinder('${v.FilePath.replace(/'/g, "\\'")}')">
                     <span class="material-icons">folder_open</span>
                  </button>
                  ` : ''}
                  <button class="w-11 h-11 rounded-full bg-accent/[0.18] hover:bg-accent text-accent-tint hover:text-white border border-accent/[0.45] flex items-center justify-center backdrop-blur transition-colors" title="Play" onclick="event.stopPropagation(); openCinema(this.closest('.card-media'))">
                     <span class="material-icons text-3xl">play_arrow</span>
                  </button>
-                 <button class="w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center backdrop-blur text-white transition-all transform hover:scale-110" title="${v.hidden ? 'Restore' : 'Move to Vault'}" onclick="event.stopPropagation(); toggleHidden(this.closest('.video-card-container'))">
+                 <button class="w-10 h-10 rounded-full bg-ink/10 hover:bg-ink/20 flex items-center justify-center backdrop-blur text-white transition-all transform hover:scale-110" title="${v.hidden ? 'Restore' : 'Move to Vault'}" onclick="event.stopPropagation(); toggleHidden(this.closest('.video-card-container'))">
                     <span class="material-icons">${v.hidden ? 'unarchive' : 'archive'}</span>
                  </button>
                   ${(window.userSettings?.enable_optimizer !== false && window.ENABLE_OPTIMIZER !== false) ? _optimizeButton(v) : ''}
@@ -1182,7 +1182,7 @@ function loadSetupDirectories() {
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-3">
                             <span class="material-icons text-arcade-cyan">${dir.is_root ? 'folder_open' : 'folder'}</span>
-                            <div><div class="text-white font-medium">${displayName}</div>
+                            <div><div class="text-text-main font-medium">${displayName}</div>
                             <div class="text-xs text-gray-500">${sizeGB} GB • ${dir.file_count.toLocaleString()} files</div></div>
                         </div>
                         <div class="setup-dir-checkbox hidden"><span class="material-icons text-arcade-cyan">check_circle</span></div>

--- a/arcade_scanner/server/static/folder_browser.js
+++ b/arcade_scanner/server/static/folder_browser.js
@@ -426,7 +426,7 @@ function createFolderCard(folder) {
 
         <!-- Subfolder Indicator -->
         ${folder.hasSubfolders ? `
-        <div class="absolute top-3 right-3 px-2 py-1 rounded-md bg-white/10 backdrop-blur text-[10px] font-bold text-gray-300 flex items-center gap-1">
+        <div class="absolute top-3 right-3 px-2 py-1 rounded-md bg-ink/10 backdrop-blur text-[10px] font-bold text-gray-300 flex items-center gap-1">
             <span class="material-icons text-xs">subdirectory_arrow_right</span>
             HAS SUBFOLDERS
         </div>
@@ -434,7 +434,7 @@ function createFolderCard(folder) {
 
         <!-- Content -->
         <div class="absolute bottom-0 left-0 right-0 p-4">
-            <h3 class="text-base font-bold text-white truncate group-hover:text-arcade-cyan transition-colors" title="${folder.path}">${folder.name}</h3>
+            <h3 class="text-base font-bold text-text-main truncate group-hover:text-arcade-cyan transition-colors" title="${folder.path}">${folder.name}</h3>
             <div class="flex items-center gap-3 mt-1 text-xs text-gray-400">
                 <span class="flex items-center gap-1">
                     <span class="material-icons text-sm">video_library</span>
@@ -501,7 +501,7 @@ function renderFolderBrowser() {
             const isLast = idx === breadcrumbs.length - 1;
             const clickHandler = isLast ? '' : `onclick="setFolderBrowserPath(${crumb.path === null ? 'null' : `'${crumb.path.replace(/'/g, "\\'")}'`})"`;
             return `
-                <span class="${isLast ? 'text-white font-bold' : 'text-arcade-cyan hover:text-white cursor-pointer transition-colors'}" ${clickHandler}>${crumb.name}</span>
+                <span class="${isLast ? 'text-text-main font-bold' : 'text-arcade-cyan hover:text-text-main cursor-pointer transition-colors'}" ${clickHandler}>${crumb.name}</span>
                 ${!isLast ? '<span class="text-gray-600 mx-1">/</span>' : ''}
             `;
         }).join('');

--- a/arcade_scanner/server/static/folder_browser.js
+++ b/arcade_scanner/server/static/folder_browser.js
@@ -131,74 +131,55 @@ function getSubfoldersAt(path) {
     const allPaths = Array.from(folderStats.keys());
     const subfolders = new Map();
 
-    if (normalizedPath === null) {
-        // Root level: find top-level folders
-        allPaths.forEach(folderPath => {
-            // Check if this path is a subfolder of any other path
-            let isSubfolder = false;
-            allPaths.forEach(otherPath => {
-                if (otherPath !== folderPath && folderPath.startsWith(otherPath + '/')) {
-                    isSubfolder = true;
-                }
+    // Root und Kind-Ebene laufen über denselben Code: die nächste Ebene wird immer
+    // aus den Pfadsegmenten abgeleitet. Wichtig für Zwischenordner, die selbst keine
+    // Dateien enthalten (z.B. /media_ralf) — die wären sonst gar keine eigene Ebene.
+    const isRoot = normalizedPath === null;
+    const prefix = isRoot ? '' : normalizedPath + '/';
+
+    allPaths.forEach(folderPath => {
+        if (!folderPath.startsWith(prefix)) return;
+
+        let remainder = folderPath.substring(prefix.length);
+
+        // Auf Root-Ebene den Mount-Slash abtrennen ('/media_ralf/OD' → 'media_ralf/OD'),
+        // damit das erste Segment nicht leer ist.
+        let leading = '';
+        if (isRoot) {
+            const match = remainder.match(/^\/+/);
+            if (match) {
+                leading = match[0];
+                remainder = remainder.substring(match[0].length);
+            }
+        }
+
+        const nextSegment = remainder.split('/')[0];
+        if (!nextSegment) return;
+
+        const childPath = isRoot ? leading + nextSegment : normalizedPath + '/' + nextSegment;
+
+        if (!subfolders.has(childPath)) {
+            // Original-Schreibweise (Backslashes) rekonstruieren: Normalisierung
+            // ersetzt nur '\' durch '/', die Länge bleibt identisch.
+            const stats = folderStats.get(folderPath);
+            subfolders.set(childPath, {
+                path: stats.originalPath.substring(0, childPath.length),
+                count: 0,
+                size_mb: 0,
+                hasSubfolders: false
             });
+        }
 
-            if (!isSubfolder) {
-                // This is a root-level folder - aggregate all subfolders into it
-                const stats = folderStats.get(folderPath);
-                if (!subfolders.has(folderPath)) {
-                    subfolders.set(folderPath, {
-                        path: stats.originalPath,
-                        count: 0,
-                        size_mb: 0,
-                        hasSubfolders: false
-                    });
-                }
-                const folder = subfolders.get(folderPath);
-                folder.count += stats.count;
-                folder.size_mb += stats.size_mb;
+        const folder = subfolders.get(childPath);
+        const stats = folderStats.get(folderPath);
+        folder.count += stats.count;
+        folder.size_mb += stats.size_mb;
 
-                // Also add stats from all subfolders
-                allPaths.forEach(subPath => {
-                    if (subPath !== folderPath && subPath.startsWith(folderPath + '/')) {
-                        const subStats = folderStats.get(subPath);
-                        folder.count += subStats.count;
-                        folder.size_mb += subStats.size_mb;
-                        folder.hasSubfolders = true;
-                    }
-                });
-            }
-        });
-    } else {
-        // Find direct children of the given path
-        allPaths.forEach(folderPath => {
-            if (folderPath.startsWith(normalizedPath + '/')) {
-                const remainder = folderPath.substring(normalizedPath.length + 1);
-                const nextSegment = remainder.split('/')[0];
-                const childPath = normalizedPath + '/' + nextSegment;
-
-                if (!subfolders.has(childPath)) {
-                    // Reconstruct original path format
-                    const originalPath = path + (path.includes('\\') ? '\\' : '/') + nextSegment;
-                    subfolders.set(childPath, {
-                        path: originalPath,
-                        count: 0,
-                        size_mb: 0,
-                        hasSubfolders: false
-                    });
-                }
-
-                const folder = subfolders.get(childPath);
-                const stats = folderStats.get(folderPath);
-                folder.count += stats.count;
-                folder.size_mb += stats.size_mb;
-
-                // Check if there are deeper subfolders
-                if (remainder.includes('/')) {
-                    folder.hasSubfolders = true;
-                }
-            }
-        });
-    }
+        // Gibt es unterhalb dieses Kindes noch tiefere Ordner?
+        if (remainder.includes('/')) {
+            folder.hasSubfolders = true;
+        }
+    });
 
     // Convert to array, add names, and sort by size
     const result = Array.from(subfolders.values()).map(folder => ({
@@ -319,20 +300,16 @@ function folderBrowserBack() {
     const lastSlash = normalized.lastIndexOf('/');
 
     if (lastSlash > 0) {
-        // Go up one level
+        // Eine Ebene hoch. Der Parent ist immer eine gültige Ebene, auch wenn er
+        // selbst keine Dateien enthält — getSubfoldersAt() leitet Ebenen aus den
+        // Pfadsegmenten ab.
         const parentPath = folderBrowserState.currentPath.substring(0,
             Math.max(folderBrowserState.currentPath.lastIndexOf('/'),
                 folderBrowserState.currentPath.lastIndexOf('\\')));
 
-        // Check if parent is a root folder or has a parent itself
-        const subfolders = getSubfoldersAt(null);
-        const isRootFolder = subfolders.some(f =>
-            normalizePath(f.path) === normalizePath(parentPath)
-        );
-
-        setFolderBrowserPath(isRootFolder ? null : parentPath);
+        setFolderBrowserPath(parentPath);
     } else {
-        // Go to root
+        // Mount-Ebene ('/media_ralf') → zurück zur Übersicht
         setFolderBrowserPath(null);
     }
 }
@@ -354,37 +331,22 @@ function getFolderBreadcrumbs() {
 
     if (!folderBrowserState.currentPath) return breadcrumbs;
 
-    const normalizePath = (p) => p.replace(/\\/g, '/');
-    const normalized = normalizePath(folderBrowserState.currentPath);
-    const rootFolders = getSubfoldersAt(null);
+    // Direkt aus den Pfadsegmenten aufbauen — jede Ebene ist anklickbar, auch
+    // Zwischenordner ohne eigene Dateien.
+    const original = folderBrowserState.currentPath;
+    const normalized = original.replace(/\\/g, '/');
 
-    // Find which root folder this path belongs to
-    let rootFolder = null;
-    for (const folder of rootFolders) {
-        const normalizedRoot = normalizePath(folder.path);
-        if (normalized === normalizedRoot || normalized.startsWith(normalizedRoot + '/')) {
-            rootFolder = folder;
-            break;
-        }
-    }
+    // Führenden Slash als Teil des ersten Segments behalten ('/media_ralf')
+    const leading = (normalized.match(/^\/+/) || [''])[0];
+    const segments = normalized.substring(leading.length).split('/').filter(Boolean);
 
-    if (rootFolder) {
-        const normalizedRoot = normalizePath(rootFolder.path);
-        breadcrumbs.push({ name: rootFolder.name, path: rootFolder.path });
-
-        // Add intermediate segments
-        if (normalized !== normalizedRoot) {
-            const remainder = normalized.substring(normalizedRoot.length + 1);
-            const segments = remainder.split('/');
-            let currentPath = rootFolder.path;
-            const separator = rootFolder.path.includes('\\') ? '\\' : '/';
-
-            segments.forEach(segment => {
-                currentPath = currentPath + separator + segment;
-                breadcrumbs.push({ name: segment, path: currentPath });
-            });
-        }
-    }
+    // Jede Ebene ist ein Präfix des Originalpfads — dadurch bleibt die
+    // Original-Schreibweise (Backslashes unter Windows) automatisch erhalten.
+    let end = leading.length;
+    segments.forEach((segment, idx) => {
+        end += segment.length + (idx === 0 ? 0 : 1);
+        breadcrumbs.push({ name: segment, path: original.substring(0, end) });
+    });
 
     return breadcrumbs;
 }
@@ -464,6 +426,49 @@ function createFolderCard(folder) {
 }
 
 /**
+ * Breakpoint check — unterhalb von md (768px) wird die kompakte Listendarstellung
+ * benutzt. Muss zum `md:`-Breakpoint der Templates passen.
+ * @returns {boolean} True auf schmalen Viewports
+ */
+function isCompactFolderView() {
+    return window.innerWidth < 768;
+}
+
+/**
+ * Create a compact folder row for mobile — ein Ordner pro Zeile statt
+ * bildschirmfüllender Karte, damit man sich durch Ebenen klicken kann.
+ * @param {Object} folder - Folder data {path, name, count, size_mb, hasSubfolders, thumbnails}
+ * @returns {HTMLElement} DOM element for the folder row
+ */
+function createFolderRow(folder) {
+    const row = document.createElement('div');
+    row.className = 'folder-row folder-card flex items-center gap-3 w-full bg-card rounded-ds-md border border-[var(--ds-hairline)] active:border-[var(--ds-hairline-strong)] transition-colors cursor-pointer';
+    row.setAttribute('data-path', folder.path);
+
+    const thumb = (folder.thumbnails || [])[0];
+    const thumbHtml = thumb
+        ? `<img src="/thumbnails/${thumb}" class="w-full h-full object-cover" loading="lazy">`
+        : `<span class="material-icons text-gray-600 text-xl">folder</span>`;
+
+    row.innerHTML = `
+        <div class="folder-row-thumb flex items-center justify-center bg-black/40 rounded-ds-sm overflow-hidden flex-shrink-0">
+            ${thumbHtml}
+        </div>
+        <div class="min-w-0 flex-1">
+            <div class="text-sm font-bold text-text-main truncate" title="${folder.path}">${folder.name}</div>
+            <div class="text-xs text-text-muted truncate">${folder.count} · ${formatSize(folder.size_mb)}</div>
+        </div>
+        <span class="material-icons text-text-muted flex-shrink-0">${folder.hasSubfolders ? 'chevron_right' : 'play_arrow'}</span>
+    `;
+
+    row.addEventListener('click', () => {
+        setFolderBrowserPath(folder.path);
+    });
+
+    return row;
+}
+
+/**
  * Render the folder browser view
  */
 function renderFolderBrowser() {
@@ -501,10 +506,14 @@ function renderFolderBrowser() {
             const isLast = idx === breadcrumbs.length - 1;
             const clickHandler = isLast ? '' : `onclick="setFolderBrowserPath(${crumb.path === null ? 'null' : `'${crumb.path.replace(/'/g, "\\'")}'`})"`;
             return `
-                <span class="${isLast ? 'text-text-main font-bold' : 'text-arcade-cyan hover:text-text-main cursor-pointer transition-colors'}" ${clickHandler}>${crumb.name}</span>
-                ${!isLast ? '<span class="text-gray-600 mx-1">/</span>' : ''}
+                <span class="flex-shrink-0 ${isLast ? 'text-text-main font-bold' : 'text-arcade-cyan hover:text-text-main cursor-pointer transition-colors'}" ${clickHandler}>${crumb.name}</span>
+                ${!isLast ? '<span class="text-gray-600 mx-1 flex-shrink-0">/</span>' : ''}
             `;
         }).join('');
+
+        // Bei tiefen Pfaden ans Ende scrollen, damit der aktuelle Ordner sichtbar ist
+        const scroller = breadcrumbEl.parentElement;
+        if (scroller) scroller.scrollLeft = scroller.scrollWidth;
     }
 
     // Update "videos here" link
@@ -521,6 +530,7 @@ function renderFolderBrowser() {
     // Clear the grid
     grid.innerHTML = '';
     grid.classList.remove('list-view');
+    grid.classList.remove('folder-list');
 
     // Decide what to render
     if (folderBrowserState.showVideosHere || (subfolders.length === 0 && folderBrowserState.currentPath)) {
@@ -561,14 +571,27 @@ function renderFolderBrowser() {
             </div>
         `;
     } else {
-        // Render folder cards
+        // Render folder cards — auf schmalen Viewports als kompakte Liste
+        const compact = isCompactFolderView();
+        grid.classList.toggle('folder-list', compact);
+
         const fragment = document.createDocumentFragment();
         subfolders.forEach(folder => {
-            fragment.appendChild(createFolderCard(folder));
+            fragment.appendChild(compact ? createFolderRow(folder) : createFolderCard(folder));
         });
         grid.appendChild(fragment);
     }
 }
+
+// Beim Wechsel über den Breakpoint (Rotation, Resize) neu rendern —
+// sonst bleiben Karten/Zeilen in der falschen Darstellung stehen.
+let lastCompactFolderView = null;
+window.addEventListener('resize', () => {
+    const compact = isCompactFolderView();
+    if (lastCompactFolderView === compact) return;
+    lastCompactFolderView = compact;
+    if (currentLayout === 'folderbrowser') renderFolderBrowser();
+});
 
 /**
  * Update the folder browser legend state

--- a/arcade_scanner/server/static/gif_export.js
+++ b/arcade_scanner/server/static/gif_export.js
@@ -102,13 +102,13 @@ function setGifPreset(preset) {
     ['360p', '480p', '720p', '1080p', 'Original'].forEach(p => {
         const el = document.getElementById(`gifPreset${p}`);
         if (el) {
-            el.classList.remove('bg-white/10', 'shadow-sm', 'text-white');
+            el.classList.remove('bg-ink/10', 'shadow-sm', 'text-text-main');
             el.classList.add('text-gray-400');
         }
     });
     const activeEl = document.getElementById(`gifPreset${preset}`);
     if (activeEl) {
-        activeEl.classList.add('bg-white/10', 'shadow-sm', 'text-white');
+        activeEl.classList.add('bg-ink/10', 'shadow-sm', 'text-text-main');
         activeEl.classList.remove('text-gray-400');
     }
     const descriptions = {
@@ -128,13 +128,13 @@ function setGifFps(fps) {
     [10, 15, 20, 25, 30].forEach(f => {
         const el = document.getElementById(`gifFps${f}`);
         if (el) {
-            el.classList.remove('bg-white/10', 'shadow-sm', 'text-white');
+            el.classList.remove('bg-ink/10', 'shadow-sm', 'text-text-main');
             el.classList.add('text-gray-400');
         }
     });
     const activeEl = document.getElementById(`gifFps${fps}`);
     if (activeEl) {
-        activeEl.classList.add('bg-white/10', 'shadow-sm', 'text-white');
+        activeEl.classList.add('bg-ink/10', 'shadow-sm', 'text-text-main');
         activeEl.classList.remove('text-gray-400');
     }
     updateGifEstimate();
@@ -149,13 +149,13 @@ function setGifLoop(loopVal) {
     loopOptions.forEach(v => {
         const el = document.getElementById(`gifLoop${v}`);
         if (el) {
-            el.classList.remove('bg-white/10', 'shadow-sm', 'text-white');
+            el.classList.remove('bg-ink/10', 'shadow-sm', 'text-text-main');
             el.classList.add('text-gray-400');
         }
     });
     const activeEl = document.getElementById(`gifLoop${loopVal}`);
     if (activeEl) {
-        activeEl.classList.add('bg-white/10', 'shadow-sm', 'text-white');
+        activeEl.classList.add('bg-ink/10', 'shadow-sm', 'text-text-main');
         activeEl.classList.remove('text-gray-400');
     }
 }
@@ -169,14 +169,14 @@ function setGifSpeed(speed) {
     speedOptions.forEach(v => {
         const el = document.getElementById(`gifSpeed${v.toString().replace('.', '_')}`);
         if (el) {
-            el.classList.remove('bg-white/10', 'shadow-sm', 'text-white');
+            el.classList.remove('bg-ink/10', 'shadow-sm', 'text-text-main');
             el.classList.add('text-gray-400');
         }
     });
     const key = speed.toString().replace('.', '_');
     const activeEl = document.getElementById(`gifSpeed${key}`);
     if (activeEl) {
-        activeEl.classList.add('bg-white/10', 'shadow-sm', 'text-white');
+        activeEl.classList.add('bg-ink/10', 'shadow-sm', 'text-text-main');
         activeEl.classList.remove('text-gray-400');
     }
     updateGifEstimate();

--- a/arcade_scanner/server/static/login.html
+++ b/arcade_scanner/server/static/login.html
@@ -18,7 +18,7 @@
             --ds-surface: #15151d;
             --ds-border: #2a2a35;
             --ds-text: #f2f2f5;
-            --ds-text-muted: #6b6b76;
+            --ds-text-muted: #7e7e8a;
             --ds-accent: #c4179f;
             --ds-accent-hover: #e34fc0;
             --ds-danger: #f36969;

--- a/arcade_scanner/server/static/optimizer.js
+++ b/arcade_scanner/server/static/optimizer.js
@@ -163,11 +163,11 @@ function setOptVideo(mode) {
 function updateOptCodecUI() {
     document.querySelectorAll('[data-codec-btn]').forEach(btn => {
         const isActive = btn.dataset.codecBtn === currentOptCodec;
-        btn.classList.toggle('text-white',  isActive);
-        btn.classList.toggle('bg-white/10', isActive);
+        btn.classList.toggle('text-text-main',  isActive);
+        btn.classList.toggle('bg-ink/10', isActive);
         btn.classList.toggle('shadow-sm',   isActive);
         btn.classList.toggle('text-gray-400',   !isActive);
-        btn.classList.toggle('hover:text-white', !isActive);
+        btn.classList.toggle('hover:text-text-main', !isActive);
     });
     const desc = document.getElementById('optCodecDesc');
     if (desc) {
@@ -182,8 +182,8 @@ function updateOptVideoUI() {
     const copyBtn     = document.getElementById('optVideoCopy');
     if (!compressBtn || !copyBtn) return;
 
-    const active   = ['text-white', 'bg-white/10', 'shadow-sm'];
-    const inactive = ['text-gray-400', 'hover:text-white'];
+    const active   = ['text-text-main', 'bg-ink/10', 'shadow-sm'];
+    const inactive = ['text-gray-400', 'hover:text-text-main'];
 
     if (currentOptVideo === 'compress') {
         compressBtn.classList.add(...active);
@@ -208,8 +208,8 @@ function updateOptAudioUI() {
     const enhancedBtn = document.getElementById('optAudioEnhanced');
     const standardBtn = document.getElementById('optAudioStandard');
 
-    const active   = ['text-white', 'bg-white/10', 'shadow-sm'];
-    const inactive = ['text-gray-400', 'hover:text-white'];
+    const active   = ['text-text-main', 'bg-ink/10', 'shadow-sm'];
+    const inactive = ['text-gray-400', 'hover:text-text-main'];
 
     if (currentOptAudio === 'enhanced') {
         enhancedBtn.classList.add(...active);

--- a/arcade_scanner/server/static/settings.js
+++ b/arcade_scanner/server/static/settings.js
@@ -913,7 +913,7 @@ async function loadQueueStatus() {
                 failed: 'bg-red-500/20 text-red-300',
                 cancelled: 'bg-gray-500/20 text-gray-300'
             };
-            return `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${map[s] || 'bg-white/10 text-gray-400'}">${s}</span>`;
+            return `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${map[s] || 'bg-ink/10 text-gray-400'}">${s}</span>`;
         };
 
         const timeAgo = (ts) => {
@@ -942,7 +942,7 @@ async function loadQueueStatus() {
             const pct = Math.max(0, Math.min(100, Number(j.progress_pct) || 0));
             const phase = j.phase || j.status;
             return `<div class="min-w-[120px]">
-                        <div class="h-1.5 rounded-full bg-white/10 overflow-hidden">
+                        <div class="h-1.5 rounded-full bg-ink/10 overflow-hidden">
                             <div class="h-full bg-accent transition-all" style="width: ${pct}%"></div>
                         </div>
                         <div class="text-[10px] text-gray-500 mt-1 truncate">${escapeHtml(phase)} ${Math.round(pct)}%${eta(j.eta_seconds)}</div>
@@ -950,9 +950,9 @@ async function loadQueueStatus() {
         };
 
         tbody.innerHTML = jobs.map(j => `
-            <tr class="border-b border-white/5 hover:bg-white/5 transition-colors">
+            <tr class="border-b border-ink/5 hover:bg-ink/5 transition-colors">
                 <td class="px-4 py-3">${statusBadge(j.status)}</td>
-                <td class="px-4 py-3 text-white text-xs font-mono truncate max-w-[200px]" title="${escapeHtml(j.file_path)}">${escapeHtml(j.file_path.split(/[\\/]/).pop())}</td>
+                <td class="px-4 py-3 text-text-main text-xs font-mono truncate max-w-[200px]" title="${escapeHtml(j.file_path)}">${escapeHtml(j.file_path.split(/[\\/]/).pop())}</td>
                 <td class="px-4 py-3">${progressCell(j)}</td>
                 <td class="px-4 py-3 text-gray-500 text-xs hidden lg:table-cell">${escapeHtml(j.worker_id || '—')}</td>
                 <td class="px-4 py-3 text-gray-500 text-xs hidden md:table-cell">${timeAgo(j.created_at)}</td>

--- a/arcade_scanner/server/static/styles.css
+++ b/arcade_scanner/server/static/styles.css
@@ -13,10 +13,10 @@
     --bg: var(--ds-bg, #0b0b10);
 
     /* SURFACES */
-    --glass: var(--ds-fill, rgba(255, 255, 255, 0.06));
-    --glass-hover: rgba(255, 255, 255, 0.10);
-    --glass-active: rgba(255, 255, 255, 0.14);
-    --glass-border: var(--ds-hairline-strong, rgba(255, 255, 255, 0.12));
+    --glass: var(--ds-fill, rgb(var(--ds-text-rgb) / 0.06));
+    --glass-hover: rgb(var(--ds-text-rgb) / 0.10);
+    --glass-active: rgb(var(--ds-text-rgb) / 0.14);
+    --glass-border: var(--ds-hairline-strong, rgb(var(--ds-text-rgb) / 0.12));
     --glass-blur: blur(20px);
 
     /* SEMANTIC COLORS */
@@ -82,7 +82,7 @@ body[data-workspace] {
 
 /* Workspace indicator bar */
 .workspace-indicator {
-    border-bottom: 1px solid var(--ds-hairline, rgba(255, 255, 255, 0.08));
+    border-bottom: 1px solid var(--ds-hairline, rgb(var(--ds-text-rgb) / 0.08));
     background: transparent;
 }
 
@@ -102,8 +102,8 @@ body[data-workspace] {
 }
 
 /* Context Menu background utilities */
-.bg-white\/6 { background: rgba(255,255,255,0.06); }
-.bg-white\/8 { background: rgba(255,255,255,0.08); }
+.bg-white\/6 { background: rgb(var(--ds-text-rgb) / 0.06); }
+.bg-white\/8 { background: rgb(var(--ds-text-rgb) / 0.08); }
 
 body {
     margin: 0;
@@ -274,7 +274,7 @@ html {
 .top-bar {
     position: sticky;
     top: 0;
-    background: var(--surface-glass, rgba(255, 255, 255, 0.9));
+    background: var(--surface-glass, rgb(var(--ds-text-rgb) / 0.9));
     backdrop-filter: blur(25px) saturate(180%);
     z-index: var(--z-modal);
     padding: 18px 0;
@@ -284,7 +284,7 @@ html {
 
 .dark .top-bar {
     background: rgba(13, 1, 26, 0.7);
-    border-bottom-color: rgba(255, 255, 255, 0.05);
+    border-bottom-color: rgb(var(--ds-text-rgb) / 0.05);
     box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
 }
 
@@ -303,7 +303,7 @@ html {
 #searchBar {
     background: var(--glass);
     border: 1px solid var(--glass-border);
-    color: white;
+    color: var(--ds-text);
     padding: 14px 24px;
     border-radius: var(--radius-pill);
     width: 300px;
@@ -365,9 +365,9 @@ html {
 
 .filter-btn.active {
     background: var(--action);
-    color: #000;
+    color: var(--ds-on-accent);
     border-color: transparent;
-    box-shadow: 0 0 20px var(--action-glow), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 20px var(--action-glow), inset 0 1px 0 rgb(var(--ds-text-rgb) / 0.3);
 }
 
 /* Action buttons - circular icons */
@@ -382,15 +382,15 @@ html {
 .filter-btn.action-btn:hover {
     background: var(--action);
     border-color: var(--action);
-    color: #000;
+    color: var(--ds-on-accent);
     transform: scale(1.08);
     box-shadow: 0 0 20px var(--action-glow);
 }
 
 /* --- SAVED VIEW CHIPS --- */
 .view-chip {
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgb(var(--ds-text-rgb) / 0.08);
+    border: 1px solid rgb(var(--ds-text-rgb) / 0.15);
     border-radius: 6px;
     /* Squarer, more like a button */
     padding: 6px 12px;
@@ -408,9 +408,9 @@ html {
 }
 
 .view-chip:hover {
-    background: rgba(255, 255, 255, 0.15);
-    border-color: rgba(255, 255, 255, 0.4);
-    color: #fff;
+    background: rgb(var(--ds-text-rgb) / 0.15);
+    border-color: rgb(var(--ds-text-rgb) / 0.4);
+    color: var(--ds-text);
     transform: translateY(-1px);
 }
 
@@ -423,12 +423,12 @@ html {
 
 .add-view-btn {
     background: transparent;
-    border: 1px dashed rgba(255, 255, 255, 0.3);
-    color: rgba(255, 255, 255, 0.6);
+    border: 1px dashed rgb(var(--ds-text-rgb) / 0.3);
+    color: rgb(var(--ds-text-rgb) / 0.6);
 }
 
 .add-view-btn:hover {
-    background: rgba(255, 255, 255, 0.05);
+    background: rgb(var(--ds-text-rgb) / 0.05);
     border-color: var(--gold);
     color: var(--gold);
 }
@@ -448,7 +448,7 @@ html {
 .chip-delete:hover {
     opacity: 1;
     background: rgba(255, 59, 48, 0.2);
-    color: #ff3b30;
+    color: var(--ds-danger);
 }
 
 /* Segmented Control - Arcade Style */
@@ -467,7 +467,7 @@ html {
 }
 
 .workspace-bar {
-    background: var(--surface-glass, rgba(255, 255, 255, 0.8));
+    background: var(--surface-glass, rgb(var(--ds-text-rgb) / 0.8));
     backdrop-filter: var(--glass-blur);
     border-bottom: 1px solid var(--surface-border, rgba(0, 0, 0, 0.1));
     padding: 12px 0;
@@ -486,7 +486,7 @@ html {
 .segment-btn {
     background: transparent;
     border: none;
-    color: rgba(255, 255, 255, 0.5);
+    color: rgb(var(--ds-text-rgb) / 0.5);
     padding: 10px 20px;
     border-radius: var(--radius-md);
     cursor: pointer;
@@ -499,14 +499,14 @@ html {
 }
 
 .segment-btn:hover {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgb(var(--ds-text-rgb) / 0.8);
     background: var(--glass);
 }
 
 .segment-btn.active {
     background: var(--action);
-    color: #000;
-    box-shadow: 0 0 20px var(--action-glow), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    color: var(--ds-on-accent);
+    box-shadow: 0 0 20px var(--action-glow), inset 0 1px 0 rgb(var(--ds-text-rgb) / 0.3);
 }
 
 /* Gold Action Style */
@@ -519,7 +519,7 @@ html {
 #codecSelect {
     background: var(--glass);
     border: 1px solid var(--glass-border);
-    color: rgba(255, 255, 255, 0.8);
+    color: rgb(var(--ds-text-rgb) / 0.8);
     padding: 0 24px;
     border-radius: var(--radius-pill);
     cursor: pointer;
@@ -537,7 +537,7 @@ html {
 #statusSelect:hover,
 #codecSelect:hover {
     background: var(--glass-hover);
-    color: white;
+    color: var(--ds-text);
     border-color: var(--highlight);
 }
 
@@ -550,7 +550,7 @@ html {
 #statusSelect option,
 #codecSelect option {
     background: var(--deep-purple);
-    color: white;
+    color: var(--ds-text);
 }
 
 /* --- QUICK ACTIONS OVERLAY --- */
@@ -579,7 +579,7 @@ html {
     height: 45px;
     border-radius: 50%;
     background: var(--pink);
-    color: white;
+    color: var(--ds-on-accent-hover);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -596,12 +596,12 @@ html {
 .quick-action-btn:hover {
     transform: scale(1.1) !important;
     background: var(--gold);
-    color: #000;
+    color: var(--ds-on-bitrate);
 }
 
 .quick-action-btn.active {
     background: var(--gold);
-    color: #000;
+    color: var(--ds-on-bitrate);
 }
 
 /* --- CINEMA MODE MODAL --- */
@@ -738,7 +738,7 @@ html {
     display: flex;
     justify-content: space-between;
     padding: 8px 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid rgb(var(--ds-text-rgb) / 0.05);
 }
 
 .info-row:last-child {
@@ -753,7 +753,7 @@ html {
 }
 
 .info-value {
-    color: white;
+    color: var(--ds-text);
     font-weight: 600;
     text-align: right;
 }
@@ -834,7 +834,7 @@ html {
     height: auto;
     min-height: 120px;
     gap: 15px;
-    background: var(--surface-glass, rgba(255, 255, 255, 0.92));
+    background: var(--surface-glass, rgb(var(--ds-text-rgb) / 0.92));
     border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.1)) !important;
     border-width: 1px !important;
     box-sizing: border-box;
@@ -933,7 +933,7 @@ html {
 }
 
 .content-card {
-    background: var(--surface-glass, rgba(255, 255, 255, 0.92));
+    background: var(--surface-glass, rgb(var(--ds-text-rgb) / 0.92));
     border-radius: var(--radius-lg);
     border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.1));
     transition: all 0.35s cubic-bezier(0.2, 1, 0.2, 1);
@@ -1029,11 +1029,11 @@ html {
     transform: translateY(-5px);
     border-color: var(--pink);
     box-shadow: 0 10px 30px rgb(var(--ds-accent-rgb) / 0.15);
-    background: var(--surface-glass, rgba(255, 255, 255, 0.95));
+    background: var(--surface-glass, rgb(var(--ds-text-rgb) / 0.95));
 }
 
 .dark .content-card:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: rgb(var(--ds-text-rgb) / 0.08);
     box-shadow: 0 10px 30px rgb(var(--ds-accent-rgb) / 0.2);
 }
 
@@ -1108,7 +1108,7 @@ html {
 
 .dark .card-footer {
     border-top-color: var(--glass-border);
-    background: rgba(0, 0, 0, 0.2);
+    background: var(--ds-fill-soft);
 }
 
 .badge {
@@ -1163,22 +1163,22 @@ html {
 
 .badge.hevc {
     background: var(--action);
-    color: #000;
+    color: var(--ds-on-accent);
     box-shadow: 0 0 12px var(--action-glow);
     margin-left: 8px;
 }
 
 .badge.av1 {
-    background: rgba(139, 92, 246, 0.25);
-    color: #c4b5fd;
-    border: 1px solid rgba(139, 92, 246, 0.4);
+    background: rgb(var(--ds-av1-rgb) / 0.2);
+    color: var(--ds-av1);
+    border: 1px solid rgb(var(--ds-av1-rgb) / 0.4);
     box-shadow: 0 0 10px rgba(139, 92, 246, 0.2);
     margin-left: 8px;
 }
 
 .badge.optimized {
     background: var(--highlight);
-    color: #000;
+    color: var(--ds-on-bitrate);
     box-shadow: 0 0 12px var(--highlight-glow);
 }
 
@@ -1288,7 +1288,7 @@ html {
 }
 
 .folder-item {
-    background: rgba(255, 255, 255, 0.03);
+    background: rgb(var(--ds-text-rgb) / 0.03);
     border: 1px solid var(--glass-border);
     padding: 22px 25px;
     border-radius: 12px;
@@ -1299,7 +1299,7 @@ html {
 }
 
 .folder-item:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: rgb(var(--ds-text-rgb) / 0.08);
     border-color: var(--pink);
 }
 
@@ -1328,7 +1328,7 @@ html {
 
 .folder-progress {
     height: 6px;
-    background: rgba(255, 255, 255, 0.05);
+    background: rgb(var(--ds-text-rgb) / 0.05);
     border-radius: 3px;
     margin-top: 15px;
     overflow: hidden;
@@ -1463,7 +1463,7 @@ html {
 .treemap-legend {
     background: rgba(13, 1, 26, 0.6);
     backdrop-filter: blur(15px);
-    border-bottom: 2px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 2px solid rgb(var(--ds-text-rgb) / 0.05);
     padding: 12px 0;
 }
 
@@ -1604,10 +1604,10 @@ html {
 .settings-section textarea,
 .settings-section input[type="number"] {
     width: 100%;
-    background: rgba(255, 255, 255, 0.05);
+    background: rgb(var(--ds-text-rgb) / 0.05);
     border: 1px solid var(--glass-border);
     border-radius: 10px;
-    color: white;
+    color: var(--ds-text);
     padding: 12px 15px;
     font-family: 'SF Mono', monospace;
     font-size: 0.85rem;
@@ -1676,14 +1676,14 @@ html {
     align-items: center;
     gap: 12px;
     padding: 10px 12px;
-    background: rgba(255, 255, 255, 0.03);
+    background: rgb(var(--ds-text-rgb) / 0.03);
     border: 1px solid var(--glass-border);
     border-radius: 8px;
     transition: 0.2s;
 }
 
 .exclusion-item:hover {
-    background: rgba(255, 255, 255, 0.06);
+    background: rgb(var(--ds-text-rgb) / 0.06);
     border-color: var(--gold);
 }
 
@@ -1709,7 +1709,7 @@ html {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    color: #000;
+    color: var(--ds-on-accent);
     font-size: 14px;
     font-weight: bold;
 }
@@ -1722,7 +1722,7 @@ html {
 .exclusion-path {
     font-family: 'SF Mono', monospace;
     font-size: 0.85rem;
-    color: #fff;
+    color: var(--ds-text);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1747,7 +1747,7 @@ html {
     align-items: center;
     gap: 12px;
     padding: 12px 15px;
-    background: rgba(255, 255, 255, 0.03);
+    background: rgb(var(--ds-text-rgb) / 0.03);
     border: 1px solid var(--glass-border);
     border-radius: 10px;
 }
@@ -1836,7 +1836,7 @@ html {
         min-height: 44px;
         background: transparent;
         border: none;
-        color: rgba(255, 255, 255, 0.5);
+        color: rgb(var(--ds-text-rgb) / 0.5);
         font-size: 10px;
         gap: 4px;
         cursor: pointer;
@@ -2226,9 +2226,9 @@ html {
 }
 
 .video-card-tag.overflow-tag {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.15);
-    color: #9ca3af;
+    background: rgb(var(--ds-text-rgb) / 0.08);
+    border-color: rgb(var(--ds-text-rgb) / 0.15);
+    color: var(--ds-text-label);
 }
 
 /* --- CINEMA MODAL TAG PICKER --- */
@@ -2274,16 +2274,16 @@ html {
     font-size: 13px;
     font-weight: 600;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.08);
-    border: 2px solid rgba(255, 255, 255, 0.15);
-    color: #e5e7eb;
+    background: rgb(var(--ds-text-rgb) / 0.08);
+    border: 2px solid rgb(var(--ds-text-rgb) / 0.15);
+    color: var(--ds-text-body);
     cursor: pointer;
     transition: all 0.2s;
 }
 
 .batch-tag-option:hover {
-    background: rgba(255, 255, 255, 0.15);
-    border-color: rgba(255, 255, 255, 0.3);
+    background: rgb(var(--ds-text-rgb) / 0.15);
+    border-color: rgb(var(--ds-text-rgb) / 0.3);
     transform: translateY(-1px);
 }
 
@@ -2302,30 +2302,30 @@ html {
 /* State: All selected videos have this tag */
 .batch-tag-option.state-all {
     background: rgba(34, 197, 94, 0.2);
-    border-color: #22c55e;
-    color: #22c55e;
+    border-color: var(--ds-optimized);
+    color: var(--ds-optimized);
 }
 
 .batch-tag-option.state-all .tag-state-icon {
-    color: #22c55e;
+    color: var(--ds-optimized);
 }
 
 /* State: Some selected videos have this tag */
 .batch-tag-option.state-some {
     background: rgba(251, 191, 36, 0.15);
-    border-color: #fbbf24;
-    color: #fbbf24;
+    border-color: var(--ds-bitrate);
+    color: var(--ds-bitrate);
 }
 
 .batch-tag-option.state-some .tag-state-icon {
-    color: #fbbf24;
+    color: var(--ds-bitrate);
 }
 
 /* State: None of selected videos have this tag */
 .batch-tag-option.state-none {
-    background: rgba(255, 255, 255, 0.05);
-    border-color: rgba(255, 255, 255, 0.15);
-    color: #9ca3af;
+    background: rgb(var(--ds-text-rgb) / 0.05);
+    border-color: rgb(var(--ds-text-rgb) / 0.15);
+    color: var(--ds-text-label);
 }
 
 /* Has pending action indicator */
@@ -2357,9 +2357,9 @@ html {
 .batch-tag-modal {
     width: 100%;
     max-width: 420px;
-    background: #1A1A1E;
+    background: var(--ds-surface);
     border-radius: 16px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid rgb(var(--ds-text-rgb) / 0.08);
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
     overflow: hidden;
     transform: scale(0.95);
@@ -2375,7 +2375,7 @@ html {
     align-items: center;
     justify-content: space-between;
     padding: 16px 20px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid rgb(var(--ds-text-rgb) / 0.06);
 }
 
 .batch-tag-title-row {
@@ -2386,30 +2386,30 @@ html {
 
 .batch-tag-icon {
     font-size: 22px;
-    color: #9D5BFF;
+    color: var(--ds-av1);
 }
 
 .batch-tag-title {
     font-size: 16px;
     font-weight: 600;
-    color: white;
+    color: var(--ds-text);
     margin: 0;
 }
 
 .batch-tag-subtitle {
     font-size: 12px;
-    color: #6B7280;
+    color: var(--ds-text-muted);
     margin: 2px 0 0 0;
 }
 
 .batch-tag-subtitle strong {
-    color: #9D5BFF;
+    color: var(--ds-av1);
 }
 
 .batch-tag-close {
     background: none;
     border: none;
-    color: #6B7280;
+    color: var(--ds-text-muted);
     cursor: pointer;
     padding: 4px;
     border-radius: 6px;
@@ -2417,14 +2417,14 @@ html {
 }
 
 .batch-tag-close:hover {
-    background: rgba(255, 255, 255, 0.08);
-    color: white;
+    background: rgb(var(--ds-text-rgb) / 0.08);
+    color: var(--ds-text);
 }
 
 .batch-tag-search-container {
     position: relative;
     padding: 12px 20px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid rgb(var(--ds-text-rgb) / 0.06);
 }
 
 .batch-tag-search-icon {
@@ -2433,28 +2433,28 @@ html {
     top: 50%;
     transform: translateY(-50%);
     font-size: 18px;
-    color: #6B7280;
+    color: var(--ds-text-muted);
 }
 
 .batch-tag-search {
     width: 100%;
     padding: 10px 12px 10px 36px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgb(var(--ds-text-rgb) / 0.05);
+    border: 1px solid rgb(var(--ds-text-rgb) / 0.1);
     border-radius: 8px;
-    color: white;
+    color: var(--ds-text);
     font-size: 13px;
     outline: none;
     transition: all 0.15s;
 }
 
 .batch-tag-search:focus {
-    border-color: #9D5BFF;
-    box-shadow: 0 0 0 3px rgba(157, 91, 255, 0.15);
+    border-color: var(--ds-av1);
+    box-shadow: 0 0 0 3px rgb(var(--ds-av1-rgb) / 0.15);
 }
 
 .batch-tag-search::placeholder {
-    color: #6B7280;
+    color: var(--ds-text-muted);
 }
 
 .batch-tag-cloud {
@@ -2470,7 +2470,7 @@ html {
     width: 100%;
     text-align: center;
     padding: 24px;
-    color: #6B7280;
+    color: var(--ds-text-muted);
 }
 
 .batch-tag-empty .material-icons {
@@ -2494,48 +2494,48 @@ html {
     cursor: pointer;
     border: 1px solid transparent;
     transition: all 0.15s;
-    background: rgba(255, 255, 255, 0.05);
-    color: #D1D5DB;
+    background: rgb(var(--ds-text-rgb) / 0.05);
+    color: var(--ds-text-body);
     position: relative;
 }
 
 .batch-tag-chip:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgb(var(--ds-text-rgb) / 0.1);
 }
 
 .batch-tag-chip:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(157, 91, 255, 0.4);
+    box-shadow: 0 0 0 2px rgb(var(--ds-av1-rgb) / 0.4);
 }
 
 .batch-tag-checkbox {
     font-size: 18px;
-    color: #6B7280;
+    color: var(--ds-text-muted);
 }
 
 .batch-tag-chip.state-applied {
-    background: rgba(34, 197, 94, 0.15);
-    border-color: rgba(34, 197, 94, 0.3);
-    color: #22c55e;
+    background: rgb(var(--ds-optimized-rgb) / 0.15);
+    border-color: rgb(var(--ds-optimized-rgb) / 0.3);
+    color: var(--ds-optimized);
 }
 
 .batch-tag-chip.state-applied .batch-tag-checkbox {
-    color: #22c55e;
+    color: var(--ds-optimized);
 }
 
 .batch-tag-chip.state-indeterminate {
-    background: rgba(251, 191, 36, 0.12);
-    border-color: rgba(251, 191, 36, 0.3);
-    color: #fbbf24;
+    background: rgb(var(--ds-bitrate-rgb) / 0.12);
+    border-color: rgb(var(--ds-bitrate-rgb) / 0.3);
+    color: var(--ds-bitrate);
 }
 
 .batch-tag-chip.state-indeterminate .batch-tag-checkbox {
-    color: #fbbf24;
+    color: var(--ds-bitrate);
 }
 
 .batch-tag-chip.state-unapplied {
-    background: rgba(255, 255, 255, 0.04);
-    color: #9CA3AF;
+    background: rgb(var(--ds-text-rgb) / 0.04);
+    color: var(--ds-text-label);
 }
 
 .batch-tag-chip.has-pending {
@@ -2557,7 +2557,7 @@ html {
     position: absolute;
     top: -2px;
     right: -2px;
-    color: #9D5BFF;
+    color: var(--ds-av1);
     font-size: 16px;
     font-weight: bold;
 }
@@ -2567,39 +2567,39 @@ html {
     align-items: center;
     gap: 8px;
     padding: 12px 20px;
-    border-top: 1px solid rgba(255, 255, 255, 0.06);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-    background: rgba(0, 0, 0, 0.2);
+    border-top: 1px solid rgb(var(--ds-text-rgb) / 0.06);
+    border-bottom: 1px solid rgb(var(--ds-text-rgb) / 0.06);
+    background: var(--ds-fill-soft);
 }
 
 .batch-tag-add-icon {
     font-size: 18px;
-    color: #6B7280;
+    color: var(--ds-text-muted);
 }
 
 .batch-tag-new-input {
     flex: 1;
     padding: 8px 12px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgb(var(--ds-text-rgb) / 0.05);
+    border: 1px solid rgb(var(--ds-text-rgb) / 0.1);
     border-radius: 6px;
-    color: white;
+    color: var(--ds-text);
     font-size: 13px;
     outline: none;
 }
 
 .batch-tag-new-input:focus {
-    border-color: #9D5BFF;
+    border-color: var(--ds-av1);
 }
 
 .batch-tag-new-input::placeholder {
-    color: #6B7280;
+    color: var(--ds-text-muted);
 }
 
 .batch-tag-add-btn {
     padding: 8px 16px;
-    background: rgba(157, 91, 255, 0.2);
-    color: #9D5BFF;
+    background: rgb(var(--ds-av1-rgb) / 0.2);
+    color: var(--ds-av1);
     border: 1px solid rgba(157, 91, 255, 0.3);
     border-radius: 6px;
     font-size: 13px;
@@ -2609,23 +2609,23 @@ html {
 }
 
 .batch-tag-add-btn:hover {
-    background: rgba(157, 91, 255, 0.3);
-    color: white;
+    background: rgb(var(--ds-av1-rgb) / 0.3);
+    color: var(--ds-text);
 }
 
 .batch-tag-footer {
     display: flex;
     gap: 12px;
     padding: 16px 20px;
-    background: rgba(0, 0, 0, 0.15);
+    background: var(--ds-fill-soft);
 }
 
 .batch-tag-cancel {
     flex: 1;
     padding: 10px 16px;
     background: transparent;
-    color: #9CA3AF;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--ds-text-label);
+    border: 1px solid rgb(var(--ds-text-rgb) / 0.1);
     border-radius: 8px;
     font-size: 13px;
     font-weight: 500;
@@ -2634,8 +2634,8 @@ html {
 }
 
 .batch-tag-cancel:hover {
-    background: rgba(255, 255, 255, 0.05);
-    color: white;
+    background: rgb(var(--ds-text-rgb) / 0.05);
+    color: var(--ds-text);
 }
 
 .batch-tag-save {
@@ -2645,7 +2645,7 @@ html {
     justify-content: center;
     gap: 6px;
     padding: 10px 16px;
-    background: #9D5BFF;
+    background: var(--ds-av1);
     color: white;
     border: none;
     border-radius: 8px;
@@ -2656,7 +2656,7 @@ html {
 }
 
 .batch-tag-save:hover {
-    background: #B47FFF;
+    background: rgb(var(--ds-av1-rgb) / 0.82);
 }
 
 .batch-tag-save:disabled {
@@ -2679,9 +2679,9 @@ html {
     overflow: hidden;
     background: linear-gradient(
         90deg,
-        rgba(255, 255, 255, 0.03) 25%,
-        rgba(255, 255, 255, 0.08) 50%,
-        rgba(255, 255, 255, 0.03) 75%
+        rgb(var(--ds-text-rgb) / 0.03) 25%,
+        rgb(var(--ds-text-rgb) / 0.08) 50%,
+        rgb(var(--ds-text-rgb) / 0.03) 75%
     );
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s ease-in-out infinite;
@@ -2711,146 +2711,13 @@ html {
     animation: none;
 }
 /* ============================================================
-   LIGHT MODE — WCAG 2.1 AA CONTRAST OVERRIDES
-   Target: 4.5:1 for normal text, 3:1 for large/UI text
-   Applied via :root (no .dark class) to flip dark-only values
+   LIGHT MODE
+   Frueher stand hier ein Block aus !important-Overrides, der die
+   dark-only Hardcodes (text-white, text-gray-*, bg-black/*) pro
+   Container zurueckgebogen hat. Die Utilities zeigen jetzt auf
+   mode-aware Tokens (--ds-text, --ds-ink, semantische Farben),
+   deshalb ist das Pflaster entfallen.
    ============================================================ */
-
-/* --- Settings Modal --- */
-:root:not(.dark) #settingsModal .settings-nav-item,
-:root:not(.dark) #settingsModal .settings-nav-item span {
-    color: var(--text-muted) !important; /* #374151 — 7:1 on white */
-}
-:root:not(.dark) #settingsModal .settings-nav-item:hover,
-:root:not(.dark) #settingsModal .settings-nav-item:hover span {
-    color: var(--text-main) !important;
-    background: rgba(0,0,0,0.05) !important;
-}
-:root:not(.dark) #settingsModal .settings-nav-item.active,
-:root:not(.dark) #settingsModal .settings-nav-item.active span {
-    color: var(--text-main) !important;
-    background: rgba(0,0,0,0.06) !important;
-}
-/* Section headings: text-white → text-main */
-:root:not(.dark) #settingsModal h1,
-:root:not(.dark) #settingsModal h2,
-:root:not(.dark) #settingsModal h3,
-:root:not(.dark) #settingsModal h4 {
-    color: var(--text-main) !important;
-}
-/* Sub-labels: text-gray-500 → text-muted */
-:root:not(.dark) #settingsModal p,
-:root:not(.dark) #settingsModal label,
-:root:not(.dark) #settingsModal .text-gray-400,
-:root:not(.dark) #settingsModal .text-gray-500,
-:root:not(.dark) #settingsModal .text-gray-600 {
-    color: var(--text-muted) !important;
-}
-/* Stats cards (THUMBNAILS/TOTAL) */
-:root:not(.dark) #settingsModal .stat-card,
-:root:not(.dark) #settingsModal [class*="rounded"][class*="bg-white"] {
-    background: rgba(0,0,0,0.05) !important;
-    border-color: rgba(0,0,0,0.1) !important;
-    color: var(--text-muted) !important;
-}
-/* Close button */
-:root:not(.dark) #settingsModal button.text-gray-500 {
-    color: var(--text-muted) !important;
-}
-:root:not(.dark) #settingsModal button.text-gray-500:hover {
-    color: var(--text-main) !important;
-    background: rgba(0,0,0,0.06) !important;
-}
-/* Dividers */
-:root:not(.dark) #settingsModal .bg-white\/10,
-:root:not(.dark) #settingsModal [class*="border-white"] {
-    border-color: rgba(0,0,0,0.1) !important;
-    background-color: rgba(0,0,0,0.06) !important;
-}
-/* Form inputs */
-:root:not(.dark) #settingsModal input,
-:root:not(.dark) #settingsModal textarea,
-:root:not(.dark) #settingsModal select {
-    background: rgba(0,0,0,0.04) !important;
-    border-color: rgba(0,0,0,0.15) !important;
-    color: var(--text-main) !important;
-}
-:root:not(.dark) #settingsModal input::placeholder,
-:root:not(.dark) #settingsModal textarea::placeholder {
-    color: rgba(0,0,0,0.3) !important;
-}
-/* Section borders */
-:root:not(.dark) #settingsModal header,
-:root:not(.dark) #settingsModal footer {
-    border-color: rgba(0,0,0,0.08) !important;
-}
-
-/* --- Segmented Control Buttons (workspace chooser) --- */
-:root:not(.dark) .segment-btn {
-    color: var(--text-muted) !important;
-}
-:root:not(.dark) .segment-btn.active {
-    color: var(--text-main) !important;
-    background: var(--surface-glass) !important;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.1) !important;
-}
-
-/* --- Filter Panel light mode text --- */
-:root:not(.dark) #filterPanelContent h3,
-:root:not(.dark) #filterPanelContent label,
-:root:not(.dark) #filterPanelContent .text-gray-400,
-:root:not(.dark) #filterPanelContent .text-gray-500,
-:root:not(.dark) #filterPanelContent .text-white {
-    color: var(--text-main) !important;
-}
-:root:not(.dark) #filterPanelContent .text-gray-400 {
-    color: var(--text-muted) !important;
-}
-
-/* --- Top-bar text (search, icons) --- */
-:root:not(.dark) .top-bar .text-gray-400,
-:root:not(.dark) .top-bar .text-gray-500,
-:root:not(.dark) .top-bar .text-white {
-    color: var(--text-main) !important;
-}
-:root:not(.dark) .top-bar .text-gray-400 {
-    color: var(--text-muted) !important;
-}
-
-/* --- Collection/Tag Modals --- */
-:root:not(.dark) #collectionsModal .text-white,
-:root:not(.dark) #collectionsModal h3,
-:root:not(.dark) #tagModal .text-white,
-:root:not(.dark) #tagModal h3 {
-    color: var(--text-main) !important;
-}
-:root:not(.dark) #collectionsModal .text-gray-400,
-:root:not(.dark) #tagModal .text-gray-400 {
-    color: var(--text-muted) !important;
-}
-
-/* --- Settings Modal — Sidebar solid background (light mode) --- */
-/* Tailwind arbitrary value might not generate in Python strings,   */
-/* so we force it here with high specificity.                       */
-:root:not(.dark) #settingsModal aside {
-    background-color: #f1f3f5 !important;
-    backdrop-filter: none !important;
-}
-:root:not(.dark) #settingsModal .settings-container > aside {
-    background-color: #f1f3f5 !important;
-}
-:root:not(.dark) #settingsModal footer {
-    background-color: #f1f3f5 !important;
-    backdrop-filter: none !important;
-}
-/* Settings main content white */
-:root:not(.dark) #settingsModal main {
-    background-color: #ffffff !important;
-}
-/* outer container slight warmth */
-:root:not(.dark) #settingsModal .settings-container {
-    background-color: #ffffff !important;
-}
 
 /* === CINEMA PLAYER (Design System) ===
    Liegt hier statt im Template, weil CINEMA_MODAL_COMPONENT durch

--- a/arcade_scanner/server/static/styles.css
+++ b/arcade_scanner/server/static/styles.css
@@ -813,6 +813,26 @@ html {
     width: 100%;
 }
 
+/* Compact Folder List (Mobile) — ein Ordner pro Zeile zum Durchklicken */
+#videoGrid.folder-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: 100%;
+    overflow: hidden;
+}
+
+#videoGrid.folder-list .folder-row {
+    /* 44px ist das minimale Touch-Ziel; 64px gibt Thumbnail + zwei Textzeilen Platz */
+    min-height: 64px;
+    padding: 8px 12px;
+}
+
+.folder-row-thumb {
+    width: 56px;
+    height: 56px;
+}
+
 /* Enhanced List View (Accessible & Readable) */
 #videoGrid.list-view {
     display: flex;

--- a/arcade_scanner/server/static/tag_manager.js
+++ b/arcade_scanner/server/static/tag_manager.js
@@ -34,28 +34,28 @@ function createBatchTagModal() {
     modal.className = 'fixed inset-0 z-[100] bg-black/80 backdrop-blur-sm flex items-center justify-center p-4';
     modal.style.display = 'none';
     modal.innerHTML = `
-        <div class="w-full max-w-md bg-[#1a1a1e] rounded-2xl shadow-2xl border border-white/10 overflow-hidden">
+        <div class="w-full max-w-md bg-[#1a1a1e] rounded-2xl shadow-2xl border border-ink/10 overflow-hidden">
             <!-- Header -->
-            <div class="px-5 py-4 border-b border-white/5 flex items-center justify-between">
+            <div class="px-5 py-4 border-b border-ink/5 flex items-center justify-between">
                 <div class="flex items-center gap-3">
                     <span class="material-icons text-purple-400 text-xl">sell</span>
                     <div>
-                        <h2 class="font-semibold text-white">Batch Tagging</h2>
+                        <h2 class="font-semibold text-text-main">Batch Tagging</h2>
                         <p class="text-xs text-gray-500">Editing <strong id="batchTagCount" class="text-purple-400">0</strong> items</p>
                     </div>
                 </div>
-                <button onclick="closeBatchTagModal()" class="text-gray-500 hover:text-white p-1 rounded hover:bg-white/10 transition-colors">
+                <button onclick="closeBatchTagModal()" class="text-gray-500 hover:text-text-main p-1 rounded hover:bg-ink/10 transition-colors">
                     <span class="material-icons">close</span>
                 </button>
             </div>
             
             <!-- Search Bar -->
-            <div class="px-5 py-3 border-b border-white/5">
+            <div class="px-5 py-3 border-b border-ink/5">
                 <div class="relative">
                     <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-lg">search</span>
                     <input type="text" 
                            id="batchTagSearch" 
-                           class="w-full pl-10 pr-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm focus:border-purple-500 focus:outline-none" 
+                           class="w-full pl-10 pr-4 py-2.5 bg-ink/5 border border-ink/10 rounded-lg text-text-main text-sm focus:border-purple-500 focus:outline-none" 
                            placeholder="Search tags..." 
                            oninput="handleBatchTagSearch(this.value)"
                            onkeydown="handleBatchTagKeyNav(event)">
@@ -68,12 +68,12 @@ function createBatchTagModal() {
             </div>
             
             <!-- Add New Tag -->
-            <div class="px-5 py-3 border-t border-white/5 bg-black/20 flex gap-2">
+            <div class="px-5 py-3 border-t border-ink/5 bg-ink/5 flex gap-2">
                 <div class="relative flex-1">
                     <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-lg">add</span>
                     <input type="text" 
                            id="batchTagNewInput" 
-                           class="w-full pl-10 pr-4 py-2 bg-white/5 border border-white/10 rounded-lg text-white text-sm focus:border-purple-500 focus:outline-none" 
+                           class="w-full pl-10 pr-4 py-2 bg-ink/5 border border-ink/10 rounded-lg text-text-main text-sm focus:border-purple-500 focus:outline-none" 
                            placeholder="New tag name..."
                            onkeydown="handleBatchTagNewKeydown(event)">
                 </div>
@@ -83,8 +83,8 @@ function createBatchTagModal() {
             </div>
             
             <!-- Footer -->
-            <div class="px-5 py-4 border-t border-white/5 flex gap-3">
-                <button onclick="closeBatchTagModal()" class="flex-1 py-2.5 bg-white/5 text-gray-400 border border-white/10 rounded-lg text-sm font-medium hover:bg-white/10 hover:text-white transition-colors">
+            <div class="px-5 py-4 border-t border-ink/5 flex gap-3">
+                <button onclick="closeBatchTagModal()" class="flex-1 py-2.5 bg-ink/5 text-gray-400 border border-ink/10 rounded-lg text-sm font-medium hover:bg-ink/10 hover:text-text-main transition-colors">
                     Cancel
                 </button>
                 <button onclick="applyBatchTags()" class="flex-1 py-2.5 bg-purple-500 text-white rounded-lg text-sm font-semibold hover:bg-purple-400 transition-colors flex items-center justify-center gap-2">
@@ -253,15 +253,15 @@ function renderBatchTagOptions() {
             textColor = 'text-yellow-400';
         } else {
             checkIcon = 'check_box_outline_blank';
-            bgColor = 'bg-white/5';
-            borderColor = 'border-white/10';
+            bgColor = 'bg-ink/5';
+            borderColor = 'border-ink/10';
             textColor = 'text-gray-400';
         }
 
         const pendingGlow = hasAction ? 'shadow-[0_0_12px_rgba(168,85,247,0.4)]' : '';
 
         return `
-            <button class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer transition-all text-sm font-medium ${bgColor} ${borderColor} ${textColor} ${pendingGlow} hover:bg-white/10"
+            <button class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer transition-all text-sm font-medium ${bgColor} ${borderColor} ${textColor} ${pendingGlow} hover:bg-ink/10"
                     onclick="toggleBatchTagOption('${tag.name}')"
                     onkeydown="handleBatchTagChipKeydown(event, '${tag.name}')"
                     tabindex="${index === batchTagFocusIndex ? '0' : '-1'}">
@@ -575,13 +575,13 @@ function renderExistingTagsList() {
     container.innerHTML = tags.map(t => {
         const shortcutValue = t.shortcut ? t.shortcut.toUpperCase() : '';
         const shortcutDisplay = shortcutValue
-            ? `<span class="text-xs px-1.5 py-0.5 rounded bg-white/10 text-gray-400 cursor-pointer hover:bg-white/20" onclick="editTagShortcut('${t.name}', '${shortcutValue}')" title="Click to edit">(${shortcutValue})</span>`
+            ? `<span class="text-xs px-1.5 py-0.5 rounded bg-ink/10 text-gray-400 cursor-pointer hover:bg-ink/20" onclick="editTagShortcut('${t.name}', '${shortcutValue}')" title="Click to edit">(${shortcutValue})</span>`
             : `<span class="text-xs text-gray-600 cursor-pointer hover:text-gray-400" onclick="editTagShortcut('${t.name}', '')" title="Click to add shortcut">+ key</span>`;
         return `
-        <div class="flex items-center justify-between py-2 px-3 bg-black/30 rounded-lg border border-white/5 group" id="tag-row-${t.name}">
+        <div class="flex items-center justify-between py-2 px-3 bg-ink/10 rounded-lg border border-ink/5 group" id="tag-row-${t.name}">
             <div class="flex items-center gap-3">
                 <span class="w-4 h-4 rounded-full" style="background-color: ${t.color}"></span>
-                <span class="text-white text-sm">${t.name}</span>
+                <span class="text-text-main text-sm">${t.name}</span>
                 ${shortcutDisplay}
             </div>
             <button onclick="deleteTag('${t.name}')" class="text-gray-500 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100">

--- a/arcade_scanner/server/static/workspace.js
+++ b/arcade_scanner/server/static/workspace.js
@@ -393,6 +393,11 @@ function loadFromURL() {
     if (params.get('folderPath')) {
         folderBrowserState.currentPath = decodeURIComponent(params.get('folderPath'));
         folderBrowserPath = folderBrowserState.currentPath;
+    } else {
+        // Kein folderPath in der URL = Wurzelebene. Ohne dieses Reset bleibt beim
+        // Zurück-Navigieren der alte Pfad stehen.
+        folderBrowserState.currentPath = null;
+        folderBrowserPath = null;
     }
 
     // Check deep links

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -506,22 +506,23 @@ FOLDER_BROWSER_LEGEND_COMPONENT = """
 <div id="folderBrowserLegend" class="hidden w-full bg-arcade-bg/95 border-b border-ink/5 py-2">
     <div class="w-full px-4 flex items-center justify-between">
         <!-- Back Button -->
-        <button id="folderBrowserBackBtn" class="hidden items-center gap-2 text-sm text-gray-400 hover:text-text-main transition-colors" onclick="folderBrowserBack()">
-            <span class="material-icons text-base">arrow_back</span> BACK
+        <button id="folderBrowserBackBtn" class="hidden items-center gap-2 text-sm text-gray-400 hover:text-text-main transition-colors flex-shrink-0" onclick="folderBrowserBack()">
+            <span class="material-icons text-base">arrow_back</span>
+            <span class="hidden md:inline">BACK</span>
         </button>
 
         <!-- Breadcrumb Navigation -->
-        <div class="flex items-center gap-2 text-sm flex-1 ml-4 overflow-x-auto">
-            <span class="material-icons text-arcade-cyan text-base">folder</span>
-            <div id="folderBreadcrumb" class="flex items-center gap-1 font-mono">
+        <div class="flex items-center gap-2 text-sm flex-1 min-w-0 ml-2 md:ml-4 overflow-x-auto">
+            <span class="material-icons text-arcade-cyan text-base flex-shrink-0">folder</span>
+            <div id="folderBreadcrumb" class="flex items-center gap-1 font-mono flex-nowrap whitespace-nowrap">
                 <!-- Populated by JS -->
             </div>
         </div>
 
         <!-- Videos Here Link -->
-        <div id="folderVideosHereLink" class="hidden items-center gap-2 text-sm text-arcade-cyan hover:text-text-main cursor-pointer transition-colors" onclick="toggleFolderBrowserVideos()">
+        <div id="folderVideosHereLink" class="hidden items-center gap-2 text-sm text-arcade-cyan hover:text-text-main cursor-pointer transition-colors flex-shrink-0 ml-2" onclick="toggleFolderBrowserVideos()">
             <span class="material-icons text-base">play_circle</span>
-            <span id="folderVideosHereCount">0 videos here</span>
+            <span id="folderVideosHereCount" class="hidden md:inline">0 videos here</span>
         </div>
     </div>
 </div>

--- a/arcade_scanner/templates/components.py
+++ b/arcade_scanner/templates/components.py
@@ -3,16 +3,16 @@
 
 OPTIMIZE_PANEL_COMPONENT = """
 <!-- Optimize Panel (Tailwind) -->
-<div id="optimizePanel" class="fixed bottom-4 left-0 right-0 mx-auto w-[96%] max-w-5xl bg-[#101018]/85 backdrop-blur-2xl border border-white/20 p-4 rounded-2xl translate-y-[150%] transition-transform duration-500 z-[10050] animate-glow-pulse glow-cyan flex flex-col gap-3">
+<div id="optimizePanel" class="fixed bottom-4 left-0 right-0 mx-auto w-[96%] max-w-5xl bg-[#101018]/85 backdrop-blur-2xl border border-ink/20 p-4 rounded-2xl translate-y-[150%] transition-transform duration-500 z-[10050] animate-glow-pulse glow-cyan flex flex-col gap-3">
     <!-- Active state class 'translate-y-0' handled by JS and inline CSS in HEAD -->
 
     <!-- Header -->
-    <div class="flex items-center justify-between border-b border-white/10 pb-2">
-        <h3 class="text-white font-bold text-base flex items-center gap-2">
+    <div class="flex items-center justify-between border-b border-ink/10 pb-2">
+        <h3 class="text-text-main font-bold text-base flex items-center gap-2">
             <span class="material-icons text-arcade-cyan text-[18px]">tune</span>
             Video Optimization
         </h3>
-        <button class="w-7 h-7 rounded-full flex items-center justify-center bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white transition-all group" onclick="closeOptimize()" title="Close">
+        <button class="w-7 h-7 rounded-full flex items-center justify-center bg-ink/5 hover:bg-ink/10 text-gray-400 hover:text-text-main transition-all group" onclick="closeOptimize()" title="Close">
             <span class="material-icons text-[16px] group-hover:rotate-90 transition-transform">close</span>
         </button>
     </div>
@@ -21,53 +21,53 @@ OPTIMIZE_PANEL_COMPONENT = """
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
 
         <!-- Codec Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Codec Target</div>
                 <span class="material-icons text-[14px] text-gray-500">memory</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full">
-                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="optCodecHevc" data-codec-btn="hevc" onclick="setOptCodec('hevc')">HEVC</div>
-                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="optCodecAv1" data-codec-btn="av1" onclick="setOptCodec('av1')">AV1 🧪</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full">
+                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="optCodecHevc" data-codec-btn="hevc" onclick="setOptCodec('hevc')">HEVC</div>
+                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="optCodecAv1" data-codec-btn="av1" onclick="setOptCodec('av1')">AV1 🧪</div>
             </div>
             <!-- Hidden to save vertical space, id kept for JS safety if needed initially -->
             <span class="hidden" id="optCodecDesc"></span>
         </div>
 
         <!-- Video Processing Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Video Stream</div>
                 <span class="material-icons text-[14px] text-gray-500">movie</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full">
-                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="optVideoCompress" onclick="setOptVideo('compress')">Compress</div>
-                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="optVideoCopy" onclick="setOptVideo('copy')">Copy</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full">
+                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="optVideoCompress" onclick="setOptVideo('compress')">Compress</div>
+                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="optVideoCopy" onclick="setOptVideo('copy')">Copy</div>
             </div>
             <span class="hidden" id="optVideoDesc"></span>
         </div>
 
         <!-- Audio Setup Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Audio Stream</div>
                 <span class="material-icons text-[14px] text-gray-500">multitrack_audio</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full">
-                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="optAudioEnhanced" onclick="setOptAudio('enhanced')">Enhanced</div>
-                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="optAudioStandard" onclick="setOptAudio('standard')">Standard</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full">
+                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="optAudioEnhanced" onclick="setOptAudio('enhanced')">Enhanced</div>
+                <div class="flex-1 py-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="optAudioStandard" onclick="setOptAudio('standard')">Standard</div>
             </div>
             <span class="hidden" id="optAudioDesc"></span>
         </div>
 
         <!-- Target Quality Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col justify-center transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col justify-center transition-colors">
             <div class="flex items-center justify-between mb-1">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Target Quality</div>
                 <span class="material-icons text-[14px] text-gray-500">high_quality</span>
             </div>
             <div class="flex items-center gap-3">
-                <input type="number" class="bg-black/50 border border-white/10 text-arcade-cyan font-bold px-2 py-1 rounded-lg font-mono text-center w-[60px] text-[13px] focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30" id="optQuality" placeholder="Auto">
+                <input type="number" class="bg-ink/5 border border-ink/10 text-arcade-cyan font-bold px-2 py-1 rounded-lg font-mono text-center w-[60px] text-[13px] focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30" id="optQuality" placeholder="Auto">
                 <div class="flex flex-col">
                     <span class="text-[10px] text-gray-400 leading-none">Q-Factor</span>
                     <span class="text-[9px] text-gray-500 italic mt-1 leading-none" id="optQualitySuggestion"></span>
@@ -79,7 +79,7 @@ OPTIMIZE_PANEL_COMPONENT = """
     <!-- Trim & Timeline Area + Actions in same horizontal block for extreme compactness -->
     <div class="flex flex-col md:flex-row gap-3 items-end">
         <!-- Trim block -->
-        <div class="bg-white/[0.02] border border-white/5 rounded-xl p-3 flex-1 flex flex-col gap-2 relative group w-full">
+        <div class="bg-ink/[0.02] border border-ink/5 rounded-xl p-3 flex-1 flex flex-col gap-2 relative group w-full">
             <div class="absolute inset-0 bg-gradient-to-r from-transparent via-arcade-cyan/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-1000 pointer-events-none rounded-xl"></div>
 
             <div class="flex items-center justify-between relative z-10 hidden md:flex">
@@ -88,16 +88,16 @@ OPTIMIZE_PANEL_COMPONENT = """
                 </div>
 
                 <div class="flex items-center gap-1.5">
-                    <input type="text" class="bg-black/40 border border-white/10 text-white px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-arcade-cyan focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all" id="optTrimStart" placeholder="00:00:00">
-                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-arcade-cyan transition-colors" onclick="setTrimFromHead('start')" title="Set Start from playhead">
+                    <input type="text" class="bg-ink/5 border border-ink/10 text-text-main px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-arcade-cyan focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all" id="optTrimStart" placeholder="00:00:00">
+                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-arcade-cyan transition-colors" onclick="setTrimFromHead('start')" title="Set Start from playhead">
                         <span class="material-icons text-[12px]">arrow_downward</span>
                     </button>
                     <div class="text-gray-600 font-mono text-[10px] mx-1">-</div>
-                    <input type="text" class="bg-black/40 border border-white/10 text-white px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-arcade-cyan focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all" id="optTrimEnd" placeholder="END">
-                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-arcade-cyan transition-colors" onclick="setTrimFromHead('end')" title="Set End from playhead">
+                    <input type="text" class="bg-ink/5 border border-ink/10 text-text-main px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-arcade-cyan focus:outline-none focus:ring-1 focus:ring-arcade-cyan/30 transition-all" id="optTrimEnd" placeholder="END">
+                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-arcade-cyan transition-colors" onclick="setTrimFromHead('end')" title="Set End from playhead">
                         <span class="material-icons text-[12px]">arrow_downward</span>
                     </button>
-                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-red-400/70 hover:bg-red-400/10 hover:text-red-400 hover:border-red-400/30 transition-colors ml-1" onclick="clearTrim()" title="Clear Trim">
+                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-ink/10 rounded-md text-red-400/70 hover:bg-red-400/10 hover:text-red-400 hover:border-red-400/30 transition-colors ml-1" onclick="clearTrim()" title="Clear Trim">
                         <span class="material-icons text-[12px]">close</span>
                     </button>
                 </div>
@@ -109,7 +109,7 @@ OPTIMIZE_PANEL_COMPONENT = """
 
         <!-- Actions -->
         <div class="flex items-center justify-end gap-2 shrink-0">
-            <button class="px-4 py-2 rounded-xl text-sm font-bold text-gray-400 bg-transparent hover:bg-white/5 hover:text-white transition-colors" onclick="closeOptimize()">
+            <button class="px-4 py-2 rounded-xl text-sm font-bold text-gray-400 bg-transparent hover:bg-ink/5 hover:text-text-main transition-colors" onclick="closeOptimize()">
                 Cancel
             </button>
             <button class="btn-glitch px-5 py-2 rounded-xl text-sm font-bold cursor-pointer text-[#000] bg-arcade-cyan hover:bg-white transition-all duration-300 shadow-[0_0_15px_rgba(0,255,208,0.3)] hover:shadow-[0_0_25px_rgba(0,255,208,0.5)] transform hover:-translate-y-0.5 flex items-center justify-center gap-1.5" onclick="triggerOptimization()">
@@ -122,16 +122,16 @@ OPTIMIZE_PANEL_COMPONENT = """
 
 GIF_EXPORT_PANEL_COMPONENT = """
 <!-- GIF Export Panel (Tailwind) -->
-<div id="gifExportPanel" class="fixed bottom-4 left-0 right-0 mx-auto w-[96%] max-w-5xl bg-[#101018]/85 backdrop-blur-2xl border border-white/20 p-4 rounded-2xl translate-y-[150%] transition-transform duration-500 z-[10100] animate-glow-pulse glow-purple flex flex-col gap-3">
+<div id="gifExportPanel" class="fixed bottom-4 left-0 right-0 mx-auto w-[96%] max-w-5xl bg-[#101018]/85 backdrop-blur-2xl border border-ink/20 p-4 rounded-2xl translate-y-[150%] transition-transform duration-500 z-[10100] animate-glow-pulse glow-purple flex flex-col gap-3">
     <!-- Active state class 'translate-y-0' handled by JS -->
 
     <!-- Header -->
-    <div class="flex items-center justify-between border-b border-white/10 pb-2">
-        <h3 class="text-white font-bold text-base flex items-center gap-2">
+    <div class="flex items-center justify-between border-b border-ink/10 pb-2">
+        <h3 class="text-text-main font-bold text-base flex items-center gap-2">
             <span class="material-icons text-purple-400 text-[18px]">gif</span>
             Export GIF
         </h3>
-        <button class="w-7 h-7 rounded-full flex items-center justify-center bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white transition-all group" onclick="closeGifExport()" title="Close">
+        <button class="w-7 h-7 rounded-full flex items-center justify-center bg-ink/5 hover:bg-ink/10 text-gray-400 hover:text-text-main transition-all group" onclick="closeGifExport()" title="Close">
             <span class="material-icons text-[16px] group-hover:rotate-90 transition-transform">close</span>
         </button>
     </div>
@@ -140,69 +140,69 @@ GIF_EXPORT_PANEL_COMPONENT = """
     <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
 
         <!-- Preset Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Preset</div>
                 <span class="text-[9px] text-gray-500 italic leading-none" id="gifPresetDesc">1280x720</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full overflow-x-auto scroller-hide">
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPreset360p" onclick="setGifPreset('360p')">360p</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPreset480p" onclick="setGifPreset('480p')">480p</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="gifPreset720p" onclick="setGifPreset('720p')">720p</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPreset1080p" onclick="setGifPreset('1080p')">1080p</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPresetOriginal" onclick="setGifPreset('original')">Max</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full overflow-x-auto scroller-hide">
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPreset360p" onclick="setGifPreset('360p')">360p</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPreset480p" onclick="setGifPreset('480p')">480p</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="gifPreset720p" onclick="setGifPreset('720p')">720p</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPreset1080p" onclick="setGifPreset('1080p')">1080p</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPresetOriginal" onclick="setGifPreset('original')">Max</div>
             </div>
         </div>
 
         <!-- FPS Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">FPS</div>
                 <span class="material-icons text-[14px] text-gray-500">speed</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full overflow-x-auto scroller-hide">
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps10" onclick="setGifFps(10)">10</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="gifFps15" onclick="setGifFps(15)">15</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps20" onclick="setGifFps(20)">20</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps25" onclick="setGifFps(25)">25</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps30" onclick="setGifFps(30)">30</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full overflow-x-auto scroller-hide">
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps10" onclick="setGifFps(10)">10</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="gifFps15" onclick="setGifFps(15)">15</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps20" onclick="setGifFps(20)">20</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps25" onclick="setGifFps(25)">25</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps30" onclick="setGifFps(30)">30</div>
             </div>
         </div>
 
         <!-- Loop Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Loop</div>
                 <span class="material-icons text-[14px] text-gray-500">loop</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full">
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="gifLoop0" onclick="setGifLoop(0)" title="Loop forever">inf</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifLoop1" onclick="setGifLoop(1)" title="Play once">1x</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifLoop3" onclick="setGifLoop(3)" title="Play 3 times">3x</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full">
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="gifLoop0" onclick="setGifLoop(0)" title="Loop forever">inf</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifLoop1" onclick="setGifLoop(1)" title="Play once">1x</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifLoop3" onclick="setGifLoop(3)" title="Play 3 times">3x</div>
             </div>
         </div>
 
         <!-- Speed Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col gap-2 transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col gap-2 transition-colors">
             <div class="flex items-center justify-between">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Speed</div>
                 <span class="material-icons text-[14px] text-gray-500">fast_forward</span>
             </div>
-            <div class="flex bg-black/40 rounded-lg p-1 w-full">
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifSpeed0_5" onclick="setGifSpeed(0.5)" title="Slow motion">0.5x</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="gifSpeed1_0" onclick="setGifSpeed(1.0)" title="Normal">1x</div>
-                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifSpeed2_0" onclick="setGifSpeed(2.0)" title="Fast forward">2x</div>
+            <div class="flex bg-ink/5 rounded-lg p-1 w-full">
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifSpeed0_5" onclick="setGifSpeed(0.5)" title="Slow motion">0.5x</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="gifSpeed1_0" onclick="setGifSpeed(1.0)" title="Normal">1x</div>
+                <div class="flex-1 py-1 px-1 text-center text-[12px] cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifSpeed2_0" onclick="setGifSpeed(2.0)" title="Fast forward">2x</div>
             </div>
         </div>
 
         <!-- Quality Card -->
-        <div class="bg-white/[0.03] hover:bg-white/[0.05] rounded-xl border border-white/5 p-2.5 flex flex-col justify-center transition-colors">
+        <div class="bg-ink/[0.03] hover:bg-ink/[0.05] rounded-xl border border-ink/5 p-2.5 flex flex-col justify-center transition-colors">
             <div class="flex items-center justify-between mb-1">
                 <div class="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Quality</div>
                 <span class="text-[9px] text-gray-500 italic leading-none font-mono">Est: <span id="gifEstimatedSize" class="text-purple-400">~0 MB</span></span>
             </div>
             <div class="flex items-center gap-3">
-                <input type="number" class="bg-black/50 border border-white/10 text-purple-400 font-bold px-2 py-1 rounded-lg font-mono text-center w-[60px] text-[13px] focus:border-purple-400/50 focus:outline-none focus:ring-1 focus:ring-purple-400/30" id="gifQuality" placeholder="80" value="80" min="50" max="100" step="10" oninput="updateGifEstimate()">
+                <input type="number" class="bg-ink/5 border border-ink/10 text-purple-400 font-bold px-2 py-1 rounded-lg font-mono text-center w-[60px] text-[13px] focus:border-purple-400/50 focus:outline-none focus:ring-1 focus:ring-purple-400/30" id="gifQuality" placeholder="80" value="80" min="50" max="100" step="10" oninput="updateGifEstimate()">
                 <div class="flex flex-col">
                     <span class="text-[10px] text-gray-400 leading-none">Scale: 50-100</span>
                     <span class="text-[9px] text-gray-500 italic mt-1 leading-none">Lower = smaller file</span>
@@ -214,7 +214,7 @@ GIF_EXPORT_PANEL_COMPONENT = """
     <!-- Trim & Timeline Area + Actions -->
     <div class="flex flex-col md:flex-row gap-3 items-end">
         <!-- Trim block -->
-        <div class="bg-white/[0.02] border border-white/5 rounded-xl p-3 flex-1 flex flex-col gap-2 relative group w-full">
+        <div class="bg-ink/[0.02] border border-ink/5 rounded-xl p-3 flex-1 flex flex-col gap-2 relative group w-full">
             <div class="absolute inset-0 bg-gradient-to-r from-transparent via-purple-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-1000 pointer-events-none rounded-xl"></div>
 
             <div class="flex items-center justify-between relative z-10 hidden md:flex">
@@ -225,16 +225,16 @@ GIF_EXPORT_PANEL_COMPONENT = """
                 <div class="flex items-center gap-1.5">
                     <span class="text-xs text-gray-500 mr-2">Dur: <span id="gifDuration" class="text-purple-400 font-mono">0.0s</span></span>
 
-                    <input type="text" class="bg-black/40 border border-white/10 text-white px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400/30 transition-all" id="gifTrimStart" placeholder="00:00:00" oninput="updateGifEstimate()">
-                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-purple-400 transition-colors" onclick="setGifTrimFromHead('start')" title="Set Start from playhead">
+                    <input type="text" class="bg-ink/5 border border-ink/10 text-text-main px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400/30 transition-all" id="gifTrimStart" placeholder="00:00:00" oninput="updateGifEstimate()">
+                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-purple-400 transition-colors" onclick="setGifTrimFromHead('start')" title="Set Start from playhead">
                         <span class="material-icons text-[12px]">arrow_downward</span>
                     </button>
                     <div class="text-gray-600 font-mono text-[10px] mx-1">-</div>
-                    <input type="text" class="bg-black/40 border border-white/10 text-white px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400/30 transition-all" id="gifTrimEnd" placeholder="END" oninput="updateGifEstimate()">
-                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-purple-400 transition-colors" onclick="setGifTrimFromHead('end')" title="Set End from playhead">
+                    <input type="text" class="bg-ink/5 border border-ink/10 text-text-main px-2 py-0.5 text-xs rounded-md font-mono text-center w-[75px] focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400/30 transition-all" id="gifTrimEnd" placeholder="END" oninput="updateGifEstimate()">
+                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-purple-400 transition-colors" onclick="setGifTrimFromHead('end')" title="Set End from playhead">
                         <span class="material-icons text-[12px]">arrow_downward</span>
                     </button>
-                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-white/10 rounded-md text-red-400/70 hover:bg-red-400/10 hover:text-red-400 hover:border-red-400/30 transition-colors ml-1" onclick="clearGifTrim()" title="Clear Trim">
+                    <button class="w-[24px] h-[24px] flex items-center justify-center border border-ink/10 rounded-md text-red-400/70 hover:bg-red-400/10 hover:text-red-400 hover:border-red-400/30 transition-colors ml-1" onclick="clearGifTrim()" title="Clear Trim">
                         <span class="material-icons text-[12px]">close</span>
                     </button>
                 </div>
@@ -246,7 +246,7 @@ GIF_EXPORT_PANEL_COMPONENT = """
 
         <!-- Actions -->
         <div class="flex items-center justify-end gap-2 shrink-0">
-            <button class="px-4 py-2 rounded-xl text-sm font-bold text-gray-400 bg-transparent hover:bg-white/5 hover:text-white transition-colors" onclick="closeGifExport()">
+            <button class="px-4 py-2 rounded-xl text-sm font-bold text-gray-400 bg-transparent hover:bg-ink/5 hover:text-text-main transition-colors" onclick="closeGifExport()">
                 Cancel
             </button>
             <button class="btn-glitch px-5 py-2 rounded-xl text-sm font-bold cursor-pointer text-[#000] bg-purple-500 hover:bg-white transition-all duration-300 shadow-[0_0_15px_rgba(168,85,247,0.3)] hover:shadow-[0_0_25px_rgba(168,85,247,0.5)] transform hover:-translate-y-0.5 flex items-center justify-center gap-1.5" onclick="triggerGifExport()">
@@ -268,7 +268,7 @@ CINEMA_MODAL_COMPONENT = """
 
     <div id="cinemaSourceMessage" class="hidden flex-col items-center justify-center bg-surface rounded-ds-md p-8 border border-[var(--ds-hairline-strong)] text-center max-w-md w-full mx-4 z-40">
         <span class="material-icons text-accent-tint text-5xl mb-4">movie_filter</span>
-        <h3 class="text-white text-lg font-semibold mb-2">Source media</h3>
+        <h3 class="text-text-main text-lg font-semibold mb-2">Source media</h3>
         <p class="text-body-text text-[13px] mb-6 leading-relaxed">This high-bitrate file exceeds streaming limits and is preserved in raw quality.</p>
         <div class="flex gap-3 w-full">
             <button onclick="cinemaLocate()" class="ds-btn ds-btn-secondary flex-1">
@@ -292,7 +292,7 @@ CINEMA_MODAL_COMPONENT = """
     </div>
 
     <div id="cinemaInfoPanel" class="absolute top-20 right-[92px] w-80 bg-surface border border-[var(--ds-hairline-strong)] rounded-ds-md p-4 transform translate-x-[140%] transition-transform duration-300 z-40 text-sm text-body-text">
-        <div class="flex items-center gap-2 mb-3 text-white font-semibold border-b border-[var(--ds-hairline-strong)] pb-2">
+        <div class="flex items-center gap-2 mb-3 text-text-main font-semibold border-b border-[var(--ds-hairline-strong)] pb-2">
             <span class="material-icons text-[16px]">info</span>
             <span>Technical Details</span>
         </div>
@@ -473,16 +473,16 @@ DUPLICATE_CHECKER_MODAL_COMPONENT = """
 
 TREEMAP_LEGEND_COMPONENT = """
 <!-- Treemap Legend -->
-<div id="treemapLegend" class="hidden w-full bg-arcade-bg/95 border-b border-white/5 py-2">
+<div id="treemapLegend" class="hidden w-full bg-arcade-bg/95 border-b border-ink/5 py-2">
     <div class="w-full px-4 flex items-center justify-between">
-        <button id="treemapBackBtn" class="hidden items-center gap-2 text-sm text-gray-400 hover:text-white" onclick="treemapZoomOut()">
+        <button id="treemapBackBtn" class="hidden items-center gap-2 text-sm text-gray-400 hover:text-text-main" onclick="treemapZoomOut()">
             <span class="material-icons text-base">arrow_back</span> BACK
         </button>
 
         <div class="flex items-center gap-4 text-xs font-mono text-gray-500">
-            <span class="legend-title text-white font-bold tracking-wider">STORAGE MAP</span>
+            <span class="legend-title text-text-main font-bold tracking-wider">STORAGE MAP</span>
             <span class="legend-hint text-arcade-cyan/70"></span>
-            <div class="flex items-center gap-2 border-l border-white/10 pl-4">
+            <div class="flex items-center gap-2 border-l border-ink/10 pl-4">
                 <span class="w-2 h-2 rounded-full bg-arcade-pink"></span> HIGH
                 <span class="w-2 h-2 rounded-full bg-arcade-cyan"></span> OPTIMIZED
             </div>
@@ -490,7 +490,7 @@ TREEMAP_LEGEND_COMPONENT = """
 
         <!-- Log Scale Toggle -->
         <label class="flex items-center gap-2 cursor-pointer group">
-            <div class="relative w-8 h-4 bg-gray-700 rounded-full transition-colors group-hover:bg-gray-600">
+            <div class="relative w-8 h-4 bg-ink/25 rounded-full transition-colors group-hover:bg-ink/40">
                 <input type="checkbox" id="treemapLogToggle" onchange="toggleTreemapScale()" class="peer sr-only">
                 <div class="absolute w-3 h-3 bg-white rounded-full left-0.5 top-0.5 peer-checked:translate-x-4 transition-transform"></div>
             </div>
@@ -503,10 +503,10 @@ TREEMAP_LEGEND_COMPONENT = """
 
 FOLDER_BROWSER_LEGEND_COMPONENT = """
 <!-- Folder Browser Legend -->
-<div id="folderBrowserLegend" class="hidden w-full bg-arcade-bg/95 border-b border-white/5 py-2">
+<div id="folderBrowserLegend" class="hidden w-full bg-arcade-bg/95 border-b border-ink/5 py-2">
     <div class="w-full px-4 flex items-center justify-between">
         <!-- Back Button -->
-        <button id="folderBrowserBackBtn" class="hidden items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors" onclick="folderBrowserBack()">
+        <button id="folderBrowserBackBtn" class="hidden items-center gap-2 text-sm text-gray-400 hover:text-text-main transition-colors" onclick="folderBrowserBack()">
             <span class="material-icons text-base">arrow_back</span> BACK
         </button>
 
@@ -519,7 +519,7 @@ FOLDER_BROWSER_LEGEND_COMPONENT = """
         </div>
 
         <!-- Videos Here Link -->
-        <div id="folderVideosHereLink" class="hidden items-center gap-2 text-sm text-arcade-cyan hover:text-white cursor-pointer transition-colors" onclick="toggleFolderBrowserVideos()">
+        <div id="folderVideosHereLink" class="hidden items-center gap-2 text-sm text-arcade-cyan hover:text-text-main cursor-pointer transition-colors" onclick="toggleFolderBrowserVideos()">
             <span class="material-icons text-base">play_circle</span>
             <span id="folderVideosHereCount">0 videos here</span>
         </div>
@@ -597,12 +597,12 @@ BATCH_BAR_COMPONENT = """
 
 FOLDER_SIDEBAR_COMPONENT = """
 <!-- Folder Sidebar (Off-Canvas) -->
-<div id="folderSidebar" class="fixed inset-y-0 left-0 w-80 bg-[#101018]/95 backdrop-blur-xl border-r border-white/10 transform -translate-x-full transition-transform duration-300 z-30 flex flex-col pt-safe-top">
+<div id="folderSidebar" class="fixed inset-y-0 left-0 w-80 bg-[#101018]/95 backdrop-blur-xl border-r border-ink/10 transform -translate-x-full transition-transform duration-300 z-30 flex flex-col pt-safe-top">
     <!-- Active class 'translate-x-0' handled by JS -->
 
-    <div class="p-4 border-b border-white/10 flex items-center justify-between">
-        <h3 class="font-bold text-white tracking-wider">FOLDERS</h3>
-        <button class="text-gray-400 hover:text-white" onclick="toggleFolderSidebar()">
+    <div class="p-4 border-b border-ink/10 flex items-center justify-between">
+        <h3 class="font-bold text-text-main tracking-wider">FOLDERS</h3>
+        <button class="text-gray-400 hover:text-text-main" onclick="toggleFolderSidebar()">
             <span class="material-icons">close</span>
         </button>
     </div>
@@ -627,17 +627,17 @@ FILTER_PANEL_COMPONENT = """
     <div id="filterPanelBackdrop" class="absolute inset-0 bg-black/60 opacity-0 transition-opacity duration-300" onclick="closeFilterPanel()"></div>
 
     <!-- Panel Content -->
-    <div id="filterPanelContent" class="absolute bg-arcade-bg/98 dark:bg-[#12121a]/95 backdrop-blur-xl border-black/10 dark:border-white/10 shadow-2xl transition-transform duration-300 flex flex-col overflow-hidden
+    <div id="filterPanelContent" class="absolute bg-arcade-bg/98 dark:bg-[#12121a]/95 backdrop-blur-xl border-black/10 dark:border-ink/10 shadow-2xl transition-transform duration-300 flex flex-col overflow-hidden
         right-0 top-0 bottom-0 w-80 translate-x-full rounded-l-2xl border-l">
 
         <!-- Header -->
-        <div class="p-4 border-b border-white/5 flex items-center justify-between shrink-0">
+        <div class="p-4 border-b border-ink/5 flex items-center justify-between shrink-0">
             <div class="flex items-center gap-3">
                 <span class="material-icons text-arcade-cyan">tune</span>
-                <h2 class="font-semibold text-white">Filters</h2>
+                <h2 class="font-semibold text-text-main">Filters</h2>
                 <span id="filterPanelCount" class="text-xs text-gray-500">(0 active)</span>
             </div>
-            <button onclick="closeFilterPanel()" class="text-gray-500 hover:text-white p-1">
+            <button onclick="closeFilterPanel()" class="text-gray-500 hover:text-text-main p-1">
                 <span class="material-icons">close</span>
             </button>
         </div>
@@ -650,12 +650,12 @@ FILTER_PANEL_COMPONENT = """
                 <h3 class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-3">Filesize (MB)</h3>
                 <div class="flex items-center gap-2">
                     <div class="relative flex-1">
-                        <input type="number" id="filterMinSize" placeholder="Min" class="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none" onchange="setMinSize(this.value)">
+                        <input type="number" id="filterMinSize" placeholder="Min" class="w-full bg-ink/5 border border-ink/10 rounded-lg px-3 py-2 text-sm text-text-main focus:border-arcade-cyan/50 focus:outline-none" onchange="setMinSize(this.value)">
                         <span class="absolute right-2 top-2 text-xs text-gray-500 pointer-events-none">MB</span>
                     </div>
                     <span class="text-gray-500">-</span>
                     <div class="relative flex-1">
-                        <input type="number" id="filterMaxSize" placeholder="Max" class="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none" onchange="setMaxSize(this.value)">
+                        <input type="number" id="filterMaxSize" placeholder="Max" class="w-full bg-ink/5 border border-ink/10 rounded-lg px-3 py-2 text-sm text-text-main focus:border-arcade-cyan/50 focus:outline-none" onchange="setMaxSize(this.value)">
                         <span class="absolute right-2 top-2 text-xs text-gray-500 pointer-events-none">MB</span>
                     </div>
                 </div>
@@ -726,7 +726,7 @@ FILTER_PANEL_COMPONENT = """
             <section>
                 <div class="flex items-center justify-between mb-3">
                     <h3 class="text-xs font-bold text-gray-500 uppercase tracking-widest">Tags</h3>
-                    <button onclick="openTagManager()" class="text-xs text-arcade-cyan hover:text-cyan-300 flex items-center gap-1">
+                    <button onclick="openTagManager()" class="text-xs text-arcade-cyan hover:text-accent-hover flex items-center gap-1">
                         <span class="material-icons text-sm">add</span> Manage
                     </button>
                 </div>
@@ -738,21 +738,21 @@ FILTER_PANEL_COMPONENT = """
                 <!-- Untagged Toggle -->
                 <label class="flex items-center gap-2 mt-4 cursor-pointer group">
                     <input type="checkbox" id="filterUntaggedOnly" onchange="toggleUntaggedFilter()" class="sr-only peer">
-                    <div class="w-5 h-5 rounded border border-white/20 flex items-center justify-center peer-checked:bg-arcade-cyan peer-checked:border-arcade-cyan transition-colors">
-                        <span class="material-icons text-sm text-black opacity-0 peer-checked:opacity-100">check</span>
+                    <div class="w-5 h-5 rounded border border-ink/20 flex items-center justify-center peer-checked:bg-arcade-cyan peer-checked:border-arcade-cyan transition-colors">
+                        <span class="material-icons text-sm text-white opacity-0 peer-checked:opacity-100">check</span>
                     </div>
-                    <span class="text-sm text-gray-400 group-hover:text-white transition-colors">Show untagged only</span>
+                    <span class="text-sm text-gray-400 group-hover:text-text-main transition-colors">Show untagged only</span>
                 </label>
             </section>
 
         </div>
 
         <!-- Footer -->
-        <div class="p-4 border-t border-black/5 dark:border-white/5 flex items-center justify-between shrink-0 bg-black/5 dark:bg-[#0a0a12]">
-            <button onclick="resetFilters()" class="text-sm text-gray-500 hover:text-white transition-colors">
+        <div class="p-4 border-t border-black/5 dark:border-ink/5 flex items-center justify-between shrink-0 bg-ink/[0.03] dark:bg-[#0a0a12]">
+            <button onclick="resetFilters()" class="text-sm text-gray-500 hover:text-text-main transition-colors">
                 Reset all
             </button>
-            <button onclick="applyFilters()" class="px-6 py-2 bg-arcade-cyan text-black font-bold rounded-lg hover:bg-cyan-300 transition-colors shadow-lg shadow-arcade-cyan/20">
+            <button onclick="applyFilters()" class="px-6 py-2 bg-arcade-cyan text-white font-bold rounded-lg hover:bg-accent-hover transition-colors shadow-lg shadow-arcade-cyan/20">
                 Apply
             </button>
         </div>
@@ -825,29 +825,29 @@ FILTER_PANEL_COMPONENT = """
 TAG_MANAGER_MODAL_COMPONENT = """
 <!-- Tag Manager Modal -->
 <div id="tagManagerModal" class="fixed inset-0 z-40 bg-black/80 backdrop-blur-sm hidden opacity-0 transition-opacity duration-300 flex items-center justify-center p-4">
-    <div class="w-full max-w-md bg-[#1a1a24] rounded-2xl shadow-2xl border border-white/10 transform scale-95 transition-transform duration-300 overflow-hidden">
+    <div class="w-full max-w-md bg-[#1a1a24] rounded-2xl shadow-2xl border border-ink/10 transform scale-95 transition-transform duration-300 overflow-hidden">
 
         <!-- Header -->
-        <div class="p-4 border-b border-white/5 flex items-center justify-between">
+        <div class="p-4 border-b border-ink/5 flex items-center justify-between">
             <div class="flex items-center gap-3">
                 <span class="material-icons text-arcade-gold">label</span>
-                <h2 class="font-semibold text-white">Manage Tags</h2>
+                <h2 class="font-semibold text-text-main">Manage Tags</h2>
             </div>
-            <button onclick="closeTagManager()" class="text-gray-500 hover:text-white p-1">
+            <button onclick="closeTagManager()" class="text-gray-500 hover:text-text-main p-1">
                 <span class="material-icons">close</span>
             </button>
         </div>
 
         <!-- Create New Tag -->
-        <div class="p-4 border-b border-white/5 bg-[#12121a]">
+        <div class="p-4 border-b border-ink/5 bg-[#12121a]">
             <h3 class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-3">Create New Tag</h3>
             <div class="flex gap-2">
-                <input type="text" id="newTagName" placeholder="Tag name..." class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none">
+                <input type="text" id="newTagName" placeholder="Tag name..." class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-2 text-sm text-text-main focus:border-arcade-cyan/50 focus:outline-none">
                                 <!-- Color Picker -->
                             <div class="relative">
-                                <button type="button" id="tagColorBtn" class="w-10 h-10 rounded-lg border-2 border-white/20 hover:border-white/40 transition-colors" style="background-color: #00ffd0" onclick="toggleTagColorPicker()"></button>
+                                <button type="button" id="tagColorBtn" class="w-10 h-10 rounded-lg border-2 border-ink/20 hover:border-ink/40 transition-colors" style="background-color: #00ffd0" onclick="toggleTagColorPicker()"></button>
                                 <input type="hidden" id="newTagColor" value="#00ffd0">
-                                <div id="tagColorPicker" class="hidden absolute bottom-full left-0 mb-2 p-2 bg-[#1a1a24] rounded-lg border border-white/10 flex gap-2 flex-wrap w-40 z-50">
+                                <div id="tagColorPicker" class="hidden absolute bottom-full left-0 mb-2 p-2 bg-[#1a1a24] rounded-lg border border-ink/10 flex gap-2 flex-wrap w-40 z-50">
                                     <button type="button" class="w-6 h-6 rounded" style="background: #00ffd0" onclick="selectTagColor('#00ffd0')"></button>
                                     <button type="button" class="w-6 h-6 rounded" style="background: #ff6b9d" onclick="selectTagColor('#ff6b9d')"></button>
                                     <button type="button" class="w-6 h-6 rounded" style="background: #a855f7" onclick="selectTagColor('#a855f7')"></button>
@@ -863,7 +863,7 @@ TAG_MANAGER_MODAL_COMPONENT = """
                             <input type="text" id="newTagShortcut"
                                    placeholder="Key"
                                    maxlength="1"
-                                   class="w-12 px-2 py-2 bg-black/40 border border-white/10 rounded-lg text-white text-center uppercase focus:outline-none focus:border-arcade-cyan/50"
+                                   class="w-12 px-2 py-2 bg-ink/5 border border-ink/10 rounded-lg text-text-main text-center uppercase focus:outline-none focus:border-arcade-cyan/50"
                                    title="Cinema mode keyboard shortcut (A-Z, except F and V)">
 
                             <button type="button" onclick="createNewTag()" class="px-4 py-2 bg-arcade-cyan/20 text-arcade-cyan rounded-lg hover:bg-arcade-cyan/30 transition-colors text-sm font-medium">
@@ -882,8 +882,8 @@ TAG_MANAGER_MODAL_COMPONENT = """
         </div>
 
         <!-- Footer -->
-        <div class="p-4 border-t border-white/5 bg-[#0a0a12]">
-            <button onclick="closeTagManager()" class="w-full py-2 bg-white/5 text-gray-400 font-medium rounded-lg hover:bg-white/10 hover:text-white transition-colors">
+        <div class="p-4 border-t border-ink/5 bg-[#0a0a12]">
+            <button onclick="closeTagManager()" class="w-full py-2 bg-ink/5 text-gray-400 font-medium rounded-lg hover:bg-ink/10 hover:text-text-main transition-colors">
                 Done
             </button>
         </div>
@@ -899,16 +899,16 @@ TAG_MANAGER_MODAL_COMPONENT = """
 COLLECTION_MODAL_COMPONENT = """
 <!-- Collection Manager Modal -->
 <div id="collectionModal" class="fixed inset-0 z-40 bg-black/80 backdrop-blur-sm hidden opacity-0 transition-opacity duration-300 flex items-center justify-center p-4">
-    <div class="bg-[#101018] border border-white/10 rounded-2xl w-full max-w-2xl overflow-hidden flex flex-col max-h-[85vh] animate-glow-pulse glow-cyan">
+    <div class="bg-[#101018] border border-ink/10 rounded-2xl w-full max-w-2xl overflow-hidden flex flex-col max-h-[85vh] animate-glow-pulse glow-cyan">
 
         <!-- Header -->
-        <div class="p-4 border-b border-white/5 flex items-center justify-between shrink-0">
+        <div class="p-4 border-b border-ink/5 flex items-center justify-between shrink-0">
             <div class="flex items-center gap-3">
                 <span class="material-icons text-arcade-cyan">auto_awesome</span>
-                <h2 id="collectionModalTitle" class="font-semibold text-white">New Collection</h2>
-                <span class="text-xs text-gray-600 ml-2 hidden sm:inline">Press <kbd class="px-1 py-0.5 bg-white/5 rounded text-[10px]">ESC</kbd> to close</span>
+                <h2 id="collectionModalTitle" class="font-semibold text-text-main">New Collection</h2>
+                <span class="text-xs text-gray-600 ml-2 hidden sm:inline">Press <kbd class="px-1 py-0.5 bg-ink/5 rounded text-[10px]">ESC</kbd> to close</span>
             </div>
-            <button onclick="closeCollectionModal()" class="text-gray-500 hover:text-white p-1 hover:bg-white/5 rounded transition-colors" aria-label="Close dialog">
+            <button onclick="closeCollectionModal()" class="text-gray-500 hover:text-text-main p-1 hover:bg-ink/5 rounded transition-colors" aria-label="Close dialog">
                 <span class="material-icons">close</span>
             </button>
         </div>
@@ -921,16 +921,16 @@ COLLECTION_MODAL_COMPONENT = """
                 <h3 class="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-2">Appearance</h3>
                 <div class="flex gap-3">
                     <input type="text" id="collectionName" placeholder="Collection name..."
-                           class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors">
+                           class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors">
 
                     <!-- Icon Picker -->
                     <div class="relative">
                         <button id="collectionIconBtn" onclick="toggleCollectionIconPicker()"
-                                class="w-10 h-10 rounded-lg border border-white/10 flex items-center justify-center hover:border-arcade-cyan/30 hover:bg-white/5 transition-colors bg-black/40"
+                                class="w-10 h-10 rounded-lg border border-ink/10 flex items-center justify-center hover:border-arcade-cyan/30 hover:bg-ink/5 transition-colors bg-black/40"
                                 aria-label="Choose icon">
                             <span class="material-icons text-arcade-cyan" id="selectedCollectionIcon">folder_special</span>
                         </button>
-                        <div id="collectionIconPicker" class="hidden absolute right-0 top-12 bg-[#1a1a24] border border-white/10 rounded-lg p-2 shadow-xl z-10 grid grid-cols-5 gap-1 w-48">
+                        <div id="collectionIconPicker" class="hidden absolute right-0 top-12 bg-[#1a1a24] border border-ink/10 rounded-lg p-2 shadow-xl z-10 grid grid-cols-5 gap-1 w-48">
                             <button onclick="selectCollectionIcon('movie')" class="p-2 hover:bg-arcade-cyan/10 rounded transition-colors" aria-label="Movie icon"><span class="material-icons text-sm">movie</span></button>
                             <button onclick="selectCollectionIcon('photo_library')" class="p-2 hover:bg-arcade-cyan/10 rounded transition-colors" aria-label="Photo library icon"><span class="material-icons text-sm">photo_library</span></button>
                             <button onclick="selectCollectionIcon('folder_special')" class="p-2 hover:bg-arcade-cyan/10 rounded transition-colors" aria-label="Special folder icon"><span class="material-icons text-sm">folder_special</span></button>
@@ -947,22 +947,22 @@ COLLECTION_MODAL_COMPONENT = """
                     <!-- Color Picker -->
                     <div class="relative">
                         <button id="collectionColorBtn" onclick="toggleCollectionColorPicker()"
-                                class="w-10 h-10 rounded-lg border-2 border-white/20 flex items-center justify-center hover:border-white/40 hover:scale-105 transition-all shadow-lg"
+                                class="w-10 h-10 rounded-lg border-2 border-ink/20 flex items-center justify-center hover:border-ink/40 hover:scale-105 transition-all shadow-lg"
                                 style="background-color: #00ffd0;"
                                 aria-label="Choose color">
                         </button>
                         <input type="hidden" id="collectionColor" value="#00ffd0">
-                        <div id="collectionColorPicker" class="hidden absolute right-0 top-12 bg-[#1a1a24] border border-white/10 rounded-lg p-3 shadow-xl z-50 grid grid-cols-5 gap-2 w-64">
-                            <button onclick="selectCollectionColor('#00ffd0')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #00ffd0;" aria-label="Cyan color"></button>
-                            <button onclick="selectCollectionColor('#F4B342')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #F4B342;" aria-label="Orange color"></button>
-                            <button onclick="selectCollectionColor('#DE1A58')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #DE1A58;" aria-label="Red color"></button>
-                            <button onclick="selectCollectionColor('#8F0177')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #8F0177;" aria-label="Purple color"></button>
-                            <button onclick="selectCollectionColor('#6366f1')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #6366f1;" aria-label="Indigo color"></button>
-                            <button onclick="selectCollectionColor('#22c55e')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #22c55e;" aria-label="Green color"></button>
-                            <button onclick="selectCollectionColor('#f97316')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #f97316;" aria-label="Bright orange color"></button>
-                            <button onclick="selectCollectionColor('#06b6d4')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #06b6d4;" aria-label="Teal color"></button>
-                            <button onclick="selectCollectionColor('#ec4899')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #ec4899;" aria-label="Pink color"></button>
-                            <button onclick="selectCollectionColor('#a855f7')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-white/20" style="background-color: #a855f7;" aria-label="Violet color"></button>
+                        <div id="collectionColorPicker" class="hidden absolute right-0 top-12 bg-[#1a1a24] border border-ink/10 rounded-lg p-3 shadow-xl z-50 grid grid-cols-5 gap-2 w-64">
+                            <button onclick="selectCollectionColor('#00ffd0')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #00ffd0;" aria-label="Cyan color"></button>
+                            <button onclick="selectCollectionColor('#F4B342')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #F4B342;" aria-label="Orange color"></button>
+                            <button onclick="selectCollectionColor('#DE1A58')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #DE1A58;" aria-label="Red color"></button>
+                            <button onclick="selectCollectionColor('#8F0177')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #8F0177;" aria-label="Purple color"></button>
+                            <button onclick="selectCollectionColor('#6366f1')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #6366f1;" aria-label="Indigo color"></button>
+                            <button onclick="selectCollectionColor('#22c55e')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #22c55e;" aria-label="Green color"></button>
+                            <button onclick="selectCollectionColor('#f97316')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #f97316;" aria-label="Bright orange color"></button>
+                            <button onclick="selectCollectionColor('#06b6d4')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #06b6d4;" aria-label="Teal color"></button>
+                            <button onclick="selectCollectionColor('#ec4899')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #ec4899;" aria-label="Pink color"></button>
+                            <button onclick="selectCollectionColor('#a855f7')" class="w-8 h-8 rounded-md hover:scale-110 transition-transform ring-2 ring-ink/20" style="background-color: #a855f7;" aria-label="Violet color"></button>
                         </div>
                     </div>
                 </div>
@@ -972,18 +972,18 @@ COLLECTION_MODAL_COMPONENT = """
                     <label for="collectionCategory" class="text-xs text-gray-400 mb-1.5 block">Category (for sidebar grouping)</label>
                     <div class="flex gap-2">
                         <select id="collectionCategory"
-                                class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                                class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                 onchange="handleCategoryChange(this)">
                             <option value="">Uncategorized</option>
                             <!-- Populated by JS -->
                         </select>
                         <input type="text" id="newCategoryInput"
                                placeholder="New category..."
-                               class="hidden flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                               class="hidden flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                aria-label="New category name">
                         <button onclick="toggleNewCategoryInput()"
                                 id="addCategoryBtn"
-                                class="px-3 py-1.5 text-arcade-cyan hover:text-cyan-300 border border-white/10 rounded-lg hover:border-arcade-cyan/30 hover:bg-arcade-cyan/5 transition-colors"
+                                class="px-3 py-1.5 text-arcade-cyan hover:text-accent-hover border border-ink/10 rounded-lg hover:border-arcade-cyan/30 hover:bg-arcade-cyan/5 transition-colors"
                                 title="Add new category"
                                 aria-label="Add new category">
                             <span class="material-icons text-sm">add</span>
@@ -996,20 +996,20 @@ COLLECTION_MODAL_COMPONENT = """
             <div class="space-y-2">
 
                 <!-- Properties Accordion -->
-                <div class="border border-white/5 rounded-lg overflow-hidden">
+                <div class="border border-ink/5 rounded-lg overflow-hidden">
                     <button onclick="toggleFilterAccordion('properties')"
-                            class="w-full flex items-center justify-between p-3 bg-black/20 hover:bg-black/30 transition-colors group"
+                            class="w-full flex items-center justify-between p-3 bg-ink/5 hover:bg-ink/10 transition-colors group"
                             aria-expanded="false"
                             aria-controls="propertiesPanel">
                         <div class="flex items-center gap-2">
                             <span class="material-icons text-sm text-gray-400 group-hover:text-arcade-cyan transition-all duration-200" id="propertiesChevron">expand_more</span>
-                            <span class="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">Properties</span>
+                            <span class="text-sm font-medium text-gray-300 group-hover:text-text-main transition-colors">Properties</span>
                             <span class="text-xs text-gray-500">Media Type, Status, Format...</span>
                         </div>
                         <span id="propertiesBadge" class="hidden px-2 py-0.5 rounded-full bg-arcade-cyan/20 text-arcade-cyan text-xs font-medium"></span>
                     </button>
                     <div id="propertiesPanel" class="hidden" role="region">
-                        <div class="p-3 space-y-3 bg-black/10">
+                        <div class="p-3 space-y-3 bg-ink/[0.03]">
 
                             <!-- Media Type -->
                             <div>
@@ -1036,11 +1036,11 @@ COLLECTION_MODAL_COMPONENT = """
 
                             <!-- Advanced Technical Filters (Collapsible) -->
                             <details class="group/details">
-                                <summary class="cursor-pointer text-xs text-arcade-cyan hover:text-cyan-300 flex items-center gap-1 py-1.5 list-none select-none">
+                                <summary class="cursor-pointer text-xs text-arcade-cyan hover:text-accent-hover flex items-center gap-1 py-1.5 list-none select-none">
                                     <span class="material-icons text-xs group-open/details:rotate-90 transition-transform">chevron_right</span>
                                     Advanced technical filters
                                 </summary>
-                                <div class="mt-3 space-y-3 pl-4 border-l-2 border-white/5">
+                                <div class="mt-3 space-y-3 pl-4 border-l-2 border-ink/5">
 
                                     <!-- Codec -->
                                     <div>
@@ -1116,25 +1116,25 @@ COLLECTION_MODAL_COMPONENT = """
                 </div>
 
                 <!-- Content & Metadata Accordion -->
-                <div class="border border-white/5 rounded-lg overflow-hidden">
+                <div class="border border-ink/5 rounded-lg overflow-hidden">
                     <button onclick="toggleFilterAccordion('metadata')"
-                            class="w-full flex items-center justify-between p-3 bg-black/20 hover:bg-black/30 transition-colors group"
+                            class="w-full flex items-center justify-between p-3 bg-ink/5 hover:bg-ink/10 transition-colors group"
                             aria-expanded="false"
                             aria-controls="metadataPanel">
                         <div class="flex items-center gap-2">
                             <span class="material-icons text-sm text-gray-400 group-hover:text-arcade-cyan transition-all duration-200" id="metadataChevron">expand_more</span>
-                            <span class="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">Content & Metadata</span>
+                            <span class="text-sm font-medium text-gray-300 group-hover:text-text-main transition-colors">Content & Metadata</span>
                             <span class="text-xs text-gray-500">Date, Size, Favorites, Tags...</span>
                         </div>
                         <span id="metadataBadge" class="hidden px-2 py-0.5 rounded-full bg-arcade-cyan/20 text-arcade-cyan text-xs font-medium"></span>
                     </button>
                     <div id="metadataPanel" class="hidden" role="region">
-                        <div class="p-3 space-y-3 bg-black/10">
+                        <div class="p-3 space-y-3 bg-ink/[0.03]">
 
                             <!-- Import Date -->
                             <div>
                                 <label for="collectionDateFilter" class="text-xs text-gray-400 mb-1.5 block">Import Date</label>
-                                <select id="collectionDateFilter" class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors" onchange="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');">
+                                <select id="collectionDateFilter" class="w-full bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors" onchange="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');">
                                     <option value="all">Any Time</option>
                                     <option value="1d">Last 24 Hours</option>
                                     <option value="7d">Last 7 Days</option>
@@ -1149,12 +1149,12 @@ COLLECTION_MODAL_COMPONENT = """
                                 <label class="text-xs text-gray-400 mb-1.5 block">File Size (MB)</label>
                                 <div class="flex items-center gap-2">
                                     <input type="number" id="collectionMinSize" placeholder="Min"
-                                           class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                                           class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                            oninput="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');"
                                            aria-label="Minimum file size in megabytes">
                                     <span class="text-gray-500 text-xs">-</span>
                                     <input type="number" id="collectionMaxSize" placeholder="Max"
-                                           class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                                           class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                            oninput="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');"
                                            aria-label="Maximum file size in megabytes">
                                 </div>
@@ -1165,12 +1165,12 @@ COLLECTION_MODAL_COMPONENT = """
                                 <label class="text-xs text-gray-400 mb-1.5 block">Runtime (Seconds)</label>
                                 <div class="flex items-center gap-2">
                                     <input type="number" id="collectionMinDuration" placeholder="Min"
-                                           class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                                           class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                            oninput="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');"
                                            aria-label="Minimum duration in seconds">
                                     <span class="text-gray-500 text-xs">-</span>
                                     <input type="number" id="collectionMaxDuration" placeholder="Max"
-                                           class="flex-1 bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                                           class="flex-1 bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                            oninput="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');"
                                            aria-label="Maximum duration in seconds">
                                 </div>
@@ -1204,7 +1204,7 @@ COLLECTION_MODAL_COMPONENT = """
                             <div>
                                 <label for="collectionSearch" class="text-xs text-gray-400 mb-1.5 block">Search Term</label>
                                 <input type="text" id="collectionSearch" placeholder="Filter by filename..."
-                                       class="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
+                                       class="w-full bg-ink/5 border border-ink/10 rounded-lg px-3 py-1.5 text-sm text-text-main placeholder:text-gray-600 focus:border-arcade-cyan/50 focus:outline-none focus:ring-1 focus:ring-arcade-cyan/20 transition-colors"
                                        oninput="updateCollectionPreviewCount(); updateFilterSectionBadge('metadata');">
                             </div>
                         </div>
@@ -1215,7 +1215,7 @@ COLLECTION_MODAL_COMPONENT = """
         </div>
 
         <!-- Footer with Count Badge -->
-        <div class="p-4 border-t border-white/5 flex items-center justify-between shrink-0 bg-[#0a0a12]">
+        <div class="p-4 border-t border-ink/5 flex items-center justify-between shrink-0 bg-[#0a0a12]">
             <div class="flex items-center gap-3">
                 <span class="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-arcade-cyan/10 text-arcade-cyan text-sm font-medium">
                     <span class="material-icons text-sm" id="matchCountIcon">movie</span>
@@ -1226,17 +1226,17 @@ COLLECTION_MODAL_COMPONENT = """
                 </button>
                 <div class="flex items-center gap-2">
                     <input id="autoTagName" type="text" placeholder="auto-tag…"
-                           class="w-28 px-2 py-1.5 rounded-lg text-xs bg-white/10 border border-white/10 text-white placeholder-gray-500">
+                           class="w-28 px-2 py-1.5 rounded-lg text-xs bg-ink/10 border border-ink/10 text-text-main placeholder-gray-500">
                     <button onclick="saveAutoTagRule()"
                             class="px-3 py-1.5 rounded-lg text-xs font-bold bg-arcade-cyan/20 text-arcade-cyan hover:bg-arcade-cyan/30 transition-colors"
                             title="Aktuelle Kriterien als Auto-Tag-Regel speichern">Als Regel</button>
                 </div>
             </div>
             <div class="flex gap-3">
-                <button onclick="closeCollectionModal()" class="px-4 py-2 bg-white/5 text-gray-400 font-medium rounded-lg hover:bg-white/10 hover:text-white transition-colors">
+                <button onclick="closeCollectionModal()" class="px-4 py-2 bg-ink/5 text-gray-400 font-medium rounded-lg hover:bg-ink/10 hover:text-text-main transition-colors">
                     Cancel
                 </button>
-                <button onclick="saveCollection()" class="px-6 py-2 bg-arcade-cyan text-black font-bold rounded-lg hover:bg-cyan-300 transition-all shadow-lg shadow-arcade-cyan/20 hover:shadow-arcade-cyan/30">
+                <button onclick="saveCollection()" class="px-6 py-2 bg-arcade-cyan text-white font-bold rounded-lg hover:bg-accent-hover transition-all shadow-lg shadow-arcade-cyan/20 hover:shadow-arcade-cyan/30">
                     Save
                 </button>
             </div>
@@ -1330,12 +1330,12 @@ COLLECTION_MODAL_COMPONENT = """
 HIDDEN_PATH_MODAL_COMPONENT = """
 <!-- Hidden Path Helper Modal -->
 <div id="hiddenPathModal" class="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm hidden opacity-0 transition-opacity duration-300 flex items-center justify-center p-4">
-    <div class="w-full max-w-lg bg-[#1a1a24] rounded-2xl shadow-2xl border border-white/10 transform scale-95 transition-transform duration-300 overflow-hidden">
+    <div class="w-full max-w-lg bg-[#1a1a24] rounded-2xl shadow-2xl border border-ink/10 transform scale-95 transition-transform duration-300 overflow-hidden">
 
         <!-- Header -->
-        <div class="p-4 border-b border-white/5 flex items-center gap-3">
+        <div class="p-4 border-b border-ink/5 flex items-center gap-3">
             <span class="material-icons text-amber-400">folder_off</span>
-            <h2 class="font-semibold text-white">File in Hidden Folder</h2>
+            <h2 class="font-semibold text-text-main">File in Hidden Folder</h2>
         </div>
 
         <!-- Body -->
@@ -1346,7 +1346,7 @@ HIDDEN_PATH_MODAL_COMPONENT = """
             </p>
 
             <!-- Path Display -->
-            <div class="bg-black/40 rounded-lg p-3 border border-white/10">
+            <div class="bg-ink/5 rounded-lg p-3 border border-ink/10">
                 <label class="text-[10px] text-gray-500 uppercase tracking-wider block mb-1">Full Path</label>
                 <code id="hiddenPathDisplay" class="text-xs text-arcade-cyan break-all select-all block"></code>
             </div>
@@ -1363,7 +1363,7 @@ HIDDEN_PATH_MODAL_COMPONENT = """
                     <span class="material-icons text-amber-400 text-sm mt-0.5">lightbulb</span>
                     <div class="text-xs text-amber-200/80">
                         <strong class="text-amber-300">Tip:</strong> In Finder, press
-                        <kbd class="px-1.5 py-0.5 bg-black/30 rounded text-[10px] mx-0.5">Cmd</kbd>+<kbd class="px-1.5 py-0.5 bg-black/30 rounded text-[10px] mx-0.5">Shift</kbd>+<kbd class="px-1.5 py-0.5 bg-black/30 rounded text-[10px] mx-0.5">.</kbd>
+                        <kbd class="px-1.5 py-0.5 bg-ink/10 rounded text-[10px] mx-0.5">Cmd</kbd>+<kbd class="px-1.5 py-0.5 bg-ink/10 rounded text-[10px] mx-0.5">Shift</kbd>+<kbd class="px-1.5 py-0.5 bg-ink/10 rounded text-[10px] mx-0.5">.</kbd>
                         to show hidden files and folders.
                     </div>
                 </div>
@@ -1371,8 +1371,8 @@ HIDDEN_PATH_MODAL_COMPONENT = """
         </div>
 
         <!-- Footer -->
-        <div class="p-4 border-t border-white/5 flex justify-end">
-            <button onclick="closeHiddenPathModal()" class="px-5 py-2 bg-white/5 text-gray-400 font-medium rounded-lg hover:bg-white/10 hover:text-white transition-colors">
+        <div class="p-4 border-t border-ink/5 flex justify-end">
+            <button onclick="closeHiddenPathModal()" class="px-5 py-2 bg-ink/5 text-gray-400 font-medium rounded-lg hover:bg-ink/10 hover:text-text-main transition-colors">
                 Close
             </button>
         </div>
@@ -1395,18 +1395,18 @@ SETUP_WIZARD_COMPONENT = """
             <div class="inline-block p-4 bg-arcade-cyan/10 rounded-full mb-4">
                 <span class="material-icons text-6xl text-arcade-cyan">rocket_launch</span>
             </div>
-            <h1 class="text-4xl font-bold text-white mb-2">Welcome to Arcade Media Scanner!</h1>
+            <h1 class="text-4xl font-bold text-text-main mb-2">Welcome to Arcade Media Scanner!</h1>
             <p class="text-gray-400 text-lg">Let's configure your media library in just a few steps</p>
         </div>
 
         <!-- Setup Card -->
-        <div class="bg-[#1a1a24] rounded-2xl shadow-2xl border border-white/10 p-8">
+        <div class="bg-[#1a1a24] rounded-2xl shadow-2xl border border-ink/10 p-8">
 
             <!-- Step 1: Select Directories -->
             <div class="mb-8">
                 <div class="flex items-center gap-3 mb-4">
-                    <span class="flex items-center justify-center w-8 h-8 rounded-full bg-arcade-cyan text-black font-bold text-sm">1</span>
-                    <h2 class="text-xl font-semibold text-white">Select Media Directories</h2>
+                    <span class="flex items-center justify-center w-8 h-8 rounded-full bg-arcade-cyan text-white font-bold text-sm">1</span>
+                    <h2 class="text-xl font-semibold text-text-main">Select Media Directories</h2>
                 </div>
                 <p class="text-sm text-gray-400 mb-4">Choose which directories to scan for videos and images. Your media is mounted at <code class="px-2 py-0.5 bg-black/40 rounded text-arcade-cyan">/media</code></p>
 
@@ -1421,29 +1421,29 @@ SETUP_WIZARD_COMPONENT = """
             </div>
 
             <!-- Step 2: Image Scanning -->
-            <div class="mb-8 p-4 bg-black/20 rounded-lg border border-white/5">
+            <div class="mb-8 p-4 bg-ink/5 rounded-lg border border-ink/5">
                 <div class="flex items-center gap-3 mb-3">
-                    <span class="flex items-center justify-center w-8 h-8 rounded-full bg-arcade-cyan text-black font-bold text-sm">2</span>
-                    <h2 class="text-xl font-semibold text-white">Image Scanning</h2>
+                    <span class="flex items-center justify-center w-8 h-8 rounded-full bg-arcade-cyan text-white font-bold text-sm">2</span>
+                    <h2 class="text-xl font-semibold text-text-main">Image Scanning</h2>
                 </div>
                 <label class="flex items-center gap-3 cursor-pointer select-none">
                     <div class="relative inline-flex items-center">
                         <input type="checkbox" id="setupScanImages" class="sr-only peer">
-                        <div class="w-11 h-6 bg-gray-700 rounded-full peer peer-focus:ring-2 peer-focus:ring-arcade-cyan/50 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-arcade-cyan"></div>
+                        <div class="w-11 h-6 bg-ink/25 rounded-full peer peer-focus:ring-2 peer-focus:ring-arcade-cyan/50 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-ink/20 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-arcade-cyan"></div>
                     </div>
                     <div>
-                        <span class="text-white font-medium">Scan images (JPG, PNG, RAW, etc.)</span>
+                        <span class="text-text-main font-medium">Scan images (JPG, PNG, RAW, etc.)</span>
                         <p class="text-xs text-gray-500">Enable if you have photo libraries</p>
                     </div>
                 </label>
             </div>
 
             <!-- Actions -->
-            <div class="flex items-center justify-between pt-6 border-t border-white/10">
-                <button onclick="skipSetup()" class="px-6 py-2.5 text-gray-400 hover:text-white transition-colors text-sm">
+            <div class="flex items-center justify-between pt-6 border-t border-ink/10">
+                <button onclick="skipSetup()" class="px-6 py-2.5 text-gray-400 hover:text-text-main transition-colors text-sm">
                     Skip for now
                 </button>
-                <button onclick="completeSetup()" id="setupCompleteBtn" disabled class="px-8 py-3 bg-arcade-cyan text-black font-bold rounded-lg hover:bg-cyan-300 transition-all shadow-lg shadow-arcade-cyan/20 disabled:bg-gray-600 disabled:text-gray-400 disabled:cursor-not-allowed disabled:shadow-none">
+                <button onclick="completeSetup()" id="setupCompleteBtn" disabled class="px-8 py-3 bg-arcade-cyan text-white font-bold rounded-lg hover:bg-accent-hover transition-all shadow-lg shadow-arcade-cyan/20 disabled:bg-ink/10 disabled:text-gray-500 disabled:cursor-not-allowed disabled:shadow-none">
                     Complete Setup →
                 </button>
             </div>
@@ -1618,13 +1618,13 @@ SETTINGS_MODAL_COMPONENT = """
                             </h3>
                             <p class="text-[12px] text-text-muted mt-1">Control terminal output density during scans.</p>
                         </div>
-                        <label class="flex items-center gap-3 cursor-pointer select-none group bg-surface p-4 rounded-xl border border-white/5 hover:border-[var(--ds-hairline-strong)] transition-all">
+                        <label class="flex items-center gap-3 cursor-pointer select-none group bg-surface p-4 rounded-xl border border-ink/5 hover:border-[var(--ds-hairline-strong)] transition-all">
                             <div class="relative inline-flex items-center">
                                 <input type="checkbox" id="settingsVerboseScanning" class="sr-only peer" onchange="markSettingsUnsaved()">
                                 <div class="ds-peer-switch"></div>
                             </div>
                             <div>
-                                <span class="text-white font-medium">Verbose Scanning Logs</span>
+                                <span class="text-text-main font-medium">Verbose Scanning Logs</span>
                                 <p class="text-xs text-gray-500">Show individual filenames. Keep disabled for cleaner summaries.</p>
                             </div>
                         </label>
@@ -1644,18 +1644,18 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Minimum Size</div>
+                                <div class="text-text-main font-medium text-sm">Minimum Size</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Files below this are skipped</div>
                             </div>
-                            <div class="flex items-center gap-2 bg-black/50 rounded-lg border border-white/10 p-1">
-                                <button class="w-9 h-9 rounded-md hover:bg-white/10 text-gray-400 hover:text-white flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinSize', -10)">
+                            <div class="flex items-center gap-2 bg-ink/5 rounded-lg border border-ink/10 p-1">
+                                <button class="w-9 h-9 rounded-md hover:bg-ink/10 text-gray-400 hover:text-text-main flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinSize', -10)">
                                     <span class="material-icons text-lg">remove</span>
                                 </button>
                                 <div class="flex items-center gap-1">
-                                    <input type="number" id="settingsMinSize" value="100" min="1" class="bg-transparent text-white font-mono text-center w-14 focus:outline-none" oninput="markSettingsUnsaved()">
+                                    <input type="number" id="settingsMinSize" value="100" min="1" class="bg-transparent text-text-main font-mono text-center w-14 focus:outline-none" oninput="markSettingsUnsaved()">
                                     <span class="text-gray-500 text-sm">MB</span>
                                 </div>
-                                <button class="w-9 h-9 rounded-md hover:bg-white/10 text-gray-400 hover:text-white flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinSize', 10)">
+                                <button class="w-9 h-9 rounded-md hover:bg-ink/10 text-gray-400 hover:text-text-main flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinSize', 10)">
                                     <span class="material-icons text-lg">add</span>
                                 </button>
                             </div>
@@ -1673,18 +1673,18 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Minimum Size</div>
+                                <div class="text-text-main font-medium text-sm">Minimum Size</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Images below this are skipped</div>
                             </div>
-                            <div class="flex items-center gap-2 bg-black/50 rounded-lg border border-white/10 p-1">
-                                <button class="w-9 h-9 rounded-md hover:bg-white/10 text-gray-400 hover:text-white flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinImageSize', -50)">
+                            <div class="flex items-center gap-2 bg-ink/5 rounded-lg border border-ink/10 p-1">
+                                <button class="w-9 h-9 rounded-md hover:bg-ink/10 text-gray-400 hover:text-text-main flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinImageSize', -50)">
                                     <span class="material-icons text-lg">remove</span>
                                 </button>
                                 <div class="flex items-center gap-1">
-                                    <input type="number" id="settingsMinImageSize" value="100" min="0" max="5000" step="50" class="bg-transparent text-white font-mono text-center w-14 focus:outline-none" oninput="markSettingsUnsaved()">
+                                    <input type="number" id="settingsMinImageSize" value="100" min="0" max="5000" step="50" class="bg-transparent text-text-main font-mono text-center w-14 focus:outline-none" oninput="markSettingsUnsaved()">
                                     <span class="text-gray-500 text-sm">KB</span>
                                 </div>
-                                <button class="w-9 h-9 rounded-md hover:bg-white/10 text-gray-400 hover:text-white flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinImageSize', 50)">
+                                <button class="w-9 h-9 rounded-md hover:bg-ink/10 text-gray-400 hover:text-text-main flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsMinImageSize', 50)">
                                     <span class="material-icons text-lg">add</span>
                                 </button>
                             </div>
@@ -1702,18 +1702,18 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Bitrate Threshold</div>
+                                <div class="text-text-main font-medium text-sm">Bitrate Threshold</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Default: 15,000 kbps</div>
                             </div>
-                            <div class="flex items-center gap-2 bg-black/50 rounded-lg border border-white/10 p-1">
-                                <button class="w-9 h-9 rounded-md hover:bg-white/10 text-gray-400 hover:text-white flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsBitrate', -1000)">
+                            <div class="flex items-center gap-2 bg-ink/5 rounded-lg border border-ink/10 p-1">
+                                <button class="w-9 h-9 rounded-md hover:bg-ink/10 text-gray-400 hover:text-text-main flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsBitrate', -1000)">
                                     <span class="material-icons text-lg">remove</span>
                                 </button>
                                 <div class="flex items-center gap-1">
-                                    <input type="number" id="settingsBitrate" value="15000" min="1000" class="bg-transparent text-white font-mono text-center w-20 focus:outline-none" oninput="markSettingsUnsaved()">
+                                    <input type="number" id="settingsBitrate" value="15000" min="1000" class="bg-transparent text-text-main font-mono text-center w-20 focus:outline-none" oninput="markSettingsUnsaved()">
                                     <span class="text-gray-500 text-sm">kbps</span>
                                 </div>
-                                <button class="w-9 h-9 rounded-md hover:bg-white/10 text-gray-400 hover:text-white flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsBitrate', 1000)">
+                                <button class="w-9 h-9 rounded-md hover:bg-ink/10 text-gray-400 hover:text-text-main flex items-center justify-center transition-colors" onclick="adjustSettingsNumber('settingsBitrate', 1000)">
                                     <span class="material-icons text-lg">add</span>
                                 </button>
                             </div>
@@ -1731,7 +1731,7 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Pre-compute Thumbnails</div>
+                                <div class="text-text-main font-medium text-sm">Pre-compute Thumbnails</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Highly recommended for NAS users.</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
@@ -1752,7 +1752,7 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Use proxies for remote clients</div>
+                                <div class="text-text-main font-medium text-sm">Use proxies for remote clients</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Clients on the local network keep getting the original.</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
@@ -1762,8 +1762,8 @@ SETTINGS_MODAL_COMPONENT = """
                         </div>
 
                         <div>
-                            <label class="block text-xs font-medium text-white mb-2">Proxy Directory</label>
-                            <input type="text" id="settingsProxyRoot" placeholder="/proxies" class="w-full bg-surface border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-accent focus:outline-none" oninput="markSettingsUnsaved()">
+                            <label class="block text-xs font-medium text-text-main mb-2">Proxy Directory</label>
+                            <input type="text" id="settingsProxyRoot" placeholder="/proxies" class="w-full bg-surface border border-ink/10 rounded-lg px-3 py-2 text-sm text-text-main focus:border-accent focus:outline-none" oninput="markSettingsUnsaved()">
                             <p class="text-xs text-gray-500 mt-1">Absolute path. Leave empty to disable proxy streaming entirely. The directory is excluded from scans automatically, so proxies never appear as duplicate entries. Generate the files with <code>scripts/generate_proxies.py</code>.</p>
                         </div>
                     </section>
@@ -1815,7 +1815,7 @@ SETTINGS_MODAL_COMPONENT = """
                             <p class="text-[12px] text-text-muted mt-1">Arcade Scanner nutzt ein einheitliches Design System.</p>
                         </div>
 
-                        <div class="bg-surface rounded-ds-md p-4 border border-white/10">
+                        <div class="bg-surface rounded-ds-md p-4 border border-ink/10">
                             <p class="text-xs text-gray-500">Light/Dark schaltest du oben rechts in der Kopfzeile (Sonne/Mond) um.</p>
                         </div>
                     </section>
@@ -1833,7 +1833,7 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Video Optimizer</div>
+                                <div class="text-text-main font-medium text-sm">Video Optimizer</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Enable video compression features <span class="text-amber-400">(restart required)</span></div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
@@ -1845,7 +1845,7 @@ SETTINGS_MODAL_COMPONENT = """
                         <!-- INCLUDE PHOTOS -->
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Include Photos</div>
+                                <div class="text-text-main font-medium text-sm">Include Photos</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Include <span class="text-accent">.jpg, .png, .gif</span> etc. in library</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
@@ -1856,20 +1856,20 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <!-- REMOVE PHOTOS CONFIRMATION MODAL -->
                         <div id="removePhotosModal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-                            <div class="bg-[#1a1a2e] border border-white/10 rounded-2xl p-6 max-w-sm w-full mx-4 shadow-2xl">
+                            <div class="bg-[#1a1a2e] border border-ink/10 rounded-2xl p-6 max-w-sm w-full mx-4 shadow-2xl">
                                 <div class="flex items-center gap-3 mb-4">
                                     <span class="material-icons text-yellow-400 text-2xl">warning</span>
-                                    <h3 class="text-white font-semibold text-lg">Remove existing photos?</h3>
+                                    <h3 class="text-text-main font-semibold text-lg">Remove existing photos?</h3>
                                 </div>
                                 <p class="text-gray-400 text-sm mb-6">
-                                    Do you want to <span class="text-white font-medium">remove all existing photos</span> from the library database?
+                                    Do you want to <span class="text-text-main font-medium">remove all existing photos</span> from the library database?
                                     They won't be deleted from disk — just removed from the index.
                                 </p>
                                 <div class="flex gap-3">
                                     <button onclick="confirmRemovePhotos(true)" class="flex-1 bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 text-red-300 rounded-xl py-2.5 text-sm font-medium transition-colors">
                                         Yes, remove from DB
                                     </button>
-                                    <button onclick="confirmRemovePhotos(false)" class="flex-1 bg-white/5 hover:bg-white/10 border border-white/10 text-gray-300 rounded-xl py-2.5 text-sm font-medium transition-colors">
+                                    <button onclick="confirmRemovePhotos(false)" class="flex-1 bg-ink/5 hover:bg-ink/10 border border-ink/10 text-gray-300 rounded-xl py-2.5 text-sm font-medium transition-colors">
                                         Keep in library
                                     </button>
                                 </div>
@@ -1892,10 +1892,10 @@ SETTINGS_MODAL_COMPONENT = """
                         </div>
 
                         <div class="grid grid-cols-2 gap-3">
-                            <div class="bg-surface p-4 rounded-xl border border-white/5 flex flex-col items-center gap-2">
+                            <div class="bg-surface p-4 rounded-xl border border-ink/5 flex flex-col items-center gap-2">
                                 <span class="material-icons text-gray-500 text-2xl">image</span>
                                 <span class="text-xs text-gray-500 uppercase tracking-wider">Thumbnails</span>
-                                <span class="text-lg font-mono text-white" id="statThumbnails">—</span>
+                                <span class="text-lg font-mono text-text-main" id="statThumbnails">—</span>
                             </div>
                             <div class="bg-surface p-4 rounded-xl border border-accent/30 flex flex-col items-center gap-2">
                                 <span class="material-icons text-accent text-2xl">storage</span>
@@ -1925,7 +1925,7 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Enable Safe Mode</div>
+                                <div class="text-text-main font-medium text-sm">Enable Safe Mode</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Hide sensitive content based on tags and directories</div>
                             </div>
                             <label class="relative inline-flex items-center cursor-pointer">
@@ -1936,19 +1936,19 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card space-y-4">
                             <div>
-                                <label class="block text-xs font-medium text-white mb-2">Sensitive Directories</label>
+                                <label class="block text-xs font-medium text-text-main mb-2">Sensitive Directories</label>
                                 <textarea class="w-full ds-textarea" id="settingsSensitiveDirs" placeholder="/path/to/private" rows="3" oninput="markSettingsUnsaved()"></textarea>
                                 <p class="text-xs text-gray-500 mt-1">One absolute path per line. Files in these folders will be hidden.</p>
                             </div>
 
                             <div>
-                                <label class="block text-xs font-medium text-white mb-2">Sensitive Tags</label>
-                                <input type="text" id="settingsSensitiveTags" placeholder="nsfw, adult" class="w-full bg-surface border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-accent focus:outline-none" oninput="markSettingsUnsaved()">
+                                <label class="block text-xs font-medium text-text-main mb-2">Sensitive Tags</label>
+                                <input type="text" id="settingsSensitiveTags" placeholder="nsfw, adult" class="w-full bg-surface border border-ink/10 rounded-lg px-3 py-2 text-sm text-text-main focus:border-accent focus:outline-none" oninput="markSettingsUnsaved()">
                                 <p class="text-xs text-gray-500 mt-1">Comma separated list of tags to hide.</p>
                             </div>
 
                             <div>
-                                <label class="block text-xs font-medium text-white mb-2">Sensitive Collections</label>
+                                <label class="block text-xs font-medium text-text-main mb-2">Sensitive Collections</label>
                                 <textarea class="w-full ds-textarea" id="settingsSensitiveCollections" placeholder="My Private Collection" rows="3" oninput="markSettingsUnsaved()"></textarea>
                                 <p class="text-xs text-gray-500 mt-1">One collection name per line. These collections will be hidden from the sidebar.</p>
                             </div>
@@ -1969,10 +1969,10 @@ SETTINGS_MODAL_COMPONENT = """
 
                         <div class="ds-settings-card flex items-center justify-between gap-4">
                             <div class="flex-1">
-                                <div class="text-white font-medium text-sm">Backup Configuration</div>
+                                <div class="text-text-main font-medium text-sm">Backup Configuration</div>
                                 <div class="text-xs text-gray-500 mt-0.5">Saves as arcade_settings_backup.json</div>
                             </div>
-                            <button onclick="exportSettings()" class="px-4 py-2 bg-white/5 hover:bg-white/10 text-white rounded-lg text-sm font-medium transition-colors border border-white/10 flex items-center gap-2">
+                            <button onclick="exportSettings()" class="px-4 py-2 bg-ink/5 hover:bg-ink/10 text-text-main rounded-lg text-sm font-medium transition-colors border border-ink/10 flex items-center gap-2">
                                 <span class="material-icons text-sm">download</span>
                                 Download
                             </button>
@@ -1991,8 +1991,8 @@ SETTINGS_MODAL_COMPONENT = """
                          <div class="ds-settings-card space-y-4">
                             <div class="flex items-center gap-4">
                                 <div class="flex-1">
-                                    <label class="block text-sm font-medium text-white mb-1">Select Backup File</label>
-                                    <input type="file" id="settingsImportFile" accept=".json" class="block w-full text-xs text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-xs file:font-medium file:bg-white/10 file:text-white hover:file:bg-white/20 cursor-pointer">
+                                    <label class="block text-sm font-medium text-text-main mb-1">Select Backup File</label>
+                                    <input type="file" id="settingsImportFile" accept=".json" class="block w-full text-xs text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-xs file:font-medium file:bg-ink/10 file:text-text-main hover:file:bg-ink/20 cursor-pointer">
                                 </div>
                                 <button onclick="importSettings()" class="px-4 py-2 bg-accent/20 hover:bg-accent/30 text-accent rounded-lg text-sm font-medium transition-colors border border-accent/30 flex items-center gap-2 h-[38px] mt-6">
                                     <span class="material-icons text-sm">upload</span>
@@ -2018,10 +2018,10 @@ SETTINGS_MODAL_COMPONENT = """
                             <p class="text-[12px] text-text-muted mt-1">Files queued for remote Mac encoding. The Mac worker polls for pending jobs.</p>
                         </div>
 
-                        <div class="bg-surface rounded-xl border border-white/5 overflow-hidden">
+                        <div class="bg-surface rounded-xl border border-ink/5 overflow-hidden">
                             <table class="w-full text-sm">
                                 <thead>
-                                    <tr class="border-b border-white/5 text-gray-500 text-xs uppercase tracking-wider">
+                                    <tr class="border-b border-ink/5 text-gray-500 text-xs uppercase tracking-wider">
                                         <th class="text-left px-4 py-3">Status</th>
                                         <th class="text-left px-4 py-3">File</th>
                                         <th class="text-left px-4 py-3">Progress</th>
@@ -2065,7 +2065,7 @@ SETTINGS_MODAL_COMPONENT = """
             </div>
 
             <!-- Footer -->
-            <footer class="p-4 border-t border-black/8 dark:border-white/5 bg-[#f1f3f5] dark:bg-[#12121a] flex justify-between items-center">
+            <footer class="p-4 border-t border-black/8 dark:border-ink/5 bg-[#f1f3f5] dark:bg-[#12121a] flex justify-between items-center">
                 <div class="flex items-center gap-2">
                     <div class="flex items-center gap-2 text-amber-400 text-xs font-medium opacity-0 transition-opacity" id="unsavedIndicator">
                         <span class="material-icons text-sm">warning</span>
@@ -2073,8 +2073,8 @@ SETTINGS_MODAL_COMPONENT = """
                     </div>
                 </div>
                 <div class="flex gap-3">
-                    <button class="px-4 py-2 rounded-lg text-sm font-medium text-text-muted dark:text-gray-400 hover:text-text-main dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 transition-all" onclick="closeSettings()">Cancel</button>
-                    <button id="saveSettingsBtn" class="px-5 py-2 rounded-lg text-sm font-bold text-black bg-accent hover:bg-cyan-300 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-accent/20 transition-all flex items-center gap-2" onclick="saveSettings()">
+                    <button class="px-4 py-2 rounded-lg text-sm font-medium text-text-muted dark:text-gray-400 hover:text-text-main dark:hover:text-text-main hover:bg-black/5 dark:hover:bg-ink/5 transition-all" onclick="closeSettings()">Cancel</button>
+                    <button id="saveSettingsBtn" class="px-5 py-2 rounded-lg text-sm font-bold text-white bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-accent/20 transition-all flex items-center gap-2" onclick="saveSettings()">
                         <span class="material-icons text-lg save-icon">save</span>
                         <svg class="animate-spin h-4 w-4 save-spinner hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -2176,7 +2176,7 @@ LIST_VIEW_COMPONENT = """
 <div id="listViewContainer" class="hidden w-full overflow-x-auto">
     <table class="w-full text-left border-collapse">
         <thead>
-            <tr class="text-xs text-gray-500 border-b border-white/10">
+            <tr class="text-xs text-gray-500 border-b border-ink/10">
                 <th class="p-3 font-medium">File</th>
                 <th class="p-3 font-medium">Size</th>
                 <th class="p-3 font-medium hidden md:table-cell">Duration</th>

--- a/arcade_scanner/templates/dashboard_template.py
+++ b/arcade_scanner/templates/dashboard_template.py
@@ -127,11 +127,11 @@ def generate_html_report(results, report_file, server_port=8000):
                 <!-- Skeleton cards shown while data loads -->
                 {''.join(['''
                 <div class="group relative w-full bg-card rounded-ds-md overflow-hidden border border-line/60 flex flex-col skeleton-card" aria-hidden="true">
-                    <div class="aspect-video bg-white/5 animate-pulse"></div>
+                    <div class="aspect-video bg-ink/5 animate-pulse"></div>
                     <div class="px-[11px] py-2.5 flex flex-col gap-2">
-                        <div class="h-3 bg-white/5 animate-pulse rounded w-3/4"></div>
-                        <div class="h-2 bg-white/5 animate-pulse rounded w-1/2"></div>
-                        <div class="h-[3px] bg-white/5 animate-pulse rounded w-full mt-2"></div>
+                        <div class="h-3 bg-ink/5 animate-pulse rounded w-3/4"></div>
+                        <div class="h-2 bg-ink/5 animate-pulse rounded w-1/2"></div>
+                        <div class="h-[3px] bg-ink/5 animate-pulse rounded w-full mt-2"></div>
                     </div>
                 </div>''' for _ in range(8)])}
             </div>
@@ -140,7 +140,7 @@ def generate_html_report(results, report_file, server_port=8000):
             {LIST_VIEW_COMPONENT}
 
             <!-- Treemap Container -->
-            <div id="treemapContainer" class="hidden h-[70vh] w-full rounded-xl overflow-hidden border border-white/10 shadow-2xl"></div>
+            <div id="treemapContainer" class="hidden h-[70vh] w-full rounded-xl overflow-hidden border border-ink/10 shadow-2xl"></div>
 
             <!-- Loading Spinner -->
             <div id="loadingSentinel" class="h-24 flex items-center justify-center opacity-0 transition-opacity">

--- a/arcade_scanner/templates/gif_panel_component.py
+++ b/arcade_scanner/templates/gif_panel_component.py
@@ -1,17 +1,17 @@
 GIF_EXPORT_PANEL_COMPONENT = """
 <!-- GIF Export Panel (Tailwind) -->
-<div id="gifExportPanel" class="fixed bottom-0 left-0 right-0 bg-[#101018]/95 backdrop-blur-xl border-t border-white/10 p-6 translate-y-[110%] transition-transform duration-300 z-[10100] shadow-[0_-10px_40px_rgba(0,0,0,0.5)] flex flex-col gap-4">
+<div id="gifExportPanel" class="fixed bottom-0 left-0 right-0 bg-[#101018]/95 backdrop-blur-xl border-t border-ink/10 p-6 translate-y-[110%] transition-transform duration-300 z-[10100] shadow-[0_-10px_40px_rgba(0,0,0,0.5)] flex flex-col gap-4">
     <!-- Active state class 'translate-y-0' handled by JS -->
 
     <!-- Preset Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">Preset</div>
-        <div class="flex bg-white/5 rounded-lg p-0.5 gap-0.5">
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPreset360p" onclick="setGifPreset('360p')">360p</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPreset480p" onclick="setGifPreset('480p')">480p</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="gifPreset720p" onclick="setGifPreset('720p')">720p</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPreset1080p" onclick="setGifPreset('1080p')">1080p</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifPresetOriginal" onclick="setGifPreset('original')">Original</div>
+        <div class="flex bg-ink/5 rounded-lg p-0.5 gap-0.5">
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPreset360p" onclick="setGifPreset('360p')">360p</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPreset480p" onclick="setGifPreset('480p')">480p</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="gifPreset720p" onclick="setGifPreset('720p')">720p</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPreset1080p" onclick="setGifPreset('1080p')">1080p</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifPresetOriginal" onclick="setGifPreset('original')">Original</div>
         </div>
         <div class="flex-1"></div>
         <span class="text-xs text-gray-500" id="gifPresetDesc">1280×720 - High Quality</span>
@@ -20,12 +20,12 @@ GIF_EXPORT_PANEL_COMPONENT = """
     <!-- FPS Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">FPS</div>
-        <div class="flex bg-white/5 rounded-lg p-0.5 gap-0.5">
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps10" onclick="setGifFps(10)">10</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-white bg-white/10 shadow-sm transition-all" id="gifFps15" onclick="setGifFps(15)">15</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps20" onclick="setGifFps(20)">20</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps25" onclick="setGifFps(25)">25</div>
-            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-white transition-all" id="gifFps30" onclick="setGifFps(30)">30</div>
+        <div class="flex bg-ink/5 rounded-lg p-0.5 gap-0.5">
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps10" onclick="setGifFps(10)">10</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-text-main bg-ink/10 shadow-sm transition-all" id="gifFps15" onclick="setGifFps(15)">15</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps20" onclick="setGifFps(20)">20</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps25" onclick="setGifFps(25)">25</div>
+            <div class="px-4 py-1.5 text-sm cursor-pointer rounded-md text-gray-400 hover:text-text-main transition-all" id="gifFps30" onclick="setGifFps(30)">30</div>
         </div>
         <div class="flex-1"></div>
         <span class="text-xs text-gray-500">Frame rate (higher = smoother)</span>
@@ -34,21 +34,21 @@ GIF_EXPORT_PANEL_COMPONENT = """
     <!-- Trim Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">Trim</div>
-        <input type="text" class="bg-black/30 border border-white/10 text-white px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifTrimStart" placeholder="00:00:00" oninput="updateGifEstimate()">
+        <input type="text" class="bg-ink/10 border border-ink/10 text-text-main px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifTrimStart" placeholder="00:00:00" oninput="updateGifEstimate()">
 
-        <button class="w-[30px] h-[30px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors" onclick="setGifTrimFromHead('start')" title="Set Start">
+        <button class="w-[30px] h-[30px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-text-main transition-colors" onclick="setGifTrimFromHead('start')" title="Set Start">
             <span class="material-icons text-[16px]">arrow_downward</span>
         </button>
 
         <div class="w-[10px] text-center text-gray-600">-</div>
 
-        <input type="text" class="bg-black/30 border border-white/10 text-white px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifTrimEnd" placeholder="END" oninput="updateGifEstimate()">
+        <input type="text" class="bg-ink/10 border border-ink/10 text-text-main px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifTrimEnd" placeholder="END" oninput="updateGifEstimate()">
 
-        <button class="w-[30px] h-[30px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors" onclick="setGifTrimFromHead('end')" title="Set End">
+        <button class="w-[30px] h-[30px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-text-main transition-colors" onclick="setGifTrimFromHead('end')" title="Set End">
             <span class="material-icons text-[16px]">arrow_downward</span>
         </button>
 
-        <button class="w-[30px] h-[30px] flex items-center justify-center border border-white/10 rounded-md text-gray-400 hover:bg-white/10 hover:text-white transition-colors ml-2" onclick="clearGifTrim()" title="Clear">
+        <button class="w-[30px] h-[30px] flex items-center justify-center border border-ink/10 rounded-md text-gray-400 hover:bg-ink/10 hover:text-text-main transition-colors ml-2" onclick="clearGifTrim()" title="Clear">
             <span class="material-icons text-[16px]">close</span>
         </button>
 
@@ -59,16 +59,16 @@ GIF_EXPORT_PANEL_COMPONENT = """
     <!-- Quality Row -->
     <div class="flex items-center gap-4 flex-wrap">
         <div class="text-xs text-gray-400 font-bold uppercase tracking-widest w-[60px]">Quality</div>
-        <input type="number" class="bg-black/30 border border-white/10 text-white px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifQuality" placeholder="80" value="80" min="50" max="100" step="10" oninput="updateGifEstimate()">
+        <input type="number" class="bg-ink/10 border border-ink/10 text-text-main px-3 py-1.5 rounded-md font-mono text-center w-[100px] focus:border-arcade-cyan/50 focus:outline-none" id="gifQuality" placeholder="80" value="80" min="50" max="100" step="10" oninput="updateGifEstimate()">
 
         <span class="text-xs text-gray-500 font-mono">Estimated: <span id="gifEstimatedSize" class="text-arcade-cyan">~0 MB</span></span>
     </div>
 
     <!-- Actions -->
     <div class="flex items-center gap-4 mt-2">
-        <button class="flex-1 py-2.5 rounded-lg font-bold cursor-pointer text-gray-400 bg-white/5 hover:bg-white/10 hover:text-white transition-all max-w-[120px]" onclick="closeGifExport()">Cancel</button>
+        <button class="flex-1 py-2.5 rounded-lg font-bold cursor-pointer text-gray-400 bg-ink/5 hover:bg-ink/10 hover:text-text-main transition-all max-w-[120px]" onclick="closeGifExport()">Cancel</button>
 
-        <button class="flex-1 py-2.5 rounded-lg font-bold cursor-pointer text-white bg-purple-500/20 text-purple-400 border border-purple-500/50 shadow-[0_0_15px_rgba(168,85,247,0.2)] hover:bg-purple-500 hover:text-white transition-all flex items-center justify-center gap-2" onclick="triggerGifExport()">
+        <button class="flex-1 py-2.5 rounded-lg font-bold cursor-pointer text-text-main bg-purple-500/20 text-purple-400 border border-purple-500/50 shadow-[0_0_15px_rgba(168,85,247,0.2)] hover:bg-purple-500 hover:text-text-main transition-all flex items-center justify-center gap-2" onclick="triggerGifExport()">
             <span class="material-icons">gif</span> EXPORT GIF
         </button>
     </div>

--- a/arcade_scanner/templates/theme.py
+++ b/arcade_scanner/templates/theme.py
@@ -26,7 +26,8 @@ SURFACES = {
     "surface-2": ("#ffffff", "#1a1a24"),
     "border": ("#e2e2e6", "#2a2a35"),
     "text": ("#15151d", "#f2f2f5"),
-    "text-muted": ("#5c5c66", "#6b6b76"),
+    # Dark lag mit #6b6b76 bei 3.4:1 unter AA; #7e7e8a bringt 4.5:1.
+    "text-muted": ("#5c5c66", "#7e7e8a"),
     # Fliesstext sitzt zwischen text und text-muted
     "text-body": ("#3a3a44", "#c7c7cf"),
     # Eyebrow/Label-Grau
@@ -37,17 +38,26 @@ SURFACES = {
     "card": ("#ffffff", "#14141a"),
 }
 
-# Brand + Semantik. Identisch in Light und Dark — nur EIN Accent.
+# Brand. Identisch in Light und Dark — nur EIN Accent.
+# #c4179f liegt bei 5.8:1 auf Weiss und 5.0:1 auf #0b0b10, funktioniert also
+# in beiden Modi als Text- und als Flaechenfarbe.
 BRAND = {
     "accent": "#c4179f",
     "accent-hover": "#e34fc0",
-    "accent-tint": "#e879c6",
-    # Semantische Farben ausschliesslich fuer Badges/Readouts:
-    "hevc": "#22d3c7",
-    "av1": "#a78bfa",
-    "bitrate": "#f2b544",
-    "optimized": "#4ade80",
-    "danger": "#f36969",
+}
+
+# Semantische Farben (Badges/Readouts): (light, dark).
+# Die Dark-Werte sind die bisherigen; die Light-Werte sind so weit abgedunkelt,
+# dass sie auf #ffffff mindestens 4.5:1 erreichen — die alten Pastelltoene lagen
+# dort bei 1.8–2.9:1 und waren praktisch unlesbar.
+SEMANTIC = {
+    "accent-tint": ("#a41285", "#e879c6"),
+    "hevc": ("#0e7d76", "#22d3c7"),
+    "av1": ("#6d3fd6", "#a78bfa"),
+    "bitrate": ("#8a6100", "#f2b544"),
+    "optimized": ("#12803e", "#4ade80"),
+    "danger": ("#c0342f", "#f36969"),
+    "info": ("#1d4ed8", "#93c5fd"),
 }
 
 SPACING = [4, 8, 12, 16, 24, 32, 48]
@@ -55,6 +65,29 @@ RADII = {"xs": 4, "sm": 6, "md": 8, "lg": 10}
 
 FONT_SANS = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
 FONT_MONO = "ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace"
+
+
+def _relative_luminance(hex_color: str) -> float:
+    h = hex_color.lstrip("#")
+    channels = []
+    for i in (0, 2, 4):
+        c = int(h[i:i + 2], 16) / 255
+        channels.append(c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4)
+    r, g, b = channels
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _on_color(hex_color: str) -> str:
+    """Lesbare Textfarbe fuer eine gefuellte Flaeche (Buttons, Badges, Chips).
+
+    Fuellfarben wechseln zwischen Light und Dark (bitrate ist hell im Dark- und
+    dunkel im Light-Mode), also darf das Vordergrund-Schwarz/Weiss nicht fest
+    im CSS stehen.
+    """
+    lum = _relative_luminance(hex_color)
+    white_ratio = 1.05 / (lum + 0.05)
+    black_ratio = (lum + 0.05) / 0.05
+    return "#ffffff" if white_ratio >= black_ratio else "#15151d"
 
 
 def _rgb(hex_color: str) -> str:
@@ -125,6 +158,7 @@ class Theme:
             "bitrate": c("bitrate"),
             "optimized": c("optimized"),
             "danger": c("danger"),
+            "info": c("info"),
             # Legacy-Aliase — zeigen bewusst auf den EINEN Accent bzw. die
             # passende semantische Farbe, damit nicht migrierte Dateien
             # automatisch konform werden.
@@ -135,6 +169,44 @@ class Theme:
             "arcade-magenta": c("accent"),
             "arcade-pink": c("accent-hover"),
             "arcade-gold": c("bitrate"),
+            # "ink" = Vordergrundfarbe als Flaechen-/Linienquelle. Ersetzt die
+            # frueheren `*-white/N`-Utilities: im Dark-Mode weiss, im Light-Mode
+            # schwarz — so bleiben Hairlines und Soft-Fills in beiden Modi sichtbar.
+            "ink": c("text"),
+        }
+
+        # Legacy-Tailwind-Paletten: die hellen 200–400er Toene stammen aus der
+        # dark-only Zeit und liegen im Light-Mode bei ~2:1 auf Weiss. Sie zeigen
+        # deshalb auf die mode-aware semantischen Tokens. 500+ bleibt Tailwind,
+        # damit gefuellte Buttons/Tints (bg-purple-500/20 ...) unveraendert sind.
+        for family, token in (
+            ("red", "danger"),
+            ("green", "optimized"),
+            ("emerald", "optimized"),
+            ("amber", "bitrate"),
+            ("yellow", "bitrate"),
+            ("orange", "bitrate"),
+            ("cyan", "hevc"),
+            ("blue", "info"),
+        ):
+            colors[family] = {shade: c(token) for shade in ("200", "300", "400")}
+        # purple/pink tragen im Code bewusste Light-Mode-Styles auf 200/300 —
+        # dort nur den 400er-Ton umbiegen.
+        colors["purple"] = {"400": c("av1")}
+        colors["pink"] = {"400": c("accent-tint")}
+
+        # Legacy-Graustufen zeigen auf die semantische Textskala, damit
+        # `text-gray-400` & Co. im Light-Mode nicht auf Weiss verschwinden.
+        colors["gray"] = {
+            "100": c("text"),
+            "200": c("text"),
+            "300": c("text-body"),
+            "400": c("text-label"),
+            "500": c("text-muted"),
+            "600": c("text-muted"),
+            "700": c("text-muted"),
+            "800": c("text-muted"),
+            "900": c("text"),
         }
 
         config = {
@@ -179,6 +251,15 @@ def _var_block(mode_index: int) -> str:
     for token, value in BRAND.items():
         lines.append(f"    --ds-{token}: {value};")
         lines.append(f"    --ds-{token}-rgb: {_rgb(value)};")
+        lines.append(f"    --ds-on-{token}: {_on_color(value)};")
+    for token, pair in SEMANTIC.items():
+        value = pair[mode_index]
+        lines.append(f"    --ds-{token}: {value};")
+        lines.append(f"    --ds-{token}-rgb: {_rgb(value)};")
+        # -media-rgb bleibt in beiden Modi der helle Dark-Ton: Badges & Co.
+        # liegen auf Thumbnails, nicht auf der Theme-Flaeche.
+        lines.append(f"    --ds-{token}-media-rgb: {_rgb(pair[1])};")
+        lines.append(f"    --ds-on-{token}: {_on_color(value)};")
 
     bg, surface, border = (
         SURFACES["bg"][mode_index],
@@ -205,7 +286,7 @@ def _var_block(mode_index: int) -> str:
         f"    --arcade-magenta: {BRAND['accent']};",
         f"    --arcade-pink: {BRAND['accent-hover']};",
         f"    --arcade-cyan: {BRAND['accent']};",
-        f"    --arcade-gold: {BRAND['bitrate']};",
+        f"    --arcade-gold: {SEMANTIC['bitrate'][mode_index]};",
         f"    --arcade-purple: {SURFACES['surface-2'][mode_index]};",
         f"    --surface-glass: {surface};",
         f"    --surface-border: {border};",
@@ -266,16 +347,20 @@ html, body {{
     line-height: 1;
     letter-spacing: 0.02em;
     color: rgb(var(--ds-badge-rgb));
-    background: rgb(var(--ds-badge-rgb) / 0.17);
+    /* Badges liegen immer auf Thumbnails, nie auf einer Theme-Flaeche: der
+       dunkle Scrim bleibt darum auch im Light-Mode stehen. */
+    background-color: rgba(0,0,0,0.5);
+    background-image: linear-gradient(
+        rgb(var(--ds-badge-rgb) / 0.2), rgb(var(--ds-badge-rgb) / 0.2));
     border: 1px solid rgb(var(--ds-badge-rgb) / 0.35);
     backdrop-filter: blur(4px);
 }}
-.ds-badge-accent {{ --ds-badge-rgb: var(--ds-accent-tint-rgb); }}
-.ds-badge-hevc {{ --ds-badge-rgb: var(--ds-hevc-rgb); }}
-.ds-badge-av1 {{ --ds-badge-rgb: var(--ds-av1-rgb); }}
-.ds-badge-bitrate {{ --ds-badge-rgb: var(--ds-bitrate-rgb); }}
-.ds-badge-optimized {{ --ds-badge-rgb: var(--ds-optimized-rgb); }}
-.ds-badge-danger {{ --ds-badge-rgb: var(--ds-danger-rgb); }}
+.ds-badge-accent {{ --ds-badge-rgb: var(--ds-accent-tint-media-rgb); }}
+.ds-badge-hevc {{ --ds-badge-rgb: var(--ds-hevc-media-rgb); }}
+.ds-badge-av1 {{ --ds-badge-rgb: var(--ds-av1-media-rgb); }}
+.ds-badge-bitrate {{ --ds-badge-rgb: var(--ds-bitrate-media-rgb); }}
+.ds-badge-optimized {{ --ds-badge-rgb: var(--ds-optimized-media-rgb); }}
+.ds-badge-danger {{ --ds-badge-rgb: var(--ds-danger-media-rgb); }}
 .ds-badge-neutral {{
     color: #fff;
     background: rgba(0,0,0,0.6);

--- a/arcade_scanner/templates/ui_components.py
+++ b/arcade_scanner/templates/ui_components.py
@@ -195,13 +195,13 @@ def render_navigation(theme: BaseTheme) -> str:
         <span class="material-icons text-[22px]">star</span>
         <span class="text-[9px] font-medium">Favs</span>
     </button>
+    <button onclick="setLayout('folderbrowser')" class="flex flex-col items-center justify-center p-1 w-12 gap-1 text-text-muted active:text-accent-tint transition-colors">
+        <span class="material-icons text-[22px]">folder</span>
+        <span class="text-[9px] font-medium">Ordner</span>
+    </button>
     <button onclick="setWorkspaceMode('optimized')" class="flex flex-col items-center justify-center p-1 w-12 gap-1 text-text-muted active:text-accent-tint transition-colors">
         <span class="material-icons text-[22px]">offline_bolt</span>
         <span class="text-[9px] font-medium">Review</span>
-    </button>
-     <button onclick="setWorkspaceMode('vault')" class="flex flex-col items-center justify-center p-1 w-12 gap-1 text-text-muted active:text-accent-tint transition-colors">
-        <span class="material-icons text-[22px]">archive</span>
-        <span class="text-[9px] font-medium">Vault</span>
     </button>
     <button onclick="document.getElementById('mobileSearchInput').focus()" class="flex flex-col items-center justify-center p-1 w-12 gap-1 text-text-muted active:text-accent-tint transition-colors">
         <span class="material-icons text-[22px]">search</span>

--- a/dev-docs/plan-path-criterion.md
+++ b/dev-docs/plan-path-criterion.md
@@ -1,0 +1,295 @@
+# Plan: Ordner-Navigation & Path-Kriterium
+
+Zwei Teile, unabhängig voneinander umsetzbar:
+
+- **Teil 1** — Path-Kriterium für Smart Collections (mit Autocomplete) — *offen*
+- **Teil 2** — Hierarchischer Folder-Browser auf Mobile (Root-Ebene-Bugfix) —
+  **umgesetzt** (siehe CHANGELOG, Abschnitt Unreleased)
+
+Teil 2 ist der kleinere Eingriff und löst das eigentliche Alltagsproblem
+(„durchklicken statt filtern"). Teil 1 ist die dauerhafte, kombinierbare Variante.
+
+---
+
+# Teil 1: Path-Kriterium für Smart Collections
+
+## Motivation
+
+Ordner-Navigation nach einem bestimmten Unterbaum (Beispiel: `/media_ralf/OD`, 510 von
+8776 Dateien) ist heute umständlich:
+
+- **Ordner-Sidebar** (`setFolderFilter`) filtert **exakt** auf ein Verzeichnis, nicht
+  rekursiv — `filter_engine.js:232` vergleicht `folder !== currentFolder`. Unterordner
+  fallen raus.
+- **Folder-Browser** (`view=folderbrowser`) kann Hierarchie, ist auf dem Handy aber nicht
+  erreichbar: die View-Toggle-Leiste ist `hidden md:flex` (`components.py:2133`).
+  Nur per Deep-Link `/lobby?view=folderbrowser&folderPath=%2Fmedia_ralf%2FOD`.
+- **Smart Collections** kennen kein Pfad-Kriterium. Workaround ist heute
+  `criteria.search = "/Media_Ralf/OD"` (Collection `RalfoOD`), was aktuell exakt die
+  richtigen 510 Dateien trifft.
+
+Grenzen des Search-Workarounds:
+
+1. **Keine Ordnergrenze** — Substring-Match. Ein künftiges `/media_ralf/ODX/` oder ein
+   Dateiname mit diesem String würde mitgezählt.
+2. **Search-Feld ist belegt** — „alles unter OD, aber nur Dateien mit `web` im Namen"
+   ist in einer Collection nicht ausdrückbar.
+3. **Nur ein Pfad, kein Ausschluss** — „OD, aber ohne `archiv`" geht nicht.
+
+## Ziel
+
+`criteria.include.path[]` / `criteria.exclude.path[]` als vollwertiges Kriterium,
+mit Präfix-Match auf Ordnergrenze und Autocomplete über die bekannten Ordner.
+
+## Umfang
+
+Rein clientseitig plus Template-Markup. **Kein Server-Change nötig**, keine
+Schema-Migration: Collections werden als JSON in `users.db` (`user_data`)
+gespeichert, neue Felder sind additiv.
+
+### 1. Schema (`collections.js`)
+
+`getDefaultCollectionCriteria()` um `path: []` in `include` und `exclude` erweitern.
+Alte Collections ohne das Feld laufen unverändert weiter (überall `?.length > 0`-Guards).
+
+### 2. Matching (`collections.js`, `evaluateCollectionMatch`)
+
+Neuer Helper, Ordnergrenzen-sicher und case-insensitiv (Rest der Funktion ist es auch):
+
+```js
+const underPath = (filePath, prefix) => {
+    const f = filePath.replace(/\\/g, '/').toLowerCase();
+    const p = prefix.replace(/\\/g, '/').toLowerCase().replace(/\/+$/, '');
+    return f === p || f.startsWith(p + '/');
+};
+```
+
+- Exclude zuerst (konsistent zum bestehenden Aufbau): trifft ein `exclude.path`-Eintrag,
+  raus.
+- Include: `inc.path.length > 0 && !inc.path.some(p => underPath(video.FilePath, p))`
+  → raus. Mehrere Include-Pfade sind ODER-verknüpft, wie bei den anderen Include-Listen.
+
+Einzubauen bei den übrigen Exclusions/Inclusions, vor dem Search-Block.
+
+### 3. Autocomplete-Datenquelle (neu, `collections.js`)
+
+`window.FOLDERS_DATA` (aus `dashboard_template.py:38-47`) enthält nur **Blatt**-Verzeichnisse
+(solche, die direkt Dateien haben) mit `count`/`size_mb`. Für die Vorschlagsliste brauchen
+wir auch die Elternpfade:
+
+```js
+function getAllKnownFolders() {
+    // leaf paths -> alle Präfixe ableiten, counts/size aufsummieren
+    // Rückgabe: [{path, count, size_mb}], sortiert nach count desc
+}
+```
+
+Ergebnis für die aktuelle Library: ~600 Pfade inkl. `/media_ralf/OD`, `/media_ralf/OD/ProSessions` usw.
+Einmal berechnen und cachen (Modul-Level-Variable), Invalidierung beim Rescan.
+
+### 4. UI (`components.py` + `collections.js`)
+
+Im Collection-Modal, neuer Block im `metadata`-Panel direkt über „Search Term"
+(`components.py:1203-1209`):
+
+- `#collectionPathInput` — Text-Input mit `list="collectionPathOptions"`
+- `#collectionPathOptions` — `<datalist>`, gefüllt aus `getAllKnownFolders()`
+  (Label mit Count, z.B. `/media_ralf/OD (510)`)
+- `#collectionPathChips` — Container für die gesetzten Pfade als Chips, Klick auf
+  Chip togglet include ↔ exclude, X entfernt
+- Handler als `window.*` exportieren: `addCollectionPath()`, `removeCollectionPath(path)`,
+  `toggleCollectionPathMode(path)`
+
+Datalist ist die billigste Variante und funktioniert auf Mobile (iOS Safari zeigt sie
+als Vorschlagsleiste). Falls das zu schwach ist: eigene gefilterte Dropdown-Liste,
+gleiche Datenquelle.
+
+### 5. Persistenz & Sync
+
+- `saveCollection()` (`collections.js:346ff`) kopiert `collectionCriteriaNew` komplett —
+  Pfade kommen automatisch mit, sobald sie im State stehen.
+- `syncSmartCollectionUI()` um das Rendern der Path-Chips erweitern.
+- `updateFilterSectionBadge('metadata')` um die Pfad-Anzahl erweitern
+  (`collections.js:194-208`).
+- `updateCollectionPreviewCount()` braucht nichts Zusätzliches, solange die Pfade im
+  State stehen (es kopiert `collectionCriteriaNew`) — nur prüfen, dass ein noch nicht
+  bestätigter Text im Input nicht verloren geht.
+
+### 6. Tests
+
+- `test_dom_contract.py`: neue IDs (`collectionPathInput`, `collectionPathOptions`,
+  `collectionPathChips`) müssen im Python-Template auftauchen, `onclick` muss `window.*`
+  sein. Dynamisch erzeugte Chip-IDs ggf. in `DYNAMIC_IDS`.
+- `test_js_syntax.py` läuft automatisch mit (`node --check`).
+- Neuer Test für `underPath`-Semantik wäre sinnvoll, sofern die JS-Contract-Tests so
+  etwas hergeben — sonst mindestens manuell: `/media_ralf/OD` darf `/media_ralf/ODX/x.mp4`
+  **nicht** matchen.
+
+### 7. Andere Clients
+
+`ios_client/SmartCollection.swift` und `tv_client/src/views/MainPanel.js` werten
+Collection-Kriterien eigenständig aus. Sie ignorieren unbekannte Felder, d.h. eine
+Collection mit Path-Kriterium zeigt dort **zu viele** Treffer. Nachziehen als
+Folgeschritt, nicht Teil dieses Plans.
+
+## Offene Punkte
+
+- Migration der bestehenden `RalfoOD`-Collection (`search: "/Media_Ralf/OD"`) auf
+  `include.path` — automatisch oder manuell? Automatisch wäre heuristisch (Search-Term
+  sieht aus wie Pfad), manuell ist ein Klick. Tendenz: manuell.
+- Soll der Folder-Browser einen „als Collection speichern"-Button bekommen, der den
+  aktuellen `folderPath` direkt in eine neue Collection schreibt?
+
+---
+
+# Teil 2: Hierarchischer Folder-Browser auf Mobile
+
+**Status: umgesetzt.** Was unten als Vorschlag steht, ist so gebaut worden —
+Abweichungen sind am Ende unter „Abweichungen bei der Umsetzung" vermerkt.
+
+## Befund
+
+Der Folder-Browser kann Hierarchie bereits vollständig:
+
+- Drill-down: `setFolderBrowserPath()` (`folder_browser.js:295`)
+- Breadcrumbs: `getFolderBreadcrumbs()` (`folder_browser.js:348`)
+- Zurück: `folderBrowserBack()` (`folder_browser.js:304`)
+- Zwischenebenen: der `else`-Zweig von `getSubfoldersAt(path)` leitet die nächste Ebene
+  korrekt aus den Pfadsegmenten ab — auch für Ordner, die selbst keine Dateien enthalten.
+
+**Der Bug sitzt allein in der Root-Ebene.** `getSubfoldersAt(null)`
+(`folder_browser.js:135-145`) definiert einen Root-Ordner als „Pfad, der kein Präfix
+eines *anderen Ordners mit Dateien* hat". Da Mount-Verzeichnisse wie `/media_ralf`
+selbst keine Dateien direkt enthalten, ist jeder tiefe Blattordner sein eigener Root.
+
+Messung an der aktuellen Library (8776 Dateien, 213 Blatt-Verzeichnisse):
+
+| | |
+|---|---|
+| Root-Einträge nach aktueller Logik | **153** (flach, tiefe Pfade) |
+| Erwartete Root-Einträge | **3** (`/media`, `/media_nas`, `/media_ralf`) |
+| Ebene 2 unter `/media_ralf` | `OD` (510), `Reface` (73), `korea` (38) |
+
+Daher wirkt die View wie „Liste der größten Ordner" statt wie ein Datei-Browser.
+
+Zweites Hindernis: Die View ist auf dem Handy gar nicht erreichbar — die
+View-Toggle-Leiste ist `hidden md:flex` (`components.py:2133`).
+
+## Änderung 1 — Root-Ebene aus dem echten Pfad-Baum
+
+`getSubfoldersAt(null)` umbauen: statt „ist Präfix eines anderen Blattpfads" die Root-Menge
+aus den Pfadsegmenten ableiten, analog zum bereits korrekten `else`-Zweig — nur mit
+`normalizedPath = ''` als Startpunkt. Das ergibt automatisch die Mount-Ebene, und die
+bestehende Aggregation (`count`, `size_mb`, `hasSubfolders`, Thumbnails über
+`getVideosUnderPath()`) greift unverändert.
+
+Damit werden Root- und Kind-Fall zum selben Code — der Sonderzweig kann ganz entfallen.
+
+Optional, danach zu bewerten: **Single-Child-Kompression**. Hat eine Ebene genau einen
+Unterordner und keine eigenen Dateien, direkt eine Ebene tiefer springen (Breadcrumb zeigt
+`media_ralf / OD`). Spart bei tiefen Bäumen Taps. Erst nach dem Basisfix entscheiden — evtl.
+verwirrender als nützlich.
+
+Achtung bei `folderBrowserBack()` (`folder_browser.js:325-333`): die Funktion ruft
+`getSubfoldersAt(null)` auf, um zu prüfen, ob der Parent ein Root ist. Mit der neuen
+Root-Definition stimmt das weiterhin, aber der Pfad-Vergleich muss den Mount-Fall
+(`/media_ralf` → Root, `lastSlash === 0`) sauber treffen. Gleiches gilt für
+`getFolderBreadcrumbs()`.
+
+## Änderung 2 — Erreichbarkeit auf Mobile
+
+**Harte Anforderung: Die Ordner-Navigation muss auf dem Handy voll nutzbar sein, nicht nur
+technisch erreichbar.**
+
+### 2a. Einstiegspunkt in der Mobile-Bottom-Nav
+
+Es gibt bereits eine Mobile-Navigation: `ui_components.py:189`, `md:hidden fixed bottom-0`.
+**Vault wurde dort bereits entfernt** (erledigt), aktuell vier Buttons: Lobby, Favs, Review,
+Search — à `w-12`.
+
+Damit ist ein Slot frei: dort kommt der Button **Ordner** (`folder`-Icon) rein, der
+`setLayout('folderbrowser')` aufruft. Fünf `w-12`-Buttons passen auch auf 375px-Viewports.
+
+Anmerkung zu Vault: der Workspace ist nur aus der Mobile-Nav verschwunden, nicht entfernt —
+`/vault` als Deep-Link und der Desktop-Zugang funktionieren weiter. Ob Vault mobil ganz
+wegfällt, ist noch offen.
+
+Das ist der eigentliche Fix. Der Desktop-Toggle (`#viewToggleFolder`, `components.py:2150`)
+steckt in einem `hidden md:flex`-Container zusammen mit dem Grid-Scale-Slider; den mobil
+einzublenden wäre die schlechtere Lösung (Slider ist auf dem Handy nutzlos, vier
+Icon-Buttons quetschen die Toolbar).
+
+### 2b. Ordnerliste mobiltauglich rendern
+
+`createFolderCard()` (`folder_browser.js:390`) baut große Karten mit 2x2-Thumbnail-Mosaik,
+`aspect-video` und Hover-Overlay. Auf dem Handy heißt das: **ein Ordner pro Bildschirm**,
+und die Hover-Effekte (`group-hover:*`) sind auf Touch tote Fläche.
+
+Vorschlag: unterhalb `md` eine kompakte Listendarstellung statt der Karten — Zeile mit
+kleinem Thumbnail (~56px), Ordnername, `count` + Größe als Subline, Chevron rechts.
+Tap-Ziel mindestens 44px hoch. Damit sind 8-10 Ordner gleichzeitig sichtbar und
+Durchklicken fühlt sich wie ein Dateimanager an.
+
+### 2c. Breadcrumbs und Zurück
+
+- Breadcrumb-Leiste (`getFolderBreadcrumbs()`) muss auf schmalen Viewports horizontal
+  scrollen (`overflow-x-auto`, `whitespace-nowrap`) statt umzubrechen oder zu überlaufen.
+  Bei tiefen Pfaden ggf. mittlere Segmente zu `…` kürzen, erstes und letztes behalten.
+- Der Zurück-Button muss auf Mobile sichtbar sein (nicht nur `folderBrowserBack()` per
+  Toolbar) — idealerweise als Pfeil links in der Breadcrumb-Zeile.
+- **Achtung, bestehender Konflikt:** Es gibt zwei konkurrierende Popstate-Handler —
+  `window.addEventListener('popstate', ...)` (`engine.js:579`) *und*
+  `window.onpopstate = ...` (`engine.js:902`). Beide feuern; der erste stellt den State
+  wieder her, der zweite ruft danach `loadFromURL()`. Das ist beim Hardware-/Browser-Back
+  auf dem Handy zu prüfen, sonst springt die Navigation. Sollte im Zuge dieser Änderung
+  auf einen Handler zusammengeführt werden.
+
+## Tests
+
+- `test_dom_contract.py`: neuer Nav-Button braucht `onclick="window.setLayout(...)"`-Form
+  bzw. muss dem bestehenden Muster der Nachbarbuttons folgen.
+- Root-Ebene manuell gegenprüfen: 3 Einträge statt 153, `/media_ralf` → `OD`/`korea`/`Reface`.
+- Zurück-Navigation von tief unten bis Root ohne Sackgasse — einmal per UI-Button, einmal
+  per Browser-Back.
+- Am echten Handy (nicht nur DevTools-Emulation) gegenprüfen: Tap-Ziele, Breadcrumb-Scroll,
+  Bottom-Nav-Überlappung mit der Ordnerliste (`pb-safe-bottom` beachten).
+
+## Abweichungen bei der Umsetzung
+
+- **Single-Child-Kompression nicht gebaut** — erst nach Praxistest entscheiden.
+- **Popstate-Konflikt gleich mitbehoben**, weil er den Handy-Zurück-Button direkt
+  betrifft: `window.onpopstate` in `engine.js` entfernt (der
+  `addEventListener('popstate')` weiter oben bleibt der einzige Handler), und
+  `loadFromURL()` setzt `folderBrowserState.currentPath` jetzt auf `null`, wenn die URL
+  keinen `folderPath` trägt.
+- **Breadcrumbs komplett neu** statt nur angepasst: sie hingen ebenfalls an der alten
+  Root-Erkennung (`getSubfoldersAt(null)`) und werden jetzt direkt aus den
+  Pfadsegmenten gebaut. Jede Ebene ist ein Präfix des Originalpfads, dadurch bleiben
+  Backslash-Pfade unverändert erhalten.
+- **Verifikation**: Die Ebenen-Logik wurde per Node-Harness gegen alle 8776 echten
+  Pfade geprüft — Root liefert 3 Mounts (vorher 153 Einträge), Summe der Root-Counts
+  entspricht der Gesamtzahl, Zurück-Navigation läuft von `…/ProSessions/Lena` ohne
+  Sackgasse bis `null`, Windows-Backslash-Pfade werden korrekt rekonstruiert.
+  Nicht abgedeckt: das tatsächliche Aussehen am Gerät.
+
+## Offen aus Teil 2
+
+- Optische Prüfung am echten Handy (Tap-Ziele, Breadcrumb-Scroll, Überlappung mit der
+  Bottom-Nav).
+- Entscheidung, ob Vault mobil ganz entfällt.
+- Single-Child-Kompression.
+
+## Beziehung zu Teil 1
+
+Unabhängig, aber sie ergänzen sich: Teil 2 ist zum Stöbern, Teil 1 zum Festhalten. Der
+naheliegende Verbindungspunkt ist ein „als Collection speichern"-Button im Folder-Browser,
+der den aktuellen `folderPath` als `include.path` in eine neue Collection schreibt (siehe
+offene Punkte Teil 1).
+
+---
+
+# Nebenbei aufgefallen (separat entscheiden)
+
+- Ordner-Sidebar rekursiv machen: `getVideosUnderPath()` existiert bereits in
+  `folder_browser.js`, wird vom Sidebar-Filter (`setFolderFilter` → exakter Vergleich in
+  `filter_engine.js:232`) nur nicht genutzt.


### PR DESCRIPTION
## Problem

Nicht nur die Settings — die Views tragen flächendeckend Hardcodes aus der dark-only Zeit. Im hellen Design landet das bei weiß auf weiß bzw. ~2:1.

| Hardcode | Vorkommen | Effekt im Light-Mode |
|---|---|---|
| `text-white` / `hover:text-white` | 192 | weiß auf weiß (z. B. „Minimum Size", „Verbose Scanning Logs", alle Settings-Zahlenfelder) |
| `text-gray-400/500/600` | 269 | 1.5–2.5:1 |
| `bg-white/N`, `border-white/N`, `ring-white/20` | ~200 | Karten, Trennlinien, Hover-Flächen unsichtbar |
| `bg-black/40,50` als Feldfläche | 40 | schwarzer Kasten in der hellen Karte |
| `rgba(255,255,255,…)` in `styles.css` | 73 | dito |
| `text-red/green/amber/purple-400` | ~60 | 1.8–2.9:1 auf Weiß |

Ein Block aus `!important`-Overrides in `styles.css` hat einen Teil davon pro Container zurückgebogen — unvollständig (nur `p`/`label`/`h*`, nicht die `div`s) und mit eigenen Hardcodes (`#f1f3f5`).

## Fix

Root statt Pflaster — die Utilities zeigen jetzt auf mode-aware Tokens:

- **`ink`** als neue Tailwind-Farbe = Vordergrund als Flächen-/Linienquelle. Alle `*-white/N` → `*-ink/N`: im Dark weiß wie bisher, im Light schwarz. Dark-Mode bleibt dadurch praktisch pixelgleich.
- **Graustufen 200–900** → semantische Textskala (`text-body`/`text-label`/`text-muted`).
- **Semantische Farben** sind `(light, dark)`-Paare; die Light-Werte erreichen ≥4.5:1 auf Weiß. Tailwind red/green/amber/cyan/blue 200–400 und purple/pink-400 zeigen darauf, 500+ bleibt unverändert, damit gefüllte Buttons gleich aussehen.
- **`--ds-on-*`** wird per Luminanz berechnet — `text-black` auf Magenta (4.0:1) und `color:#000` auf Gold sind weg.
- **Badges auf Thumbnails** behalten über `--ds-*-media-rgb` den hellen Ton plus dunklen Scrim; Cinema-Player, Karten-Overlays und Toasts bleiben bewusst weiß.
- `--ds-text-muted` dark `#6b6b76` → `#7e7e8a` (3.4:1 → 4.5:1, war auch im Dark unter AA), `login.html` nachgezogen.
- Der `!important`-Block entfällt ersatzlos.

## Verifikation

- 880 Tests grün (inkl. `node --check` und DOM-Contract)
- Token-Kontrastmatrix in beiden Modi durchgerechnet: Light alles ≥4.6:1, Dark alles ≥4.5:1 — außer `accent`/`accent-hover` als *Textfarbe* (3.2–3.4:1), die dort nur Large/UI-Text bzw. Füllfarbe sind
- **Kein Browser-Check**: in der Umgebung war kein Chromium verfügbar, die Prüfung ist statisch + rechnerisch. Ein Blick auf Settings, Filter-Panel, Duplicates und Batch-Tagging im hellen Design wäre vor dem Merge sinnvoll.

## Bewusst offen

`login.html` ist eine eigenständige, fest dunkle Seite ohne Theme-Toggle; Canvas-Views wie die Treemap malen eigene Farbflächen. Beides unberührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)